### PR TITLE
Enhance verify positions 

### DIFF
--- a/packages/dnd/src/DnD.ts
+++ b/packages/dnd/src/DnD.ts
@@ -49,12 +49,6 @@ class DnD extends Droppable {
   ) {
     const elmCoreInstanceWithTree: ElmTree = store.getElmTreeById(id);
 
-    const {
-      keys: { sK },
-    } = store.registry[id];
-
-    const siblingsBoundaries = store.siblingsBoundaries[sK];
-
     const options = { ...opts };
 
     (Object.keys(defaultOpts) as Array<keyof typeof defaultOpts>).forEach(
@@ -72,7 +66,6 @@ class DnD extends Droppable {
 
     const draggable = new Draggable(
       elmCoreInstanceWithTree,
-      siblingsBoundaries,
       initCoordinates,
       options as FinalDndOpts
     );

--- a/packages/dnd/src/DnDStore/index.ts
+++ b/packages/dnd/src/DnDStore/index.ts
@@ -4,6 +4,6 @@
  * This source code is licensed under the AGPL3.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-export type { ElmTree, BoundariesOffset } from "./types";
+export type { ElmTree } from "./types";
 
 export { default } from "./DnDStoreImp";

--- a/packages/dnd/src/Draggable/Base.ts
+++ b/packages/dnd/src/Draggable/Base.ts
@@ -13,7 +13,7 @@ import type { ELmBranch } from "@dflex/dom-gen";
 
 import store from "../DnDStore";
 
-import type { ElmTree, BoundariesOffset } from "../DnDStore";
+import type { ElmTree } from "../DnDStore";
 
 import type {
   DraggableBaseInterface,
@@ -53,7 +53,6 @@ class Base
 
   constructor(
     elmTree: ElmTree,
-    siblingsBoundaries: BoundariesOffset,
     initCoordinates: MouseCoordinates,
     opts: FinalDndOpts
   ) {
@@ -104,6 +103,9 @@ class Base
      * Init max direction for position
      */
     this.setThreshold(this.draggedElm.currentTop, this.draggedElm.currentLeft);
+
+    const siblingsBoundaries =
+      store.siblingsBoundaries[store.registry[this.draggedElm.id].keys.sK];
 
     this.setThreshold(
       siblingsBoundaries.top,

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -10,7 +10,7 @@ import type { MouseCoordinates } from "@dflex/draggable";
 import store from "../DnDStore";
 
 import Base from "./Base";
-import type { ElmTree, BoundariesOffset } from "../DnDStore";
+import type { ElmTree } from "../DnDStore";
 import type {
   DraggableDnDInterface,
   TempOffset,
@@ -44,11 +44,10 @@ class Draggable extends Base implements DraggableDnDInterface {
 
   constructor(
     elmTree: ElmTree,
-    siblingsBoundaries: BoundariesOffset,
     initCoordinates: MouseCoordinates,
     opts: FinalDndOpts
   ) {
-    super(elmTree, siblingsBoundaries, initCoordinates, opts);
+    super(elmTree, initCoordinates, opts);
 
     const { x, y } = initCoordinates;
 

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -311,7 +311,7 @@ class Droppable {
    *
    * @param id -
    */
-  private isIDEligible2Move(id: string) {
+  protected isIDEligible2Move(id: string) {
     return id && id !== this.draggable.draggedElm.id;
   }
 

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -41,7 +41,7 @@ class EndDroppable extends Droppable {
     }
   }
 
-  private loopAscWithAnimationFrame = (from: number, lst: Array<string>) => {
+  private loopAscWithAnimationFrame(from: number, lst: string[]) {
     let i = from;
 
     const run = () => {
@@ -54,9 +54,9 @@ class EndDroppable extends Droppable {
     };
 
     requestAnimationFrame(run);
-  };
+  }
 
-  private loopDesWithAnimationFrame = (from: number, lst: Array<string>) => {
+  private loopDesWithAnimationFrame(from: number, lst: string[]) {
     let i = from;
 
     const run = () => {
@@ -69,7 +69,7 @@ class EndDroppable extends Droppable {
     };
 
     requestAnimationFrame(run);
-  };
+  }
 
   /**
    * Undo list elements order and instances including translateX/Y and indexes
@@ -113,8 +113,7 @@ class EndDroppable extends Droppable {
     const element = store.getElmById(id);
 
     return (
-      Math.floor(siblingsBoundaries.top) ===
-      Math.floor(element.ref.getBoundingClientRect().top)
+      Math.floor(siblingsBoundaries.top) === Math.floor(element.currentTop)
     );
   }
 

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -96,10 +96,10 @@ class EndDroppable extends Droppable {
   }
 
   private verify(lst: string[]) {
-    for (let i = 1; i < lst.length; i += 1) {
+    for (let i = 0; i < lst.length; i += 1) {
       const elmID = lst[i];
 
-      if (elmID && elmID !== this.draggable.draggedElm.id) {
+      if (this.isIDEligible2Move(elmID)) {
         const element = store.getElmById(elmID);
 
         return (

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -75,7 +75,7 @@ class EndDroppable extends Droppable {
    * Undo list elements order and instances including translateX/Y and indexes
    * locally.
    */
-  private undoList(lst: Array<string>) {
+  private undoList(lst: string[]) {
     const {
       order: { self: from },
       id: draggedID,
@@ -96,20 +96,26 @@ class EndDroppable extends Droppable {
   }
 
   private verify(lst: string[]) {
-    for (let i = 0; i < lst.length; i += 1) {
-      const elmID = lst[i];
+    const siblingsBoundaries =
+      store.siblingsBoundaries[
+        store.registry[this.draggable.draggedElm.id].keys.sK
+      ];
 
-      if (this.isIDEligible2Move(elmID)) {
-        const element = store.getElmById(elmID);
+    const id = lst[0];
 
-        return (
-          Math.floor(element.currentTop) ===
-          Math.floor(element.ref.getBoundingClientRect().top)
-        );
-      }
+    if (id.length === 0 || this.draggable.draggedElm.id === id) {
+      return (
+        Math.floor(siblingsBoundaries.top) ===
+        Math.floor(this.draggable.occupiedOffset.currentTop)
+      );
     }
 
-    return false;
+    const element = store.getElmById(id);
+
+    return (
+      Math.floor(siblingsBoundaries.top) ===
+      Math.floor(element.ref.getBoundingClientRect().top)
+    );
   }
 
   endDragging() {
@@ -120,6 +126,7 @@ class EndDroppable extends Droppable {
     if (Array.isArray(siblings)) {
       if (this.draggable.isNotSettled() || !this.verify(siblings)) {
         isFallback = true;
+
         this.undoList(siblings);
       }
     }


### PR DESCRIPTION
- [x] Fix checking for position loop to start from `0` instead of `1` 
- [x] Dynamically calls sibling boundaries inside `Draggable` instead of passing it as an argument. 
- [x] Verify with the value that existed in sibling boundaries to make sure the element is still inside without any layout shift. 
- [x] Verify without even calling animation listener. Make it even faster, with a zero delay.
