### PR TITLE
Add new feature to deal with multiple heights 

### DIFF
--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -160,6 +160,7 @@ class CoreInstance
       this.prevTranslateY.push({
         ID: operationID,
         translateY: this.translateY,
+        shiftOffsetY: 0,
       });
     }
 

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -166,6 +166,7 @@ class CoreInstance
     this.translateY += topSpace;
 
     this.transformElm();
+    this.setCurrentOffset();
   }
 
   /**

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -108,7 +108,7 @@ class CoreInstance
     };
   }
 
-  setCurrentOffset() {
+  private setCurrentOffset() {
     const { left, top } = this.offset;
     /**
      * This offset related directly to translate Y and Y. It's isolated from
@@ -167,6 +167,7 @@ class CoreInstance
     this.translateY += topSpace;
 
     this.transformElm();
+    this.setCurrentOffset();
   }
 
   /**

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -166,7 +166,6 @@ class CoreInstance
     this.translateY += topSpace;
 
     this.transformElm();
-    this.setCurrentOffset();
   }
 
   /**

--- a/packages/core-instance/src/typings.ts
+++ b/packages/core-instance/src/typings.ts
@@ -25,7 +25,6 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
   currentLeft: number;
   order: Order;
   keys: Keys;
-  setCurrentOffset(): void;
   setYPosition(
     iDsInOrder: ELmBranch,
     sign: number,

--- a/packages/core-instance/src/typings.ts
+++ b/packages/core-instance/src/typings.ts
@@ -16,7 +16,11 @@ export interface Offset {
   top: number;
 }
 
-export type TransitionHistory = { ID: string; translateY: number }[];
+export type TransitionHistory = {
+  ID: string;
+  translateY: number;
+  shiftOffsetY: number;
+}[];
 
 export interface CoreInstanceInterface extends AbstractCoreInterface {
   offset: Offset;

--- a/packages/dnd/playgrounds/dflex-react-dnd/src/todo/Todo.js
+++ b/packages/dnd/playgrounds/dflex-react-dnd/src/todo/Todo.js
@@ -73,8 +73,8 @@ const TodoList = () => {
   const tasks = [
     { id: "mtg", msg: "Meet with Laura" },
     { id: "org", msg: "Organize weekly meetup" },
-    { id: "gym", msg: "Hit the gym" },
     { id: "proj", msg: "Continue working on the project" },
+    { id: "gym", msg: "Hit the gym" },
   ];
 
   return (

--- a/packages/dnd/playgrounds/dflex-react-dnd/src/todo/Todo.js
+++ b/packages/dnd/playgrounds/dflex-react-dnd/src/todo/Todo.js
@@ -72,14 +72,14 @@ const TodoList = () => {
 
   const tasks = [
     { id: "mtg", msg: "Meet with Laura" },
-    { id: "org", msg: "Organize weekly meetup" },
     { id: "proj", msg: "Continue working on the project" },
+    { id: "org", msg: "Organize weekly meetup" },
     { id: "gym", msg: "Hit the gym" },
   ];
 
   return (
     <div className="todo-container">
-      <ul ref={listRef}>
+      <ul id="dnd-todo-list" ref={listRef}>
         {tasks.map(({ msg, id }) => (
           <Task task={msg} id={id} key={id} />
         ))}

--- a/packages/dnd/playgrounds/dflex-react-dnd/src/todo/Todo.js
+++ b/packages/dnd/playgrounds/dflex-react-dnd/src/todo/Todo.js
@@ -72,8 +72,8 @@ const TodoList = () => {
 
   const tasks = [
     { id: "mtg", msg: "Meet with Laura" },
-    { id: "proj", msg: "Continue working on the project" },
     { id: "org", msg: "Organize weekly meetup" },
+    { id: "proj", msg: "Continue working on the project" },
     { id: "gym", msg: "Hit the gym" },
   ];
 

--- a/packages/dnd/src/DnD.ts
+++ b/packages/dnd/src/DnD.ts
@@ -40,7 +40,7 @@ class DnD extends Droppable {
       keys: { sK },
     } = store.registry[id];
 
-    const siblingsBoundaries = store.boundaries[sK];
+    const siblingsBoundaries = store.siblingsBoundaries[sK];
 
     const options = opts;
 

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -15,18 +15,18 @@ import type { ElmTree, BoundariesOffset } from "./types";
 class DnDStoreImp extends Store<CoreInstance> {
   tracker: Tracker;
 
-  boundaries: { [k: string]: BoundariesOffset };
+  siblingsBoundaries: { [k: string]: BoundariesOffset };
 
   constructor() {
     super();
 
-    this.boundaries = {};
+    this.siblingsBoundaries = {};
     this.tracker = new Tracker();
   }
 
   assignSiblingsBoundaries(siblingsK: string, elemOffset: Offset) {
-    if (!this.boundaries[siblingsK]) {
-      this.boundaries[siblingsK] = {
+    if (!this.siblingsBoundaries[siblingsK]) {
+      this.siblingsBoundaries[siblingsK] = {
         height: elemOffset.height,
         width: elemOffset.width,
         left: elemOffset.left,
@@ -37,7 +37,7 @@ class DnDStoreImp extends Store<CoreInstance> {
       return;
     }
 
-    const $ = this.boundaries[siblingsK];
+    const $ = this.siblingsBoundaries[siblingsK];
 
     if ($.left < elemOffset.left) {
       $.left = elemOffset.left;

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -284,9 +284,6 @@ class Draggable extends Base implements DraggableDnDInterface {
       return;
     }
 
-    // @ts-expect-error
-    this.draggedElm.setCurrentOffset();
-
     const draggedDirection =
       this.tempIndex < this.draggedElm.order.self ? -1 : 1;
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -24,8 +24,6 @@ class Draggable extends Base implements DraggableDnDInterface {
 
   numberOfElementsTransformed: number;
 
-  inc: number;
-
   isMovingDown: boolean;
 
   isOutHorizontal: boolean;
@@ -60,7 +58,6 @@ class Draggable extends Base implements DraggableDnDInterface {
      * crucial to calculate drag's translate and index
      */
     this.numberOfElementsTransformed = 0;
-    this.inc = 1;
 
     this.isMovingDown = false;
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -278,7 +278,8 @@ class Draggable extends Base implements DraggableDnDInterface {
       return;
     }
 
-    // this.draggedElm.setCurrentOffset();
+    // @ts-expect-error
+    this.draggedElm.setCurrentOffset();
 
     const draggedDirection =
       this.tempIndex < this.draggedElm.order.self ? -1 : 1;

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -92,7 +92,7 @@ class Draggable extends Base implements DraggableDnDInterface {
   }
 
   private selfHorizontalAxesFilter(x: number) {
-    const { left } = store.boundaries[
+    const { left } = store.siblingsBoundaries[
       store.registry[this.draggedElm.id].keys.sK
     ];
 
@@ -113,7 +113,7 @@ class Draggable extends Base implements DraggableDnDInterface {
   }
 
   private containerVerticalAxesFilter(y: number) {
-    const { maxTop, minTop } = store.boundaries[
+    const { maxTop, minTop } = store.siblingsBoundaries[
       store.registry[this.draggedElm.id].keys.sK
     ];
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -226,7 +226,11 @@ class Draggable extends Base implements DraggableDnDInterface {
   }
 
   isSiblingsTransformed() {
-    return !this.isDraggedLeavingFromBottom() && this.isDraggedOut();
+    return (
+      this.siblingsList !== null &&
+      !this.isDraggedLeavingFromBottom() &&
+      this.isDraggedOut()
+    );
   }
 
   /**
@@ -270,10 +274,12 @@ class Draggable extends Base implements DraggableDnDInterface {
 
       this.draggedElm.transformElm();
 
-      this.draggedElm.assignNewPosition(
-        this.siblingsList!,
-        this.draggedElm.order.self
-      );
+      if (this.siblingsList) {
+        this.draggedElm.assignNewPosition(
+          this.siblingsList,
+          this.draggedElm.order.self
+        );
+      }
 
       return;
     }

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -66,21 +66,23 @@ class Draggable extends Base implements DraggableDnDInterface {
     const $ = this.opts.restrictions;
 
     this.axesFilterNeeded =
-      !$.allowLeavingFromLeft ||
-      !$.allowLeavingFromRight ||
-      !$.allowLeavingFromTop ||
-      !$.allowLeavingFromBottom;
+      this.siblingsList !== null &&
+      (!$.allowLeavingFromLeft ||
+        !$.allowLeavingFromRight ||
+        !$.allowLeavingFromTop ||
+        !$.allowLeavingFromBottom);
+  }
+
+  getLastElmIndex() {
+    return this.siblingsList!.length - 1;
   }
 
   private isDraggedFirstOrOutside() {
-    return this.siblingsList !== null && this.tempIndex <= 0;
+    return this.tempIndex <= 0;
   }
 
-  private isDraggedLastELm() {
-    return (
-      this.siblingsList !== null &&
-      this.tempIndex === this.siblingsList.length - 1
-    );
+  isDraggedLastELm() {
+    return this.tempIndex === this.getLastElmIndex();
   }
 
   private selfRightAxesFilter(x: number, left: number) {
@@ -268,17 +270,15 @@ class Draggable extends Base implements DraggableDnDInterface {
 
       this.draggedElm.transformElm();
 
-      if (this.siblingsList) {
-        this.draggedElm.assignNewPosition(
-          this.siblingsList,
-          this.draggedElm.order.self
-        );
-      }
+      this.draggedElm.assignNewPosition(
+        this.siblingsList!,
+        this.draggedElm.order.self
+      );
 
       return;
     }
 
-    this.draggedElm.setCurrentOffset();
+    // this.draggedElm.setCurrentOffset();
 
     const draggedDirection =
       this.tempIndex < this.draggedElm.order.self ? -1 : 1;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -75,5 +75,7 @@ export interface DraggableDnDInterface extends DraggableBaseInterface {
   isDraggedLeavingFromTop(): boolean;
   isDraggedLeavingFromBottom(): boolean;
   isSiblingsTransformed(): boolean;
+  getLastElmIndex(): number;
+  isDraggedLastELm(): boolean;
   endDragging(topDifference: number): void;
 }

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -17,8 +17,6 @@ class Droppable implements DroppableInterface {
 
   isListLocked: boolean;
 
-  prevIsListLocked: boolean;
-
   droppableIndex: number;
 
   isFoundBreakingPoint: boolean;
@@ -35,7 +33,6 @@ class Droppable implements DroppableInterface {
     this.effectedElemDirection = 1;
 
     this.isListLocked = false;
-    this.prevIsListLocked = false;
 
     this.droppableIndex = -1;
     this.isFoundBreakingPoint = false;
@@ -285,7 +282,6 @@ class Droppable implements DroppableInterface {
 
   unlockParent() {
     this.isListLocked = false;
-    this.prevIsListLocked = true;
   }
 
   /**

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -3,7 +3,6 @@ import store from "../DnDStore";
 import type { DraggableDnDInterface } from "../Draggable";
 import type { DroppableInterface } from "./types";
 
-let transformationOffsetY = 0;
 /**
  * Class includes all transformation methods related to droppable.
  */
@@ -13,8 +12,6 @@ class Droppable implements DroppableInterface {
   elmYSpace: number;
 
   draggedYSPace: number;
-
-  transformationOffsetY: number;
 
   leftDifference: number;
 
@@ -31,7 +28,6 @@ class Droppable implements DroppableInterface {
 
     this.elmYSpace = 0;
     this.draggedYSPace = 0;
-    this.transformationOffsetY = 0;
 
     this.leftDifference = 0;
 
@@ -59,7 +55,6 @@ class Droppable implements DroppableInterface {
 
   getNextTop(i: number) {
     const nextElmID = this.draggable.siblingsList![i];
-    console.log("file: Droppable.ts ~ line 58 ~ nextElmID", nextElmID);
 
     const nextElm = store.getElmById(nextElmID);
 
@@ -103,31 +98,26 @@ class Droppable implements DroppableInterface {
       } = this.draggable;
 
       const heightOffset = Math.abs(draggedHight - elmHight);
-      console.log("file: Droppable.ts ~ line 101 ~ heightOffset", heightOffset);
-      console.log("file: Droppable.ts ~ line 101 ~ draggedHight", draggedHight);
-      console.log("file: Droppable.ts ~ line 101 ~ elmHight", elmHight);
-
-      console.log(this.effectedElemDirection);
 
       this.draggedYSPace = Math.abs(elmTop - draggedTop);
 
       this.elmYSpace = this.draggedYSPace;
 
-      if (draggedHight > heightOffset) {
-        if (transformationOffsetY === 0) {
-          this.elmYSpace += heightOffset;
-          transformationOffsetY = heightOffset;
-          console.log("one");
-        } else {
-          this.draggedYSPace -= heightOffset;
-          transformationOffsetY = 0;
-          console.log("two");
-        }
-      }
-      console.log(
-        "file: Droppable.ts ~ line 110 ~ this.elmYSpace ",
-        this.elmYSpace
-      );
+      // if (draggedHight > heightOffset) {
+      //   if (transformationOffsetY === 0) {
+      //     this.elmYSpace += heightOffset;
+      //     transformationOffsetY = heightOffset;
+      //     console.log("one");
+      //   } else {
+      //     this.draggedYSPace -= heightOffset;
+      //     transformationOffsetY = 0;
+      //     console.log("two");
+      //   }
+      // }
+      // console.log(
+      //   "file: Droppable.ts ~ line 110 ~ this.elmYSpace ",
+      //   this.elmYSpace
+      // );
 
       /**
        * Sets the transform value by calculating offset difference from

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -88,7 +88,7 @@ class EndDroppable extends Droppable {
       if (Array.isArray(siblings)) this.undoList(siblings);
     }
 
-    this.draggable.endDragging(this.topDifference);
+    this.draggable.endDragging(this.draggedYSPace);
   }
 }
 

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -83,9 +83,10 @@ class EndDroppable extends Droppable {
       !this.draggable.siblingsList !== null &&
       this.draggable.isSiblingsTransformed()
     ) {
-      const siblings = this.getSiblings();
+      // const siblings = this.getSiblings();
 
-      if (Array.isArray(siblings)) this.undoList(siblings);
+      if (Array.isArray(this.draggable.siblingsList))
+        this.undoList(this.draggable.siblingsList);
     }
 
     this.draggable.endDragging(this.draggedYSPace);

--- a/packages/dnd/src/Droppable/types.ts
+++ b/packages/dnd/src/Droppable/types.ts
@@ -2,7 +2,7 @@ import type { DraggableDnDInterface } from "../Draggable";
 
 export interface DroppableInterface {
   draggable: DraggableDnDInterface;
-  topDifference: number;
+  elmYSpace: number;
   leftDifference: number;
   isListLocked: boolean;
   droppableIndex: number;

--- a/packages/dnd/src/Droppable/types.ts
+++ b/packages/dnd/src/Droppable/types.ts
@@ -5,7 +5,6 @@ export interface DroppableInterface {
   topDifference: number;
   leftDifference: number;
   isListLocked: boolean;
-  prevIsListLocked: boolean;
   droppableIndex: number;
   isFoundBreakingPoint: boolean;
 }

--- a/packages/draggable/src/AbstractDraggable.ts
+++ b/packages/draggable/src/AbstractDraggable.ts
@@ -23,6 +23,11 @@ const draggedStyleProps: DraggedStyle = [
     dragValue: "none",
     afterDragValue: "auto",
   },
+  {
+    prop: "pointer-events",
+    dragValue: "none",
+    afterDragValue: "auto",
+  },
 ];
 
 class AbstractDraggable<T extends AbstractCoreInterface>

--- a/packages/draggable/src/AbstractDraggable.ts
+++ b/packages/draggable/src/AbstractDraggable.ts
@@ -23,11 +23,11 @@ const draggedStyleProps: DraggedStyle = [
     dragValue: "none",
     afterDragValue: "auto",
   },
-  {
-    prop: "pointer-events",
-    dragValue: "none",
-    afterDragValue: "auto",
-  },
+  // {
+  //   prop: "pointer-events",
+  //   dragValue: "none",
+  //   afterDragValue: "inherit",
+  // },
 ];
 
 class AbstractDraggable<T extends AbstractCoreInterface>


### PR DESCRIPTION
It's built to deal with multiple heights but apparently, there's an extra calculation need to be done.

**The Solution**: This should be done by defining a height offset.

**The Problem**: If any offset is added then at some point the offset should be removed:

Say 10px is added to move `a` up then when it's moved down transformer should subtract 10.

This leads to:

1- Define vertical offset between dragged and the targeted element.

2- Add decision-maker: should offset be added/subtracted? How?  Track each movement. Count them. If it going back to the destination then subtract. But how to know it's going back? 

3- Assign an offset history for each element.
