### PR TITLE
Fix self contained restrictions bug caused by calculating the wrong boundaries

### DIFF
--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -166,7 +166,7 @@ class CoreInstance
     siblingsEmptyElmIndex = -1
   ) {
     if (newIndex < 0 || newIndex > branchIDsOrder.length - 1) {
-      if (process.env.NODE_ENV === "development") {
+      if (process.env.NODE_ENV !== "production") {
         // eslint-disable-next-line no-console
         console.error(
           `Illegal Attempt: Received an index:${newIndex} on siblings list:${
@@ -180,7 +180,7 @@ class CoreInstance
 
     if (oldIndex > -1) {
       if (siblingsEmptyElmIndex >= 0 && siblingsEmptyElmIndex !== newIndex) {
-        if (process.env.NODE_ENV === "development") {
+        if (process.env.NODE_ENV !== "production") {
           // eslint-disable-next-line no-console
           console.error(
             "Illegal Attempt: More than one element have left the siblings list"
@@ -192,7 +192,7 @@ class CoreInstance
 
       branchIDsOrder[oldIndex] = "";
     } else if (branchIDsOrder[newIndex].length > 0) {
-      if (process.env.NODE_ENV === "development") {
+      if (process.env.NODE_ENV !== "production") {
         // eslint-disable-next-line no-console
         console.error("Illegal Attempt: Colliding in positions");
       }

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -166,7 +166,7 @@ class CoreInstance
     siblingsEmptyElmIndex = -1
   ) {
     if (newIndex < 0 || newIndex > branchIDsOrder.length - 1) {
-      if (process.env.NODE_ENV !== "production") {
+      if (process.env.NODE_ENV === "development") {
         // eslint-disable-next-line no-console
         console.error(
           `Illegal Attempt: Received an index:${newIndex} on siblings list:${
@@ -180,7 +180,7 @@ class CoreInstance
 
     if (oldIndex > -1) {
       if (siblingsEmptyElmIndex >= 0 && siblingsEmptyElmIndex !== newIndex) {
-        if (process.env.NODE_ENV !== "production") {
+        if (process.env.NODE_ENV === "development") {
           // eslint-disable-next-line no-console
           console.error(
             "Illegal Attempt: More than one element have left the siblings list"
@@ -192,7 +192,7 @@ class CoreInstance
 
       branchIDsOrder[oldIndex] = "";
     } else if (branchIDsOrder[newIndex].length > 0) {
-      if (process.env.NODE_ENV !== "production") {
+      if (process.env.NODE_ENV === "development") {
         // eslint-disable-next-line no-console
         console.error("Illegal Attempt: Colliding in positions");
       }

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -72,7 +72,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     const scroll = this.siblingsScrollElement[requiredBranchKey];
 
     if (!scroll || !requiredBranch) {
-      if (process.env.NODE_ENV === "development") {
+      if (process.env.NODE_ENV !== "production") {
         // eslint-disable-next-line no-console
         console.error(`Scroll and/or Sibling branch is not found`);
       }

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -67,7 +67,6 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     requiredBranchKey: string,
     allowDynamicVisibility: boolean
   ) {
-    console.log("file: DnDStoreImp.ts ~ line 70 ~ updateBranchVisibility");
     const requiredBranch = this.DOMGen.branches[requiredBranchKey];
 
     const scroll = this.siblingsScrollElement[requiredBranchKey];
@@ -106,11 +105,6 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
         if (allowDynamicVisibility) {
           isVisibleY = scroll.isElementVisibleViewportY(
             this.registry[elmID].currentTop!
-          );
-          console.log(
-            "file: DnDStoreImp.ts ~ line 109 ~ isVisibleY",
-            isVisibleY,
-            elmID
           );
 
           isVisibleX = scroll.isElementVisibleViewportX(

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -106,6 +106,11 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
           isVisibleY = scroll.isElementVisibleViewportY(
             this.registry[elmID].currentTop!
           );
+          console.log(
+            "file: DnDStoreImp.ts ~ line 109 ~ isVisibleY",
+            isVisibleY,
+            elmID
+          );
 
           isVisibleX = scroll.isElementVisibleViewportX(
             this.registry[elmID].currentLeft!
@@ -152,7 +157,9 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       !this.registry[firstElemID].isPaused &&
       this.siblingsScrollElement[key]
     ) {
-      // Avoid multiple calls that runs function multiple times.
+      // Avoid multiple calls that runs function multiple times. This happens
+      // when there's a delay in firing load event and clicking on the element.
+      // It's fine.
       return;
     }
 

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -67,6 +67,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     requiredBranchKey: string,
     allowDynamicVisibility: boolean
   ) {
+    console.log("file: DnDStoreImp.ts ~ line 70 ~ updateBranchVisibility");
     const requiredBranch = this.DOMGen.branches[requiredBranchKey];
 
     const scroll = this.siblingsScrollElement[requiredBranchKey];

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -108,6 +108,11 @@ class Draggable
 
     const { hasOverflowX, hasOverflowY } = store.siblingsScrollElement[SK];
 
+    console.log(
+      "file: Draggable.ts ~ line 110 ~ store.siblingsScrollElement[SK];",
+      store.siblingsScrollElement[SK]
+    );
+
     const siblings = store.getElmSiblingsListById(this.draggedElm.id);
 
     this.isViewportRestricted = true;
@@ -135,6 +140,10 @@ class Draggable
       // Override the default options. (FYI, this is the only privilege I have.)
       this.scroll.enable = false;
     }
+    console.log(
+      "file: Draggable.ts ~ line 137 ~  this.scroll.enable",
+      this.scroll.enable
+    );
 
     if (this.scroll.enable) {
       this.isViewportRestricted = false;
@@ -419,11 +428,29 @@ class Draggable
     } else if (this.isViewportRestricted) {
       const { SK } = store.registry[this.draggedElm.id].keys;
 
-      const { height, width } = store.siblingsScrollElement[SK].scrollRect;
+      const {
+        scrollX,
+        scrollY,
+        scrollRect: { height, width, left, top },
+      } = store.siblingsScrollElement[SK];
 
-      // TODO: Fix this when scroll is implemented.
-      filteredX = this.axesXFilter(x, 0, width, false, false, true);
-      filteredY = this.axesYFilter(y, 0, height, false, false, true);
+      // TODO: Test the fix this when scroll is implemented.
+      filteredX = this.axesXFilter(
+        x,
+        0,
+        left + width + scrollX,
+        false,
+        false,
+        true
+      );
+      filteredY = this.axesYFilter(
+        y,
+        0,
+        top + height + scrollY,
+        false,
+        false,
+        true
+      );
     }
 
     this.translate(filteredX, filteredY);

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -104,14 +104,10 @@ class Draggable
      */
     this.tempIndex = order.self;
 
-    this.scroll = opts.scroll;
+    // This tiny bug caused an override  options despite it's actually freezed!
+    this.scroll = { ...opts.scroll };
 
     const { hasOverflowX, hasOverflowY } = store.siblingsScrollElement[SK];
-
-    console.log(
-      "file: Draggable.ts ~ line 110 ~ store.siblingsScrollElement[SK];",
-      store.siblingsScrollElement[SK]
-    );
 
     const siblings = store.getElmSiblingsListById(this.draggedElm.id);
 
@@ -140,10 +136,6 @@ class Draggable
       // Override the default options. (FYI, this is the only privilege I have.)
       this.scroll.enable = false;
     }
-    console.log(
-      "file: Draggable.ts ~ line 137 ~  this.scroll.enable",
-      this.scroll.enable
-    );
 
     if (this.scroll.enable) {
       this.isViewportRestricted = false;
@@ -384,9 +376,9 @@ class Draggable
     let filteredY = y;
     let filteredX = x;
 
-    if (this.axesFilterNeeded) {
-      const { SK } = store.registry[this.draggedElm.id].keys;
+    const { SK } = store.registry[this.draggedElm.id].keys;
 
+    if (this.axesFilterNeeded) {
       const { top, bottom, maxLeft, minRight } = store.siblingsBoundaries[SK];
 
       if (this.restrictionsStatus.isContainerRestricted) {
@@ -426,19 +418,11 @@ class Draggable
         );
       }
     } else if (this.isViewportRestricted) {
-      const { SK } = store.registry[this.draggedElm.id].keys;
-
-      const {
-        scrollX,
-        scrollY,
-        scrollRect: { height, width, left, top },
-      } = store.siblingsScrollElement[SK];
-
       // TODO: Test the fix this when scroll is implemented.
       filteredX = this.axesXFilter(
         x,
         0,
-        left + width + scrollX,
+        store.siblingsScrollElement[SK].getMaximumScrollContainerLeft(),
         false,
         false,
         true
@@ -446,7 +430,7 @@ class Draggable
       filteredY = this.axesYFilter(
         y,
         0,
-        top + height + scrollY,
+        store.siblingsScrollElement[SK].getMaximumScrollContainerTop(),
         false,
         false,
         true

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -91,7 +91,7 @@ class Draggable
      * all the branch is updated.
      */
     if (!store.siblingsScrollElement[SK]) {
-      store.loadElementsFormKeyBranch(SK);
+      store.initSiblingsScrollAndVisibility(SK);
     }
 
     super(element, initCoordinates);

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -233,7 +233,7 @@ class Scroll implements ScrollInterface {
     const { left, width } = this.scrollRect;
 
     return (
-      currentLeft >= this.scrollX && currentLeft <= left + width - this.scrollX
+      currentLeft >= this.scrollX && currentLeft <= left + width + this.scrollX
     );
   }
 
@@ -241,7 +241,7 @@ class Scroll implements ScrollInterface {
     const { top, height } = this.scrollRect;
 
     return (
-      currentTop >= this.scrollY && currentTop <= top + height - this.scrollY
+      currentTop >= this.scrollY && currentTop <= top + height + this.scrollY
     );
   }
 

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -255,7 +255,7 @@ class Scroll implements ScrollInterface {
       const isUpdated = this[setter]();
 
       if (isUpdated && cb) {
-        cb(this.siblingKey);
+        cb(this.siblingKey, true);
       }
       this.hasThrottledFrame = null;
     });

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -230,16 +230,18 @@ class Scroll implements ScrollInterface {
   }
 
   isElementVisibleViewportX(currentLeft: number): boolean {
+    const { left, width } = this.scrollRect;
+
     return (
-      currentLeft >= this.scrollX &&
-      currentLeft <= this.scrollRect.width + this.scrollX
+      currentLeft >= this.scrollX && currentLeft <= left + width - this.scrollX
     );
   }
 
   isElementVisibleViewportY(currentTop: number): boolean {
+    const { top, height } = this.scrollRect;
+
     return (
-      currentTop >= this.scrollY &&
-      currentTop <= this.scrollRect.height + this.scrollY
+      currentTop >= this.scrollY && currentTop <= top + height - this.scrollY
     );
   }
 

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -229,25 +229,35 @@ class Scroll implements ScrollInterface {
     return isUpdated;
   }
 
-  isElementVisibleViewportX(currentLeft: number): boolean {
+  getMaximumScrollContainerLeft() {
     const { left, width } = this.scrollRect;
 
+    return left + width + this.scrollX;
+  }
+
+  getMaximumScrollContainerTop() {
+    const { top, height } = this.scrollRect;
+
+    return top + height + this.scrollY;
+  }
+
+  isElementVisibleViewportX(currentLeft: number): boolean {
     return (
-      currentLeft >= this.scrollX && currentLeft <= left + width + this.scrollX
+      currentLeft >= this.scrollX &&
+      currentLeft <= this.getMaximumScrollContainerLeft()
     );
   }
 
   isElementVisibleViewportY(currentTop: number): boolean {
-    const { top, height } = this.scrollRect;
-
     return (
-      currentTop >= this.scrollY && currentTop <= top + height + this.scrollY
+      currentTop >= this.scrollY &&
+      currentTop <= this.getMaximumScrollContainerTop()
     );
   }
 
   private animatedListener(
     setter: "setScrollRect" | "setScrollCoordinates",
-    cb: Function | null
+    cb: Function | null // Can we improve the type here. This going to be a bug in the future.
   ) {
     if (this.hasThrottledFrame !== null) return;
 

--- a/packages/dnd/src/Plugins/Scroll/types.ts
+++ b/packages/dnd/src/Plugins/Scroll/types.ts
@@ -26,6 +26,8 @@ export interface ScrollInterface {
   hasDocumentAsContainer: boolean;
   scrollEventCallback: Function | null;
   hasThrottledFrame: number | null;
+  getMaximumScrollContainerLeft(): number;
+  getMaximumScrollContainerTop(): number;
   isElementVisibleViewportX(currentLeft: number): boolean;
   isElementVisibleViewportY(currentTop: number): boolean;
   setThresholdMatrix(

--- a/packages/dnd/src/utils/extractOpts.ts
+++ b/packages/dnd/src/utils/extractOpts.ts
@@ -54,13 +54,14 @@ export function extractOpts(opts: DndOpts) {
       };
     }
 
-    if (!options[props]) {
+    if (options[props] === undefined) {
       options[props] = { ...defaultOpts[props] };
 
       return;
     }
 
     Object.keys(defaultOpts[props]).forEach((subProp) => {
+      // for sub options with objects values, like restrictions.
       if (typeof defaultOpts[props][subProp] === "object") {
         if (options[props][subProp] !== undefined) {
           options[props][subProp] = {


### PR DESCRIPTION
- [x] Refactor loading and initiating siblings branch fixing a minor bug prevented initializing a solo element with no siblings.
- [x] Fix `isElementVisibleViewportY/X` depending on the `Scroll` container adding new methods to know the container boundaries.
- [x] Fix minor bug in calling back function triggered by the scroll event. 
- [x] Fix minor bug in override options