### PR TITLE
Add scroll instance to each sibling list

### DIFF
--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -49,6 +49,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     this.isDOM = false;
 
     this.onLoadListeners = this.onLoadListeners.bind(this);
+    this.updateBranchVisibility = this.updateBranchVisibility.bind(this);
   }
 
   private init() {
@@ -70,15 +71,12 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     const scroll = new Scroll({
       element: this.registry[firstElemID].ref!,
       requiredBranchKey: key,
-      scrollEventCallback: hasSiblings
-        ? this.updateRegisteredLayoutIndicators
-        : null,
+      scrollEventCallback: hasSiblings ? this.updateBranchVisibility : null,
     });
-    console.log("file: DnDStoreImp.ts ~ line 77 ~ scroll", scroll);
 
     this.siblingsScrollElement[key] = scroll;
 
-    if (hasSiblings) this.updateRegisteredLayoutIndicators(key);
+    if (hasSiblings) this.updateBranchVisibility(key);
   }
 
   onLoadListeners() {
@@ -95,7 +93,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     };
   }
 
-  private updateRegisteredLayoutIndicators(requiredBranchKey: string) {
+  private updateBranchVisibility(requiredBranchKey: string) {
     this.initELmIndicator();
 
     Object.keys(this.DOMGen.branches).forEach((branchKey) => {

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -117,6 +117,11 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
               this.registry[elmID].resume(scroll.scrollX, scroll.scrollY);
             }
 
+            this.assignSiblingsBoundaries(
+              this.registry[elmID].keys.SK,
+              this.registry[elmID].offset!
+            );
+
             const isVisibleY = scroll.isElementVisibleViewportY(
               this.registry[elmID].currentTop!
             );
@@ -142,17 +147,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
               // Override the result.
               isVisible = true;
-
-              this.assignSiblingsBoundaries(
-                this.registry[elmID].keys.SK,
-                this.registry[elmID].offset!
-              );
             } else if (isVisible) {
-              this.assignSiblingsBoundaries(
-                this.registry[elmID].keys.SK,
-                this.registry[elmID].offset!
-              );
-
               if (this.elmIndicator.exceptionToNextElm) {
                 // In this case, we are moving from hidden to visible.
                 // Eg: 1, 2 are hidden the rest of the list is visible.

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -9,6 +9,7 @@ import type { CoreInstanceInterface, Rect } from "@dflex/core-instance";
 import type { ELmBranch } from "@dflex/dom-gen";
 import type { ElmInstance } from "@dflex/store";
 
+import type { ScrollInterface } from "../Plugins/Scroll";
 import type { ThresholdInterface } from "../Plugins/Threshold";
 import type { TrackerInterface } from "../Plugins/Tracker";
 
@@ -73,6 +74,8 @@ export interface DnDStoreInterface {
   tracker: TrackerInterface;
   siblingsBoundaries: { [siblingKey: string]: BoundariesOffset };
   siblingsOverflow: { [siblingKey: string]: Overflow };
+  siblingsScrollElement: { [siblingKey: string]: HTMLElement };
+  scroll: ScrollInterface | null;
   register(element: ElmInstance, x?: boolean): void;
   initScrollContainer(
     scrollThresholdPercentages: ThresholdInterface["thresholdPercentages"]

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -74,16 +74,12 @@ export interface DnDStoreInterface {
   tracker: TrackerInterface;
   siblingsBoundaries: { [siblingKey: string]: BoundariesOffset };
   siblingsOverflow: { [siblingKey: string]: Overflow };
-  siblingsScrollElement: { [siblingKey: string]: HTMLElement };
-  scroll: ScrollInterface | null;
+  siblingsScrollElement: { [siblingKey: string]: ScrollInterface };
   register(element: ElmInstance, x?: boolean): void;
-  initScrollContainer(
-    scrollThresholdPercentages: ThresholdInterface["thresholdPercentages"]
-  ): void;
   getELmOffsetById(id: string): Rect | undefined;
   getELmTranslateById(id: string): Translate;
   getElmTreeById(id: string): ElmTree;
   getElmSiblingsById(id: string): ELmBranch | null;
   getElmSiblingsListById(id: string): string[] | null;
-  destroy(): null;
+  destroy(): void;
 }

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -105,8 +105,8 @@ class Draggable
     const siblings = store.getElmSiblingsListById(this.draggedElm.id);
 
     if (
-      siblings === null
-      // || (!store.siblingsOverflow[SK].x && !store.siblingsOverflow[SK].y)
+      siblings === null ||
+      (!store.siblingsOverflow[SK].x && !store.siblingsOverflow[SK].y)
     ) {
       this.scroll.enable = false;
     }

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -147,7 +147,7 @@ class EndDroppable extends Droppable {
   }
 
   private verify(lst: string[]) {
-    const siblingsBoundaries =
+    const { top } =
       store.siblingsBoundaries[
         store.registry[this.draggable.draggedElm.id].keys.SK
       ];
@@ -156,16 +156,13 @@ class EndDroppable extends Droppable {
 
     if (id.length === 0 || this.draggable.draggedElm.id === id) {
       return (
-        Math.floor(siblingsBoundaries.top) ===
-        Math.floor(this.draggable.occupiedOffset.currentTop)
+        Math.floor(top) === Math.floor(this.draggable.occupiedOffset.currentTop)
       );
     }
 
     const element = store.registry[id];
 
-    return (
-      Math.floor(siblingsBoundaries.top) === Math.floor(element.currentTop!)
-    );
+    return Math.floor(top) === Math.floor(element.currentTop!);
   }
 
   endDragging() {

--- a/packages/dnd/src/Plugins/Scroll/types.ts
+++ b/packages/dnd/src/Plugins/Scroll/types.ts
@@ -7,16 +7,22 @@
 
 import type { ThresholdInterface } from "../Threshold";
 
+export interface ScrollInput {
+  scrollEventCallback: Function | null;
+}
+
 export interface ScrollInterface {
   threshold: ThresholdInterface | null;
   viewportHeight: number;
   viewportWidth: number;
-  resizeEventCallback: Function | null;
+  scrollEventCallback: Function | null;
   scrollX: number;
   scrollY: number;
   scrollHeight: number;
   scrollContainer: Element;
   hasThrottledFrame: number | null;
+  isElementVisibleViewportX(currentLeft: number): boolean;
+  isElementVisibleViewportY(currentTop: number): boolean;
   setThresholdMatrix(): void;
   setScrollContainer(): void;
   destroy(): void;

--- a/packages/dnd/src/Plugins/Scroll/types.ts
+++ b/packages/dnd/src/Plugins/Scroll/types.ts
@@ -23,7 +23,9 @@ export interface ScrollInterface {
   hasThrottledFrame: number | null;
   isElementVisibleViewportX(currentLeft: number): boolean;
   isElementVisibleViewportY(currentTop: number): boolean;
-  setThresholdMatrix(): void;
-  setScrollContainer(): void;
+  setThresholdMatrix(
+    threshold: ThresholdInterface["thresholdPercentages"]
+  ): void;
+  setScrollContainer(element: Element): void;
   destroy(): void;
 }

--- a/packages/dnd/src/utils/loopInDOM.ts
+++ b/packages/dnd/src/utils/loopInDOM.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Jalal Maskoun.
+ *
+ * This source code is licensed under the AGPL3.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+function loopInDOM(
+  fromElement: Element,
+  // eslint-disable-next-line no-unused-vars
+  cb: (arg: Element) => boolean
+) {
+  let current: Element | null = fromElement;
+
+  do {
+    if (cb(current)) {
+      return current;
+    }
+
+    current = current.parentNode as Element;
+  } while (current && !current.isSameNode(document.body));
+
+  return null;
+}
+
+export default loopInDOM;

--- a/packages/dnd/test/Store/__snapshots__/dndStore.test.ts.snap
+++ b/packages/dnd/test/Store/__snapshots__/dndStore.test.ts.snap
@@ -4,127 +4,79 @@ exports[`DnD Store Element is initiated 1`] = `
 Object {
   "id-1": CoreInstance {
     "animatedFrame": null,
-    "currentLeft": 450,
-    "currentTop": 114,
-    "hasToTransform": false,
     "id": "id-1",
     "isInitialized": true,
-    "isPaused": false,
-    "isVisible": true,
+    "isPaused": true,
+    "isVisible": false,
     "keys": Object {
       "CHK": null,
       "PK": "1-0",
       "SK": "0-0",
-    },
-    "offset": Object {
-      "height": 50,
-      "left": 450,
-      "top": 114,
-      "width": 170,
     },
     "order": Object {
       "parent": 0,
       "self": 0,
     },
-    "prevTranslateY": Array [],
     "ref": <div
       data-index="0"
     />,
-    "translateX": 0,
-    "translateY": 0,
   },
   "id-2": CoreInstance {
     "animatedFrame": null,
-    "currentLeft": 450,
-    "currentTop": 172,
-    "hasToTransform": false,
     "id": "id-2",
     "isInitialized": true,
-    "isPaused": false,
-    "isVisible": true,
+    "isPaused": true,
+    "isVisible": false,
     "keys": Object {
       "CHK": null,
       "PK": "1-0",
       "SK": "0-0",
-    },
-    "offset": Object {
-      "height": 50,
-      "left": 450,
-      "top": 172,
-      "width": 170,
     },
     "order": Object {
       "parent": 0,
       "self": 1,
     },
-    "prevTranslateY": Array [],
     "ref": <div
       data-index="1"
     />,
-    "translateX": 0,
-    "translateY": 0,
   },
   "id-3": CoreInstance {
     "animatedFrame": null,
-    "currentLeft": 450,
-    "currentTop": 230,
-    "hasToTransform": false,
     "id": "id-3",
     "isInitialized": true,
-    "isPaused": false,
-    "isVisible": true,
+    "isPaused": true,
+    "isVisible": false,
     "keys": Object {
       "CHK": null,
       "PK": "1-0",
       "SK": "0-0",
-    },
-    "offset": Object {
-      "height": 50,
-      "left": 450,
-      "top": 230,
-      "width": 170,
     },
     "order": Object {
       "parent": 0,
       "self": 2,
     },
-    "prevTranslateY": Array [],
     "ref": <div
       data-index="2"
     />,
-    "translateX": 0,
-    "translateY": 0,
   },
   "id-4": CoreInstance {
     "animatedFrame": null,
-    "currentLeft": 450,
-    "currentTop": 288,
-    "hasToTransform": false,
     "id": "id-4",
     "isInitialized": true,
-    "isPaused": false,
-    "isVisible": true,
+    "isPaused": true,
+    "isVisible": false,
     "keys": Object {
       "CHK": null,
       "PK": "1-0",
       "SK": "0-0",
     },
-    "offset": Object {
-      "height": 50,
-      "left": 450,
-      "top": 288,
-      "width": 170,
-    },
     "order": Object {
       "parent": 0,
       "self": 3,
     },
-    "prevTranslateY": Array [],
     "ref": <div
       data-index="3"
     />,
-    "translateX": 0,
-    "translateY": 0,
   },
 }
 `;
@@ -142,34 +94,22 @@ Object {
   },
   "element": CoreInstance {
     "animatedFrame": null,
-    "currentLeft": 450,
-    "currentTop": 114,
-    "hasToTransform": false,
     "id": "id-1",
     "isInitialized": true,
-    "isPaused": false,
-    "isVisible": true,
+    "isPaused": true,
+    "isVisible": false,
     "keys": Object {
       "CHK": null,
       "PK": "1-0",
       "SK": "0-0",
     },
-    "offset": Object {
-      "height": 50,
-      "left": 450,
-      "top": 114,
-      "width": 170,
-    },
     "order": Object {
       "parent": 0,
       "self": 0,
     },
-    "prevTranslateY": Array [],
     "ref": <div
       data-index="0"
     />,
-    "translateX": 0,
-    "translateY": 0,
   },
   "parent": null,
 }

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -4,6 +4,6 @@
  * This source code is licensed under the AGPL3.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-export type { ElmInstance } from "./types";
+export type { ElmInstance, ElmInstanceWithProps } from "./types";
 
 export { default } from "./Store";


### PR DESCRIPTION
- [x] Refactor `register` to soft register. Remove the old burden, reduce the initial scripting time. All elements now are paused by default and can be not initialized if there's no `ref` passed.  The earlier version threw an error then it was optional. 
- [x] Change `Scroll` workflow. Every group of siblings has its own scroll instance. Allowing to change lists with scroll container. 