### PR TITLE
Add new core API with `isInitialized`, `isPaused` and `isVisible`

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -45,8 +45,8 @@ jobs:
           project: ./packages/dnd
           start: yarn workspace dflex-react-dnd start
           wait-on: "http://localhost:3001/"
-          # wait for 1/5 minutes for the server to respond
-          wait-on-timeout: 30
+          # wait for 10 seconds for the server to respond
+          wait-on-timeout: 10
           browser: chrome
           headless: true
         env:

--- a/packages/core-instance/src/AbstractCoreInstance.ts
+++ b/packages/core-instance/src/AbstractCoreInstance.ts
@@ -45,6 +45,10 @@ class AbstractCoreInstance implements AbstractCoreInterface {
     }
   }
 
+  hasValidRef() {
+    return this.isInitialized && this.ref !== null && this.ref.isConnected;
+  }
+
   attach(incomingRef: HTMLElement | null) {
     if (!incomingRef) {
       const ref = document.getElementById(this.id);

--- a/packages/core-instance/src/AbstractCoreInstance.ts
+++ b/packages/core-instance/src/AbstractCoreInstance.ts
@@ -7,12 +7,8 @@
 
 import type { AbstractCoreInterface, AbstractCoreInput } from "./types";
 
-/**
- * This is the link (bridge) between the Store and element actions/classes.
- * Abstract is essential for Draggable & extended Store.
- */
 class AbstractCoreInstance implements AbstractCoreInterface {
-  ref: HTMLElement | null;
+  ref!: HTMLElement | null;
 
   id: string;
 
@@ -22,43 +18,66 @@ class AbstractCoreInstance implements AbstractCoreInterface {
 
   isInitialized: boolean;
 
+  isPaused: boolean;
+
   /**
    * Creates an instance of AbstractCoreInstance.
    */
-  constructor({ ref, id, isInitialized = true }: AbstractCoreInput) {
-    this.ref = ref;
+  constructor({
+    ref,
+    id,
+    isPaused = false,
+    isInitialized = true,
+  }: AbstractCoreInput) {
     this.id = id;
 
     this.isInitialized = isInitialized;
+    this.isPaused = isPaused;
 
     if (this.isInitialized) {
-      this.initialize();
+      this.attach(ref);
+    } else {
+      this.ref = null;
+    }
+
+    if (!this.isPaused) {
+      this.initTranslate();
     }
   }
 
-  private initTranslate() {
+  attach(incomingRef: HTMLElement | null) {
+    if (!incomingRef) {
+      const ref = document.getElementById(this.id);
+      if (!ref) {
+        throw new Error(`DFlex: Element with ID: ${this.id} is not found.`);
+      }
+    } else if (incomingRef.nodeType !== Node.ELEMENT_NODE) {
+      throw new Error(
+        `DFlex: Invalid HTMLElement: ${incomingRef} is passed to registry.`
+      );
+    }
+
+    this.ref = incomingRef;
+  }
+
+  detach() {
+    this.ref = null;
+  }
+
+  initialize(ref: HTMLElement | null) {
+    this.attach(ref);
+    this.isInitialized = true;
+  }
+
+  initTranslate() {
     /**
      * Since element render once and being transformed later we keep the data
      * stored to navigate correctly.
      */
     this.translateY = 0;
     this.translateX = 0;
-  }
 
-  initialize() {
-    if (!this.ref) {
-      const ref = document.getElementById(this.id);
-      if (!ref) {
-        throw new Error(`Element with ID: ${this.id} is not found.`);
-      }
-      this.ref = ref;
-    }
-
-    this.initTranslate();
-
-    if (!this.isInitialized) {
-      this.isInitialized = true;
-    }
+    this.isPaused = false;
   }
 }
 

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -94,6 +94,10 @@ class CoreInstance
     this.isPaused = false;
   }
 
+  changeVisibility(isVisible: boolean) {
+    this.isVisible = isVisible;
+  }
+
   private updateCurrentIndicators(topSpace: number, leftSpace: number) {
     this.translateY! += topSpace;
     this.translateX! += leftSpace;

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -12,10 +12,10 @@ import AbstractCoreInstance from "./AbstractCoreInstance";
 import type {
   Keys,
   Order,
-  ElmWIthPointer,
   CoreInstanceInterface,
   Offset,
   TransitionHistory,
+  CoreInput,
 } from "./types";
 
 class CoreInstance
@@ -37,22 +37,22 @@ class CoreInstance
 
   isVisible: boolean;
 
-  constructor(
-    elementWithPointer: ElmWIthPointer,
-    { isInitialized = true, isPause = false, scrollX = 0, scrollY = 0 } = {}
-  ) {
-    const { order, keys, ...element } = elementWithPointer;
+  constructor(elementWithPointer: CoreInput) {
+    const { order, keys, scrollX, scrollY, ...element } = elementWithPointer;
 
-    super({ ...element, isInitialized });
+    super(element);
 
     this.order = order;
     this.keys = keys;
 
-    this.isVisible = isPause;
+    this.isVisible = element.isInitialized && !element.isPaused;
 
-    if (isInitialized && !isPause) {
-      this.initIndicators(scrollX, scrollY);
+    if (element.isInitialized) {
       this.updateDataset(this.order.self);
+    }
+
+    if (!element.isPaused) {
+      this.initIndicators(scrollX, scrollY);
     }
   }
 
@@ -63,7 +63,7 @@ class CoreInstance
    *
    * So, basically any working element in DnD should be initiated first.
    */
-  initIndicators(scrollX: number, scrollY: number) {
+  private initIndicators(scrollX: number, scrollY: number) {
     this.prevTranslateY = [];
 
     const { height, width, left, top } = this.ref!.getBoundingClientRect();
@@ -85,14 +85,13 @@ class CoreInstance
     this.currentLeft = this.offset.left;
   }
 
-  visibilityHasChanged(isVisible: boolean) {
-    if (isVisible === this.isVisible) return;
+  resume(scrollX: number, scrollY: number) {
+    if (!this.isInitialized) this.initialize(null);
 
-    if (isVisible && !this.isVisible) {
-      this.transformElm();
-    }
+    this.initTranslate();
+    this.initIndicators(scrollX, scrollY);
 
-    this.isVisible = isVisible;
+    this.isPaused = false;
   }
 
   private updateCurrentIndicators(topSpace: number, leftSpace: number) {

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -37,6 +37,7 @@ export interface AbstractCoreInterface {
   initTranslate(): void;
   attach(ref: HTMLElement | null): void;
   detach(): void;
+  hasValidRef(): void;
 }
 
 export type ELmBranch = string | string[];

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -96,6 +96,7 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
   order: Order;
   keys: Keys;
   resume(scrollX: number, scrollY: number): void;
+  changeVisibility(isVisible: boolean): void;
   setYPosition(
     iDsInOrder: ELmBranch,
     sign: 1 | -1,

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -7,31 +7,36 @@
 
 /* eslint-disable no-unused-vars */
 
-export type AbstractCoreInput =
-  | {
-      id: string;
-      isInitialized: false;
-      ref: HTMLElement | null;
-    }
-  | {
-      id: string;
-      isInitialized: true;
-      ref: HTMLElement;
-    };
-
-export interface AbstractCoreInterface {
-  isInitialized: boolean;
-  ref: HTMLElement | null;
+interface AbsCoreEssential {
   id: string;
-  translateY?: number;
-  translateX?: number;
-  initialize(): void;
+  isPaused?: boolean;
 }
 
-export interface ElmInstance {
-  id: string;
-  depth: number;
+interface AbsCoreWithRef {
+  isInitialized: true;
   ref: HTMLElement;
+}
+
+interface AbsCoreWithoutRef {
+  isInitialized: false;
+  ref: null;
+}
+
+export type AbstractCoreInput =
+  | (AbsCoreEssential & AbsCoreWithoutRef)
+  | (AbsCoreEssential & AbsCoreWithRef);
+
+export interface AbstractCoreInterface {
+  ref: HTMLElement | null;
+  id: string;
+  isPaused: boolean;
+  isInitialized: boolean;
+  translateY?: number;
+  translateX?: number;
+  initialize(ref: HTMLElement | null): void;
+  initTranslate(): void;
+  attach(ref: HTMLElement | null): void;
+  detach(): void;
 }
 
 export type ELmBranch = string | string[];
@@ -61,10 +66,14 @@ export interface Pointer {
   order: Order;
 }
 
-export interface ElmWIthPointer extends ElmInstance {
+export interface CoreEssential {
   order: Order;
   keys: Keys;
+  scrollX: number;
+  scrollY: number;
 }
+
+export type CoreInput = CoreEssential & AbstractCoreInput;
 
 export interface Offset {
   height: number;
@@ -85,6 +94,7 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
   currentLeft?: number;
   order: Order;
   keys: Keys;
+  resume(scrollX: number, scrollY: number): void;
   setYPosition(
     iDsInOrder: ELmBranch,
     sign: 1 | -1,
@@ -101,7 +111,5 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
     oldIndex?: number,
     siblingsHasEmptyElm?: number
   ): number;
-  initIndicators(scrollX: number, scrollY: number): void;
-  visibilityHasChanged(isVisible: boolean): void;
   updateDataset(index: number): void;
 }

--- a/packages/dnd/cypress/integration/extended/visibility.transformation.spec.js
+++ b/packages/dnd/cypress/integration/extended/visibility.transformation.spec.js
@@ -81,19 +81,9 @@ context("Visible elements have transformation", () => {
     }
   });
 
-  it("Scroll to element 21", () => {
-    cy.scrollTo(0, 600); // Scroll the window 500px down
-  });
-
-  it("DFlex automatically activate visible element to transformation - until 22", () => {
-    for (let i = 1; i < 23; i += 1) {
-      cy.get(`#${i}-extended`).should(
-        "have.css",
-        "transform",
-        "matrix(1, 0, 0, 1, 0, 0)"
-      );
-    }
-  });
+  // it("Scroll to element 21", () => {
+  //   cy.scrollTo(0, 600); // Scroll the window 500px down
+  // });
 
   it("Rest of non-visible and not effected elements have no transformation", () => {
     for (let i = 24; i < 100; i += 1) {

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -253,18 +253,17 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       return;
     }
 
-    super.register(
-      {
-        id,
-        depth: element.depth || 0,
-        ref: element.ref || null,
-        scrollX: this.scrollX,
-        scrollY: this.scrollY,
-        isInitialized: true,
-        isPause: this.isPauseRegistration,
-      },
-      CoreInstance
-    );
+    const coreInput = {
+      id,
+      depth: element.depth || 0,
+      ref: element.ref || null,
+      scrollX: this.scrollX,
+      scrollY: this.scrollY,
+      isInitialized: true,
+      isPaused: this.isPauseRegistration,
+    };
+
+    super.register(coreInput, CoreInstance);
 
     if (this.isPauseRegistration) return;
 

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -225,40 +225,29 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       this.isPauseRegistration = false;
     }
 
-    if (!element.ref) {
-      if (!element.id) return;
-
-      const ref = document.getElementById(element.id);
-
-      if (!ref) return;
-
-      // @ts-expect-error
-      // eslint-disable-next-line no-param-reassign
-      element.ref = ref;
+    if (!element.ref && !element.id) {
+      throw new Error(
+        `DFlex: A valid unique id Or/and HTML element is required.`
+      );
     }
 
     /**
      * If element already exist in the store, then the reattach the reference.
      */
-    const id = element.id || element.ref.id;
+    const id = element.id || element.ref?.id;
+
+    if (!id) {
+      throw new Error(`DFlex: A valid and unique id is required.`);
+    }
 
     if (this.registry[id]) {
-      if (
-        (this.registry[id].ref &&
-          this.registry[id].isInitialized &&
-          !this.registry[id].ref!.isConnected) ||
-        this.registry[id].ref!.isEqualNode(element.ref)
-      ) {
-        this.registry[id].attach(element.ref);
+      if (this.registry[id].isInitialized) {
+        this.registry[id].attach(element.ref || null);
+      }
 
-        if (this.registry[id].isVisible) {
-          // Preserves last changes.
-          this.registry[id].transformElm();
-        }
-      } else {
-        throw new Error(
-          `DFlex: Element with id:${id} is already registered. Please, provide DFlex with a unique id.`
-        );
+      if (this.registry[id].isVisible) {
+        // Preserves last changes.
+        this.registry[id].transformElm();
       }
 
       return;

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -141,15 +141,11 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
         (this.DOMGen.branches[branchKey] as string[]).forEach((elmID, i) => {
           if (elmID.length > 0) {
-            if (!this.registry[elmID].isInitialized) {
-              this.registry[elmID].initialize();
-            }
+            const { currentTop, currentLeft, isPaused } = this.registry[elmID];
 
-            if (!this.registry[elmID].offset) {
-              this.registry[elmID].initIndicators(this.scrollX, this.scrollY);
+            if (isPaused) {
+              this.registry[elmID].resume(this.scrollX, this.scrollY);
             }
-
-            const { currentTop, currentLeft } = this.registry[elmID];
 
             let isVisible = !this.isElementHiddenInViewport(
               currentTop!,
@@ -171,7 +167,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
               // Eg: 1, 2: hidden 3, 4, 5, 6, 7:visible 8, 9, 10: hidden.
               this.initELmIndicator();
             }
-            this.registry[elmID].visibilityHasChanged(isVisible);
+            this.registry[elmID].isVisible = isVisible;
             prevIndex = i;
           }
         });

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -55,7 +55,6 @@ export type RegisterInput =
   | (RegisterInputDepth & RegisterInputRef);
 
 export interface DnDStoreInterface {
-  reattachElmRef(id: string, elmRef: HTMLElement): void;
   register(element: ElmInstance, x?: boolean): void;
   unregister(id: string): void;
   destroy(): void;

--- a/packages/dnd/src/Draggable/Base.ts
+++ b/packages/dnd/src/Draggable/Base.ts
@@ -55,10 +55,6 @@ class Base
 
     const { order } = element;
 
-    if (!this.draggedElm.offset) {
-      this.draggedElm.initIndicators(store.scrollX, store.scrollY);
-    }
-
     this.opts = opts;
 
     /**

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -326,7 +326,10 @@ class Droppable {
    */
   protected isIDEligible2Move(id: string) {
     return (
-      id && id !== this.draggable.draggedElm.id && store.registry[id].offset
+      id &&
+      id !== this.draggable.draggedElm.id &&
+      store.registry[id].ref !== null &&
+      store.registry[id].isVisible
     );
   }
 

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -326,7 +326,7 @@ class Droppable {
    */
   protected isIDEligible2Move(id: string) {
     return (
-      id &&
+      id.length > 0 &&
       id !== this.draggable.draggedElm.id &&
       store.registry[id].ref !== null &&
       store.registry[id].isVisible

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -29,14 +29,12 @@ class EndDroppable extends Droppable {
 
     if (this.isIDEligible2Move(elmID)) {
       const element = store.registry[elmID];
-      if (element.offset) {
-        /**
-         * Note: rolling back won't affect order array. It only deals with element
-         * itself and totally ignore any instance related to store.
-         */
-        element.rollYBack(this.draggable.operationID);
-        this.draggable.numberOfElementsTransformed -= 1;
-      }
+      /**
+       * Note: rolling back won't affect order array. It only deals with element
+       * itself and totally ignore any instance related to store.
+       */
+      element.rollYBack(this.draggable.operationID);
+      this.draggable.numberOfElementsTransformed -= 1;
     } else {
       this.spliceAt = i;
     }

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -27,7 +27,7 @@ class EndDroppable extends Droppable {
   private undoElmTranslate(lst: ELmBranch, i: number) {
     const elmID = lst[i];
 
-    if (elmID) {
+    if (this.isIDEligible2Move(elmID)) {
       const element = store.registry[elmID];
       if (element.offset) {
         /**

--- a/packages/dnd/test/Store/__snapshots__/dndStore.test.ts.snap
+++ b/packages/dnd/test/Store/__snapshots__/dndStore.test.ts.snap
@@ -7,6 +7,7 @@ Object {
     "currentTop": 114,
     "id": "id-1",
     "isInitialized": true,
+    "isPaused": false,
     "isVisible": true,
     "keys": Object {
       "chK": null,
@@ -35,6 +36,7 @@ Object {
     "currentTop": 172,
     "id": "id-2",
     "isInitialized": true,
+    "isPaused": false,
     "isVisible": true,
     "keys": Object {
       "chK": null,
@@ -63,6 +65,7 @@ Object {
     "currentTop": 230,
     "id": "id-3",
     "isInitialized": true,
+    "isPaused": false,
     "isVisible": true,
     "keys": Object {
       "chK": null,
@@ -91,6 +94,7 @@ Object {
     "currentTop": 288,
     "id": "id-4",
     "isInitialized": true,
+    "isPaused": false,
     "isVisible": true,
     "keys": Object {
       "chK": null,
@@ -133,6 +137,7 @@ Object {
     "currentTop": 114,
     "id": "id-1",
     "isInitialized": true,
+    "isPaused": false,
     "isVisible": true,
     "keys": Object {
       "chK": null,

--- a/packages/draggable/test/__snapshots__/draggableStore.test.ts.snap
+++ b/packages/draggable/test/__snapshots__/draggableStore.test.ts.snap
@@ -3,11 +3,12 @@
 exports[`Draggable Store Registers element and initiates translateX,Y 1`] = `
 Object {
   "id-0": CoreInstance {
-    "currentLeft": 0,
-    "currentTop": 0,
+    "currentLeft": NaN,
+    "currentTop": NaN,
     "id": "id-0",
     "isInitialized": true,
-    "isVisible": false,
+    "isPaused": false,
+    "isVisible": undefined,
     "keys": Object {
       "chK": null,
       "pK": "1-0",
@@ -15,8 +16,8 @@ Object {
     },
     "offset": Object {
       "height": 0,
-      "left": 0,
-      "top": 0,
+      "left": NaN,
+      "top": NaN,
       "width": 0,
     },
     "order": Object {
@@ -24,9 +25,7 @@ Object {
       "self": 0,
     },
     "prevTranslateY": Array [],
-    "ref": <div
-      data-index="0"
-    />,
+    "ref": <div />,
     "translateX": 0,
     "translateY": 0,
   },

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -6,9 +6,13 @@
  */
 import Generator from "@dflex/dom-gen";
 import type { ELmBranch } from "@dflex/dom-gen";
-import type { Class, ElmInstance, ElmWIthPointer } from "./types";
+import type {
+  Class,
+  ElmInstanceWithProps,
+  ElmWithPointerWithProps,
+} from "./types";
 
-class Store<T = ElmWIthPointer> {
+class Store<T = ElmWithPointerWithProps> {
   registry: {
     [id: string]: T;
   };
@@ -28,24 +32,16 @@ class Store<T = ElmWIthPointer> {
    * @param element -
    * @param CustomInstance -
    */
-  register(element: ElmInstance, CustomInstance?: Class<T>, opts?: {}) {
-    const { id: idElm, depth = 0, ref } = element;
-
-    if (!ref || ref.nodeType !== Node.ELEMENT_NODE) {
-      throw new Error(
-        `DFlex: Invalid HTMLElement: ${ref} is passed to registry`
-      );
-    }
-
-    if (!idElm && !ref.id) {
-      throw new Error(`DFlex: A valid and unique id is required.`);
-    }
-
-    const id = idElm || ref.id;
+  register(
+    element: ElmInstanceWithProps,
+    CustomInstance?: Class<T>,
+    opts?: {}
+  ) {
+    const { id, depth, ...rest } = element;
 
     const { order, keys } = this.DOMGen.getElmPointer(id, depth);
 
-    const coreElement: ElmWIthPointer = { id, depth, ref, order, keys };
+    const coreElement: ElmWithPointerWithProps = { id, order, keys, ...rest };
 
     // TODO: fix TS error here.
     // @ts-ignore

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -4,6 +4,6 @@
  * This source code is licensed under the AGPL3.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-export type { ElmInstance, ElmWIthPointer } from "./types";
+export type { ElmInstance } from "./types";
 
 export { default } from "./Store";

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -10,13 +10,16 @@ import type { Keys, Order } from "@dflex/dom-gen";
 export type Class<classInstance> = new (...args: any[]) => classInstance;
 
 export interface ElmInstance {
-  id?: string;
-  depth?: number;
-  ref: HTMLElement;
+  id: string;
+  depth: number;
 }
 
-export interface ElmWIthPointer extends ElmInstance {
-  id: string;
+export interface ElmInstanceWithProps extends Required<ElmInstance> {
+  [key: string]: any;
+}
+
+export interface ElmWithPointerWithProps
+  extends Omit<ElmInstanceWithProps, "depth"> {
   order: Order;
   keys: Keys;
 }

--- a/packages/store/test/__snapshots__/store.test.ts.snap
+++ b/packages/store/test/__snapshots__/store.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`Testing Store Package Snaps shot registry 1`] = `
 Object {
   "id-0": Object {
-    "depth": 0,
     "id": "id-0",
     "keys": Object {
       "chK": null,
@@ -17,7 +16,6 @@ Object {
     "ref": <div />,
   },
   "id-1": Object {
-    "depth": 0,
     "id": "id-1",
     "keys": Object {
       "chK": null,
@@ -31,7 +29,6 @@ Object {
     "ref": <div />,
   },
   "id-2": Object {
-    "depth": 0,
     "id": "id-2",
     "keys": Object {
       "chK": null,
@@ -45,7 +42,6 @@ Object {
     "ref": <div />,
   },
   "p-id-0": Object {
-    "depth": 1,
     "id": "p-id-0",
     "keys": Object {
       "chK": "0-0",
@@ -64,7 +60,6 @@ Object {
 exports[`Testing Store Package Snaps shot registry after delete 1`] = `
 Object {
   "id-0": Object {
-    "depth": 0,
     "id": "id-0",
     "keys": Object {
       "chK": null,
@@ -78,7 +73,6 @@ Object {
     "ref": <div />,
   },
   "id-1": Object {
-    "depth": 0,
     "id": "id-1",
     "keys": Object {
       "chK": null,
@@ -92,7 +86,6 @@ Object {
     "ref": <div />,
   },
   "id-2": Object {
-    "depth": 0,
     "id": "id-2",
     "keys": Object {
       "chK": null,
@@ -106,7 +99,6 @@ Object {
     "ref": <div />,
   },
   "p-id-0": Object {
-    "depth": 1,
     "id": "p-id-0",
     "keys": Object {
       "chK": "0-0",

--- a/packages/store/test/store.test.ts
+++ b/packages/store/test/store.test.ts
@@ -64,7 +64,6 @@ describe("Testing Store Package", () => {
     const elemInstance = store.registry[elm0D0.id];
 
     expect(elemInstance).toStrictEqual({
-      depth: 0,
       id: "id-0",
       keys: {
         chK: null,


### PR DESCRIPTION
- [x] Add `isPaused` and `isInitialized` to the Core. This is going to add more flexibility to the API. When to resume and when to initialize. The current situation is core has multi-levels `isInitialized`, `isPaused` and `isVisible`.
- [x] Validate element reference from inside the Core. This step enables a more flexible attach/detach and it's more reliable to pass `id` without HTML reference.  It's also consistent with the three new levels.
- [x] Element Reference is nullish when not passed to not hurt the runtime. Adding a reference is unavoidable. 
- [x] Checking visibility depending on so-called parent flags.
- [x] To make it more reliable and less buggy, there's a resume function that checks if the instance is initialized or not.
- [x] Changing visibility is done inside the Core. Make it easier to debug any issue in the future.
- [x] Add strong types to Core input. Refactor old names to more clear names.
- [x] Check listeners' values and then update. Avoid unnecessary function trigger. 
- [x] Fix a bug when updating visibility in the store.
- [x] Remove incoming reference validation from the store implementation in the DnD. (Legacy code).
- [x] Suspend id duplication validation for now. Need to be investigated more in the future. 