### PR TITLE
Add element visibility to calculations 

### DIFF
--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -18,33 +18,6 @@ import type {
   TransitionHistory,
 } from "./types";
 
-/**
- * Why storing index here? when it's already sorted in order?
- *
- * Each element has index elements to element's position in list. It allows us
- * to avoid looping in idsTreeOrder to know each element position.
- *
- * elem-id = id1
- * iDsInOrder[id3, id1, id2]
- * How do we get elem-id from iDsInOrder without loop? We don't want to loop
- * twice once to know the qualified element to transform and the second to
- * figure out element position.
- *
- * So, iDsInOrder[index] is our position in list. And, to update to
- * new position: iDsInOrder[new-index] = elem-id.
- *
- *
- * Why storing prev-index?
- *
- * Currently, there's no undo history. But, still need one-step back. Why?
- * Because if dragged is out and release, it should go back to its
- * prevIndex aka selfIndex before transformation.
- *
- * why Storing parent-index?
- *
- * To connect element with parents by knowing their locations.
- */
-
 class CoreInstance
   extends AbstractCoreInstance
   implements CoreInstanceInterface
@@ -62,7 +35,7 @@ class CoreInstance
 
   keys: Keys;
 
-  constructor(elementWithPointer: ElmWIthPointer) {
+  constructor(elementWithPointer: ElmWIthPointer, isPause = false) {
     const { order, keys, ...element } = elementWithPointer;
 
     super(element);
@@ -84,7 +57,7 @@ class CoreInstance
 
     this.currentLeft = 0;
 
-    if (this.ref) {
+    if (this.ref && !isPause) {
       this.initIndicators();
     }
 
@@ -117,16 +90,6 @@ class CoreInstance
 
     this.currentTop = top;
     this.currentLeft = left;
-  }
-
-  getOffset() {
-    return {
-      height: this.offset.height,
-      width: this.offset.width,
-
-      left: this.currentLeft,
-      top: this.currentTop,
-    };
   }
 
   private updateCurrentIndicators(topSpace: number, leftSpace: number) {

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -18,6 +18,12 @@ import type {
   TransitionHistory,
 } from "./types";
 
+interface Opts {
+  isPause: boolean;
+  viewportHeight: number;
+  viewportWidth: number;
+}
+
 class CoreInstance
   extends AbstractCoreInstance
   implements CoreInstanceInterface
@@ -35,7 +41,12 @@ class CoreInstance
 
   keys: Keys;
 
-  constructor(elementWithPointer: ElmWIthPointer, isPause = false) {
+  isVisible: boolean;
+
+  constructor(
+    elementWithPointer: ElmWIthPointer,
+    { isPause = false, viewportHeight = 0, viewportWidth = 0 }: Opts
+  ) {
     const { order, keys, ...element } = elementWithPointer;
 
     super(element);
@@ -59,10 +70,22 @@ class CoreInstance
 
     if (this.ref && !isPause) {
       this.initIndicators();
+      this.isVisible = this.isElementVisible(viewportHeight, viewportWidth);
+    } else {
+      this.isVisible = false;
     }
 
     this.order = order;
     this.keys = keys;
+  }
+
+  isElementVisible(viewportHeight: number, viewportWidth: number) {
+    return (
+      this.offset.top + this.offset.height <= viewportHeight &&
+      this.offset.left + this.offset.width <= viewportWidth &&
+      this.offset.top >= 0 &&
+      this.offset.left >= 0
+    );
   }
 
   /**

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -59,6 +59,7 @@ class CoreInstance
 
     if (this.ref && this.isVisible) {
       this.initIndicators();
+      this.ref.dataset.index = `${this.order.self}`;
     }
   }
 
@@ -81,12 +82,12 @@ class CoreInstance
       height,
       width,
 
-      left,
-      top,
+      left: Math.round(Math.abs(left)),
+      top: Math.round(Math.abs(top)),
     };
 
-    this.currentTop = top;
-    this.currentLeft = left;
+    this.currentTop = this.offset.top;
+    this.currentLeft = this.offset.left;
   }
 
   visibilityHasChanged(isVisible: boolean) {

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -91,15 +91,16 @@ class CoreInstance
 
   updatePixelRatio(devicePixelRatio: number, sign: 1 | -1) {
     let trigger = false;
+    const ratio = sign * (1 / devicePixelRatio);
 
     if (this.translateY > 0) {
       trigger = true;
-      this.translateY += sign * (1 / devicePixelRatio);
+      this.translateY += ratio;
     }
 
     if (this.translateX > 0) {
       trigger = true;
-      this.translateX += sign * (1 / devicePixelRatio);
+      this.translateX += ratio;
     }
 
     if (trigger && this.isVisible) {

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -89,25 +89,6 @@ class CoreInstance
     this.currentLeft = left;
   }
 
-  updatePixelRatio(devicePixelRatio: number, sign: 1 | -1) {
-    let trigger = false;
-    const ratio = sign * (1 / devicePixelRatio);
-
-    if (this.translateY > 0) {
-      trigger = true;
-      this.translateY += ratio;
-    }
-
-    if (this.translateX > 0) {
-      trigger = true;
-      this.translateX += ratio;
-    }
-
-    if (trigger && this.isVisible) {
-      this.transformElm();
-    }
-  }
-
   visibilityHasChanged(isVisible: boolean) {
     if (isVisible === this.isVisible) return;
 
@@ -193,6 +174,8 @@ class CoreInstance
     }
 
     branchIDsOrder[newIndex] = this.id;
+
+    this.ref.dataset.index = `${newIndex}`;
 
     return oldIndex;
   }

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -82,8 +82,8 @@ class CoreInstance
       height,
       width,
 
-      left: Math.round(Math.abs(left)),
-      top: Math.round(Math.abs(top)),
+      left: Math.abs(left),
+      top: Math.abs(top),
     };
 
     this.currentTop = this.offset.top;

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -72,7 +72,7 @@ class CoreInstance
    *
    * So, basically any working element in DnD should be initiated first.
    */
-  private initIndicators() {
+  initIndicators() {
     const { height, width, left, top } = this.ref.getBoundingClientRect();
 
     /**

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -89,6 +89,5 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
     siblingsHasEmptyElm?: number
   ): number;
   initIndicators(): void;
-  updatePixelRatio(devicePixelRatio: number, sign: 1 | -1): void;
   visibilityHasChanged(isVisible: boolean): void;
 }

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -88,5 +88,4 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
     oldIndex?: number,
     siblingsHasEmptyElm?: number
   ): number;
-  getOffset(): Offset;
 }

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -88,4 +88,5 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
     oldIndex?: number,
     siblingsHasEmptyElm?: number
   ): number;
+  initIndicators(): void;
 }

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -74,7 +74,7 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
   keys: Keys;
   setYPosition(
     iDsInOrder: ELmBranch,
-    sign: number,
+    sign: 1 | -1,
     topSpace: number,
     operationID: string,
     siblingsHasEmptyElm?: number,
@@ -89,4 +89,6 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
     siblingsHasEmptyElm?: number
   ): number;
   initIndicators(): void;
+  updatePixelRatio(devicePixelRatio: number, sign: 1 | -1): void;
+  visibilityHasChanged(isVisible: boolean): void;
 }

--- a/packages/dnd/playgrounds/dflex-react-dnd/src/DnDComponent.tsx
+++ b/packages/dnd/playgrounds/dflex-react-dnd/src/DnDComponent.tsx
@@ -38,7 +38,7 @@ export const TodoItem = ({
   }, []);
 
   const onMouseMove = (e: MouseEvent) => {
-    e.stopPropagation();
+    // e.stopPropagation();
 
     if (dndEvent) {
       const { clientX, clientY } = e;
@@ -66,6 +66,7 @@ export const TodoItem = ({
       if (id) {
         document.addEventListener("mouseup", onMouseUp);
         document.addEventListener("mousemove", onMouseMove);
+        // document.addEventListener("scroll", onMouseScroll);
 
         dndEvent = new DnD(id, { x: clientX, y: clientY });
       }

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -124,6 +124,11 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
               this.elmIndicator.exceptionToNextElm = true;
               isVisible = true;
             } else if (isVisible && this.elmIndicator.exceptionToNextElm) {
+              // In this case, we are moving from hidden to visible.
+              // Eg: 1, 2 are hidden the rest of the list is visible.
+              // But, there's a possibility that the rest of the branch elements
+              // are hidden.
+              // Eg: 1, 2: hidden 3, 4, 5, 6, 7:visible 8, 9, 10: hidden.
               this.initELmIndicator();
             }
             this.registry[elmID].visibilityHasChanged(isVisible);

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -68,6 +68,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     if (!this.throttle) {
       window.requestAnimationFrame(() => {
         this.updateRegisteredLayoutIndicators();
+        this.throttle = false;
       });
 
       this.throttle = true;

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -111,7 +111,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
   }
 
   getELmOffsetById(id: string) {
-    return this.getElmById(id).getOffset();
+    return this.getElmById(id).offset;
   }
 
   getELmTranslateById(id: string) {

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -48,15 +48,6 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     );
   }
 
-  isElementVisible(elemOffset: Offset) {
-    return (
-      elemOffset.top + elemOffset.height <= this.viewportHeight &&
-      elemOffset.left + elemOffset.width <= this.viewportWidth &&
-      elemOffset.top >= 0 &&
-      elemOffset.left >= 0
-    );
-  }
-
   private assignSiblingsBoundaries(siblingsK: string, elemOffset: Offset) {
     const elmRight = elemOffset.left + elemOffset.width;
 
@@ -101,22 +92,6 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     // Preserves last changes.
     this.registry[id].transformElm();
   }
-
-  // isElementOnViewport(id: string) {
-  //   const {
-  //     offset,
-  //     keys: { sK },
-  //   } = this.registry[id];
-
-  //   const { top, bottom, left, right } = this.siblingsBoundaries[sK];
-
-  //   return (
-  //     offset.top >= top &&
-  //     offset.top <= bottom &&
-  //     offset.left >= left &&
-  //     offset.left <= right
-  //   );
-  // }
 
   /**
    *  Register DnD element.

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -23,11 +23,38 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
   siblingsBoundaries: { [k: string]: BoundariesOffset };
 
+  viewportHeight!: number;
+
+  viewportWidth!: number;
+
   constructor() {
     super();
 
     this.siblingsBoundaries = {};
     this.tracker = new Tracker();
+
+    this.setViewport();
+  }
+
+  setViewport() {
+    this.viewportHeight = Math.max(
+      document.documentElement.clientHeight || 0,
+      window.innerHeight || 0
+    );
+
+    this.viewportWidth = Math.max(
+      document.documentElement.clientWidth || 0,
+      window.innerWidth || 0
+    );
+  }
+
+  isElementVisible(elemOffset: Offset) {
+    return (
+      elemOffset.top + elemOffset.height <= this.viewportHeight &&
+      elemOffset.left + elemOffset.width <= this.viewportWidth &&
+      elemOffset.top >= 0 &&
+      elemOffset.left >= 0
+    );
   }
 
   private assignSiblingsBoundaries(siblingsK: string, elemOffset: Offset) {
@@ -75,6 +102,22 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     this.registry[id].transformElm();
   }
 
+  // isElementOnViewport(id: string) {
+  //   const {
+  //     offset,
+  //     keys: { sK },
+  //   } = this.registry[id];
+
+  //   const { top, bottom, left, right } = this.siblingsBoundaries[sK];
+
+  //   return (
+  //     offset.top >= top &&
+  //     offset.top <= bottom &&
+  //     offset.left >= left &&
+  //     offset.left <= right
+  //   );
+  // }
+
   /**
    *  Register DnD element.
    *
@@ -100,7 +143,10 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       return;
     }
 
-    super.register(element, CoreInstance);
+    super.register(element, CoreInstance, {
+      viewportHeight: this.viewportHeight,
+      viewportWidth: this.viewportWidth,
+    });
 
     const {
       offset,

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -32,11 +32,31 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
   scrollX!: number;
 
+  elmIndicator: {
+    currentKy: string;
+
+    prevKy: string;
+
+    order: number;
+
+    prevElmVisibility: boolean;
+
+    exceptionToNextElm: boolean;
+  };
+
   constructor() {
     super();
 
     this.siblingsBoundaries = {};
     this.tracker = new Tracker();
+
+    this.elmIndicator = {
+      currentKy: "",
+      prevKy: "",
+      order: -1,
+      prevElmVisibility: false,
+      exceptionToNextElm: false,
+    };
 
     this.setViewport();
     this.setScrollXY();
@@ -170,15 +190,26 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       offset,
       currentTop,
       currentLeft,
-      keys: { sK },
+      keys: { sK, pK },
     } = this.registry[id];
 
     this.assignSiblingsBoundaries(sK, offset);
 
-    this.registry[id].isVisible = !this.isElementHiddenInViewport(
-      currentTop,
-      currentLeft
-    );
+    let isVisible = !this.isElementHiddenInViewport(currentTop, currentLeft);
+
+    // same branch
+    this.elmIndicator.currentKy = sK + pK;
+
+    if (this.elmIndicator.currentKy === this.elmIndicator.prevKy) {
+      if (!isVisible && !this.elmIndicator.exceptionToNextElm) {
+        this.elmIndicator.exceptionToNextElm = true;
+        isVisible = true;
+      }
+    }
+
+    this.registry[id].isVisible = isVisible;
+
+    this.elmIndicator.prevKy = this.elmIndicator.currentKy;
   }
 
   getELmOffsetById(id: string) {

--- a/packages/dnd/test/Store/__snapshots__/dndStore.test.ts.snap
+++ b/packages/dnd/test/Store/__snapshots__/dndStore.test.ts.snap
@@ -7,6 +7,7 @@ Object {
     "currentTop": 114,
     "depth": 0,
     "id": "id-1",
+    "isVisible": true,
     "keys": Object {
       "chK": null,
       "pK": "1-0",
@@ -23,7 +24,9 @@ Object {
       "self": 0,
     },
     "prevTranslateY": Array [],
-    "ref": <div />,
+    "ref": <div
+      data-index="0"
+    />,
     "translateX": 0,
     "translateY": 0,
   },
@@ -32,6 +35,7 @@ Object {
     "currentTop": 172,
     "depth": 0,
     "id": "id-2",
+    "isVisible": true,
     "keys": Object {
       "chK": null,
       "pK": "1-0",
@@ -48,7 +52,9 @@ Object {
       "self": 1,
     },
     "prevTranslateY": Array [],
-    "ref": <div />,
+    "ref": <div
+      data-index="1"
+    />,
     "translateX": 0,
     "translateY": 0,
   },
@@ -57,6 +63,7 @@ Object {
     "currentTop": 230,
     "depth": 0,
     "id": "id-3",
+    "isVisible": true,
     "keys": Object {
       "chK": null,
       "pK": "1-0",
@@ -73,7 +80,9 @@ Object {
       "self": 2,
     },
     "prevTranslateY": Array [],
-    "ref": <div />,
+    "ref": <div
+      data-index="2"
+    />,
     "translateX": 0,
     "translateY": 0,
   },
@@ -82,6 +91,7 @@ Object {
     "currentTop": 288,
     "depth": 0,
     "id": "id-4",
+    "isVisible": true,
     "keys": Object {
       "chK": null,
       "pK": "1-0",
@@ -98,7 +108,9 @@ Object {
       "self": 3,
     },
     "prevTranslateY": Array [],
-    "ref": <div />,
+    "ref": <div
+      data-index="3"
+    />,
     "translateX": 0,
     "translateY": 0,
   },
@@ -121,6 +133,7 @@ Object {
     "currentTop": 114,
     "depth": 0,
     "id": "id-1",
+    "isVisible": true,
     "keys": Object {
       "chK": null,
       "pK": "1-0",
@@ -137,7 +150,9 @@ Object {
       "self": 0,
     },
     "prevTranslateY": Array [],
-    "ref": <div />,
+    "ref": <div
+      data-index="0"
+    />,
     "translateX": 0,
     "translateY": 0,
   },

--- a/packages/draggable/src/AbstractDraggable.ts
+++ b/packages/draggable/src/AbstractDraggable.ts
@@ -103,6 +103,9 @@ class AbstractDraggable<T extends AbstractCoreInterface>
         // @ts-expect-error
         this.draggedStyleRef[prop] = dragValue;
       });
+
+      getSelection()?.removeAllRanges();
+
       return;
     }
     /**

--- a/packages/draggable/test/__snapshots__/draggableStore.test.ts.snap
+++ b/packages/draggable/test/__snapshots__/draggableStore.test.ts.snap
@@ -7,6 +7,7 @@ Object {
     "currentTop": 0,
     "depth": 0,
     "id": "id-0",
+    "isVisible": true,
     "keys": Object {
       "chK": null,
       "pK": "1-0",
@@ -23,7 +24,9 @@ Object {
       "self": 0,
     },
     "prevTranslateY": Array [],
-    "ref": <div />,
+    "ref": <div
+      data-index="0"
+    />,
     "translateX": 0,
     "translateY": 0,
   },

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -40,7 +40,7 @@ class Store<T = ElmWIthPointer> {
    * @param element -
    * @param CustomInstance -
    */
-  register(element: ElmInstance, CustomInstance?: Class<T>) {
+  register(element: ElmInstance, CustomInstance?: Class<T>, opts?: {}) {
     const { id: idElm, depth = 0, ref } = element;
 
     if (!ref || ref.nodeType !== Node.ELEMENT_NODE) {
@@ -63,7 +63,7 @@ class Store<T = ElmWIthPointer> {
     // @ts-ignore
     this.registry[id] =
       CustomInstance && typeof CustomInstance.constructor === "function"
-        ? new CustomInstance(coreElement)
+        ? new CustomInstance(coreElement, opts)
         : coreElement;
   }
 


### PR DESCRIPTION
- [x] Remove text selection from the entire document when starting dragging.
- [x] Remove unnecessary `getOffset` method from `core-instance`.
- [x] Add ability to reset `DOMRect`  from outside the `core-instance`.
- [x] `core-instance` accepts opts now.
- [x] Add custom dataset `data-index` which refers to element order inside rendering list after the transform is calculated. We have now original order in the `DOM` tree and a transformation order related to elements' appearance on the screen.
- [x] Introduce element visibility which is true when the element is visible on the viewport.
     - [x] Calculate element visibility with scrolling. 
     - [x] Update element position in the store but don't transform when the element is hidden.
     - [x] Invoke transformer when the element is visible,. Which is done with scrolling. 
     - [x] Scroll is throttled to the animated frame. 
     - [x] Add visibility exceptions to enhance UX. Immediate elements before and after the visible elements are `isVisible: true` 
     - [x] Done with adding new methods: 
        - [x] Inside the store: 
        `setViewport`
        `setScrollXY`
        `initELmIndicator`
        `isElementHiddenInViewport`
        `updateRegisteredLayoutIndicators`
     - [x] Inside the core-instance: 
       `visibilityHasChanged`
 - [x] Refactor Jest Snapshots to include the new changes.
