### PR TITLE
Add clear methods to `DOM-Gen`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "lerna": "^4.0.0",
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
-    "typescript": "^4.1.3"
+    "typescript": "^4.4.2"
   }
 }

--- a/packages/dnd/playgrounds/dflex-react-dnd/package.json
+++ b/packages/dnd/playgrounds/dflex-react-dnd/package.json
@@ -8,8 +8,8 @@
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "@types/react-router-dom": "^5.1.7",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3"
   },

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -341,6 +341,16 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     };
   }
 
+  private clearBranchesScroll() {
+    Object.keys(this.DOMGen.branches).forEach((key) => {
+      if (this.siblingsScrollElement[key]) {
+        this.siblingsScrollElement[key].destroy();
+      }
+    });
+
+    this.siblingsScrollElement = {};
+  }
+
   dispose() {
     if (!this.isInitialized) return null;
 
@@ -353,6 +363,8 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
   destroy() {
     this.dispose();
+
+    this.clearBranchesScroll();
 
     // Destroys all registered instances.
     super.destroy();

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -145,7 +145,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     const hasSiblings = Array.isArray(this.DOMGen.branches[key]);
 
     const firstElemID = hasSiblings
-      ? this.DOMGen.branches[key][0]
+      ? this.DOMGen.branches[key]![0]
       : (this.DOMGen.branches[key] as string);
 
     if (
@@ -327,7 +327,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     let parent = null;
     if (parents !== undefined) {
       const parentsID = Array.isArray(parents) ? parents[pi] : parents;
-      parent = this.registry[parentsID];
+      parent = this.registry[parentsID as string];
     }
 
     return {
@@ -349,6 +349,17 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     });
 
     this.siblingsScrollElement = {};
+  }
+
+  unregister(id: string) {
+    const {
+      keys: { SK },
+      order: { self },
+    } = this.registry[id];
+
+    this.DOMGen.removeElementIDFromBranch(SK, self);
+
+    super.unregister(id);
   }
 
   dispose() {

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -30,7 +30,7 @@ class EndDroppable extends Droppable {
    * @param i -
    */
   private undoElmTranslate(
-    lst: ELmBranch,
+    lst: Exclude<ELmBranch, null>,
     i: number,
     prevVisibility: boolean,
     listVisibility: boolean

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -9,7 +9,7 @@ import loopInDOM from "../../utils/loopInDOM";
 import Threshold from "../Threshold";
 import { ThresholdPercentages } from "../Threshold/types";
 
-import { ScrollInterface } from "./types";
+import { ScrollInput, ScrollInterface } from "./types";
 
 function getScrollFromDocument() {
   return document.scrollingElement || document.documentElement;
@@ -49,7 +49,7 @@ class Scroll implements ScrollInterface {
 
   offsetWidth?: number;
 
-  scrollEventCallback: Function | null;
+  scrollEventCallback: ScrollInterface["scrollEventCallback"];
 
   scrollX!: number;
 
@@ -77,11 +77,7 @@ class Scroll implements ScrollInterface {
     element,
     requiredBranchKey,
     scrollEventCallback,
-  }: {
-    element: Element;
-    requiredBranchKey: string;
-    scrollEventCallback: Function | null;
-  }) {
+  }: ScrollInput) {
     this.threshold = null;
     this.hasThrottledFrame = null;
 
@@ -257,7 +253,7 @@ class Scroll implements ScrollInterface {
 
   private animatedListener(
     setter: "setScrollRect" | "setScrollCoordinates",
-    cb: Function | null // Can we improve the type here. This going to be a bug in the future.
+    cb: ScrollInput["scrollEventCallback"]
   ) {
     if (this.hasThrottledFrame !== null) return;
 

--- a/packages/dnd/src/Plugins/Scroll/types.ts
+++ b/packages/dnd/src/Plugins/Scroll/types.ts
@@ -9,7 +9,11 @@ import { Rect } from "packages/core-instance/src/types";
 import type { ThresholdInterface } from "../Threshold";
 
 export interface ScrollInput {
-  scrollEventCallback: Function | null;
+  element: Element;
+  requiredBranchKey: string;
+  scrollEventCallback:
+    | ((SK: string, isCalledFromScroll: true) => unknown)
+    | null;
 }
 
 export interface ScrollInterface {
@@ -24,7 +28,7 @@ export interface ScrollInterface {
   allowDynamicVisibility: boolean;
   scrollContainer: Element;
   hasDocumentAsContainer: boolean;
-  scrollEventCallback: Function | null;
+  scrollEventCallback: ScrollInput["scrollEventCallback"];
   hasThrottledFrame: number | null;
   getMaximumScrollContainerLeft(): number;
   getMaximumScrollContainerTop(): number;

--- a/packages/dom-gen/src/Generator.ts
+++ b/packages/dom-gen/src/Generator.ts
@@ -100,7 +100,7 @@ class Generator implements GeneratorInterface {
     /**
      * Don't create array for only one child.
      */
-    if (this.branches[SK] === undefined) {
+    if (!this.branches[SK]) {
       this.branches[SK] = id;
     } else {
       /**
@@ -129,16 +129,6 @@ class Generator implements GeneratorInterface {
    */
   getElmBranch(SK: string): ELmBranch {
     return this.branches[SK];
-  }
-
-  /**
-   * Sets new branch for given key.
-   *
-   * @param  sk - Siblings Key- sibling key
-   * @param branch - new branch
-   */
-  setElmBranch(SK: string, branch: ELmBranch) {
-    this.branches[SK] = branch;
   }
 
   /**
@@ -204,6 +194,12 @@ class Generator implements GeneratorInterface {
     ) {
       [deletedElmID] = (this.branches[SK] as []).splice(index, 1);
 
+      // When it has only one child, use string instead of array.
+      if (this.branches[SK]!.length === 1) {
+        const elm = this.branches[SK]![0];
+        this.branches[SK] = elm;
+      }
+
       return deletedElmID;
     }
 
@@ -220,16 +216,18 @@ class Generator implements GeneratorInterface {
 
   // eslint-disable-next-line no-unused-vars
   destroyBranch(SK: string, cb: (elmID: string) => unknown) {
-    if (Array.isArray(this.branches[SK]) && this.branches[SK]!.length > 0) {
+    if (Array.isArray(this.branches[SK])) {
       const elmID = (this.branches[SK] as string[]).pop();
 
-      if (elmID !== null) {
-        cb(elmID as string);
+      cb(elmID as string);
 
+      if (this.branches[SK]!.length > 0) {
         this.destroyBranch(SK, cb);
-      }
+      } else {
+        this.branches[SK] = null;
 
-      return;
+        return;
+      }
     }
 
     if (this.branches[SK] !== undefined) {

--- a/packages/dom-gen/src/Generator.ts
+++ b/packages/dom-gen/src/Generator.ts
@@ -83,15 +83,6 @@ class Generator {
   }
 
   /**
-   *  Checks if element has no siblings in the branch
-   *
-   * @param  sk - Siblings Key- siblings key
-   */
-  private isElmSingleton(SK: string) {
-    return this.branches[SK].constructor !== Array;
-  }
-
-  /**
    * Adds elements to its siblings.
    *
    * @param id - element id
@@ -109,11 +100,12 @@ class Generator {
       /**
        * So here we have multiple children, we better create an array now.
        */
-      if (this.isElmSingleton(SK)) {
+      if (!Array.isArray(this.branches[SK])) {
         const prevId = this.branches[SK];
 
         this.branches[SK] = [];
-        // @ts-ignore
+
+        // @ts-expect-error
         this.branches[SK].push(prevId);
       }
 

--- a/packages/dom-gen/src/Generator.ts
+++ b/packages/dom-gen/src/Generator.ts
@@ -122,52 +122,6 @@ class Generator implements GeneratorInterface {
     return selfIndex;
   }
 
-  removeElementIDFromBranch(SK: string, index: number) {
-    let deletedElmID: string;
-
-    if (
-      Array.isArray(this.branches[SK]) &&
-      this.branches[SK]![index] !== undefined
-    ) {
-      [deletedElmID] = (this.branches[SK] as []).splice(index, 1);
-
-      return deletedElmID;
-    }
-
-    if (this.branches[SK] !== undefined) {
-      deletedElmID = this.branches[SK] as string;
-
-      this.branches[SK] = null;
-
-      return deletedElmID;
-    }
-
-    return null;
-  }
-
-  // eslint-disable-next-line no-unused-vars
-  destroyBranch(SK: string, cb: (elmID: string) => unknown) {
-    if (Array.isArray(this.branches[SK]) && this.branches[SK]!.length > 0) {
-      const elmID = (this.branches[SK] as string[]).pop();
-
-      if (elmID !== null) {
-        cb(elmID as string);
-
-        this.destroyBranch(SK, cb);
-      }
-
-      return;
-    }
-
-    if (this.branches[SK] !== undefined) {
-      const elmID = this.branches[SK] as string;
-
-      this.branches[SK] = null;
-
-      cb(elmID);
-    }
-  }
-
   /**
    * Gets all element IDs Siblings in given node represented by sk.
    *
@@ -239,6 +193,52 @@ class Generator implements GeneratorInterface {
     };
 
     return { order, keys };
+  }
+
+  removeElementIDFromBranch(SK: string, index: number) {
+    let deletedElmID: string;
+
+    if (
+      Array.isArray(this.branches[SK]) &&
+      this.branches[SK]![index] !== undefined
+    ) {
+      [deletedElmID] = (this.branches[SK] as []).splice(index, 1);
+
+      return deletedElmID;
+    }
+
+    if (this.branches[SK] !== undefined) {
+      deletedElmID = this.branches[SK] as string;
+
+      this.branches[SK] = null;
+
+      return deletedElmID;
+    }
+
+    return null;
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  destroyBranch(SK: string, cb: (elmID: string) => unknown) {
+    if (Array.isArray(this.branches[SK]) && this.branches[SK]!.length > 0) {
+      const elmID = (this.branches[SK] as string[]).pop();
+
+      if (elmID !== null) {
+        cb(elmID as string);
+
+        this.destroyBranch(SK, cb);
+      }
+
+      return;
+    }
+
+    if (this.branches[SK] !== undefined) {
+      const elmID = this.branches[SK] as string;
+
+      this.branches[SK] = null;
+
+      cb(elmID);
+    }
   }
 
   clearBranchesAndIndicator() {

--- a/packages/dom-gen/src/types.ts
+++ b/packages/dom-gen/src/types.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the AGPL3.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-export type ELmBranch = string | string[];
+export type ELmBranch = string | Array<string> | null;
 
 /**
  * Element unique keys in DOM tree.
@@ -29,4 +29,16 @@ export interface Order {
 export interface Pointer {
   keys: Keys;
   order: Order;
+}
+
+export interface GeneratorInterface {
+  branches: {
+    [keys: string]: ELmBranch;
+  };
+  setElmBranch(SK: string, branch: ELmBranch): void;
+  getElmBranch(SK: string): ELmBranch;
+  getElmPointer(id: string, depth: number): Pointer;
+  removeElementIDFromBranch(SK: string, index: number): string | null;
+  destroyBranch(SK: string, cb: (elmID: string) => unknown): void;
+  clearBranchesAndIndicator(): void;
 }

--- a/packages/dom-gen/src/types.ts
+++ b/packages/dom-gen/src/types.ts
@@ -35,7 +35,6 @@ export interface GeneratorInterface {
   branches: {
     [keys: string]: ELmBranch;
   };
-  setElmBranch(SK: string, branch: ELmBranch): void;
   getElmBranch(SK: string): ELmBranch;
   getElmPointer(id: string, depth: number): Pointer;
   removeElementIDFromBranch(SK: string, index: number): string | null;

--- a/packages/dom-gen/test/delete.test.ts
+++ b/packages/dom-gen/test/delete.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Jalal Maskoun.
+ *
+ * This source code is licensed under the AGPL3.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Generator from "../src";
+
+const domGen = new Generator();
+
+let pointerChild0D0;
+let pointerChild1D0;
+
+const KEYS_CHILDREN_D0 = {
+  CHK: null,
+  PK: "1-0",
+  SK: "0-0",
+};
+
+describe("Testing clear methods", () => {
+  it("Adds two siblings to empty branch", () => {
+    // DOM-root
+    // │
+    // │───id-0  => (order:{parent: 0, self: 0 }) || (keys: {CHK: null,PK: "1-0",SK: "0-0"})
+    // │
+    // │───id-1  => (order:{parent: 0, self: 1 }) || (keys: {CHK: null,PK: "1-0",SK: "0-0"})
+
+    pointerChild0D0 = domGen.getElmPointer("id-0", 0);
+    pointerChild1D0 = domGen.getElmPointer("id-1", 0);
+
+    expect(pointerChild0D0).toStrictEqual({
+      keys: KEYS_CHILDREN_D0,
+      order: {
+        parent: 0,
+        self: 0,
+      },
+    });
+
+    expect(pointerChild1D0).toStrictEqual({
+      keys: KEYS_CHILDREN_D0,
+      order: {
+        parent: 0,
+        self: 1,
+      },
+    });
+
+    const branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
+
+    expect(branch).toStrictEqual(["id-0", "id-1"]);
+  });
+
+  it("Remove the first siblings", () => {
+    const elmID = domGen.removeElementIDFromBranch(KEYS_CHILDREN_D0.SK, 0);
+
+    expect(elmID).toBe("id-0");
+
+    const branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
+
+    expect(branch).toStrictEqual("id-1");
+  });
+
+  it("Add new element after deleting the old one to check indicators working correctly", () => {
+    pointerChild0D0 = domGen.getElmPointer("id-0", 0);
+
+    expect(pointerChild0D0).toStrictEqual({
+      keys: KEYS_CHILDREN_D0,
+      order: {
+        parent: 0,
+        self: 1,
+      },
+    });
+
+    const branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
+
+    expect(branch).toStrictEqual(["id-1", "id-0"]);
+  });
+
+  it("Destroy branch", () => {
+    domGen.destroyBranch(KEYS_CHILDREN_D0.SK, () => {});
+
+    const branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
+
+    expect(branch).toBeNull();
+  });
+
+  it("Adds two siblings again", () => {
+    // DOM-root
+    // │
+    // │───id-0  => (order:{parent: 0, self: 0 }) || (keys: {CHK: null,PK: "1-0",SK: "0-0"})
+    // │
+    // │───id-1  => (order:{parent: 0, self: 1 }) || (keys: {CHK: null,PK: "1-0",SK: "0-0"})
+
+    pointerChild0D0 = domGen.getElmPointer("id-0", 0);
+    pointerChild1D0 = domGen.getElmPointer("id-1", 0);
+
+    expect(pointerChild0D0).toStrictEqual({
+      keys: KEYS_CHILDREN_D0,
+      order: {
+        parent: 0,
+        self: 0,
+      },
+    });
+
+    expect(pointerChild1D0).toStrictEqual({
+      keys: KEYS_CHILDREN_D0,
+      order: {
+        parent: 0,
+        self: 1,
+      },
+    });
+
+    const branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
+
+    expect(branch).toStrictEqual(["id-0", "id-1"]);
+  });
+});

--- a/packages/dom-gen/test/gen.asc.test.ts
+++ b/packages/dom-gen/test/gen.asc.test.ts
@@ -210,20 +210,5 @@ describe("DOM Relationship Generator: Ascending-Simple", () => {
         "0-1": "id-00",
       });
     });
-
-    it("Updates branches correctly", () => {
-      const newBranch = ["id-2", "id-1", "id-0"];
-
-      domGen.setElmBranch("0-0", newBranch);
-
-      const { branches } = domGen;
-
-      expect(branches).toStrictEqual({
-        "0-0": newBranch,
-        "1-0": "id-parent-1",
-        "2-0": "id-grand-parent-1",
-        "0-1": "id-00",
-      });
-    });
   });
 });

--- a/packages/draggable/playgrounds/dflex-react-draggable/package.json
+++ b/packages/draggable/playgrounds/dflex-react-draggable/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "dependencies": {
     "@folo/utils": "^0.1.3",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3"
   },

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -57,28 +57,19 @@ class Store<T = ElmWithPointerWithProps> implements StoreInterface<T> {
   }
 
   destroyBranch(branchKey: string) {
-    if (this.DOMGen.branches[branchKey].length === 0) return;
-
-    const elmID = (this.DOMGen.branches[branchKey] as string[]).pop();
-
-    this.unregister(elmID!);
-
-    this.destroyBranch(branchKey);
+    this.DOMGen.destroyBranch(branchKey, (id) => {
+      this.unregister(id);
+    });
   }
 
   destroy() {
     Object.keys(this.DOMGen.branches).forEach((branchKey) => {
-      // Ignore non array branches.
-      if (Array.isArray(this.DOMGen.branches[branchKey])) {
-        this.destroyBranch(branchKey);
-      } else {
-        this.unregister(this.DOMGen.branches[branchKey] as string);
-      }
+      this.DOMGen.destroyBranch(branchKey, (id) => {
+        delete this.registry[id];
+      });
     });
 
-    // TODO: Add reset method to DOM Gen.
-    this.DOMGen.branches = {};
-    this.DOMGen.indicator = {};
+    this.DOMGen.clearBranchesAndIndicator();
   }
 
   /**

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -13,7 +13,7 @@ import type {
   StoreInterface,
 } from "./types";
 
-class Store<T extends ElmWithPointerWithProps> implements StoreInterface<T> {
+class Store<T = ElmWithPointerWithProps> implements StoreInterface<T> {
   registry: {
     [id: string]: T;
   };
@@ -53,19 +53,12 @@ class Store<T extends ElmWithPointerWithProps> implements StoreInterface<T> {
   }
 
   unregister(id: string) {
-    const {
-      keys: { SK },
-      order: { self },
-    } = this.registry[id];
-
-    this.DOMGen.removeElementIDFromBranch(SK, self);
-
     delete this.registry[id];
   }
 
   destroyBranch(branchKey: string) {
     this.DOMGen.destroyBranch(branchKey, (id) => {
-      delete this.registry[id];
+      this.unregister(id);
     });
   }
 

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -65,7 +65,7 @@ class Store<T extends ElmWithPointerWithProps> implements StoreInterface<T> {
 
   destroyBranch(branchKey: string) {
     this.DOMGen.destroyBranch(branchKey, (id) => {
-      this.unregister(id);
+      delete this.registry[id];
     });
   }
 

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -13,7 +13,7 @@ import type {
   StoreInterface,
 } from "./types";
 
-class Store<T = ElmWithPointerWithProps> implements StoreInterface<T> {
+class Store<T extends ElmWithPointerWithProps> implements StoreInterface<T> {
   registry: {
     [id: string]: T;
   };
@@ -53,6 +53,13 @@ class Store<T = ElmWithPointerWithProps> implements StoreInterface<T> {
   }
 
   unregister(id: string) {
+    const {
+      keys: { SK },
+      order: { self },
+    } = this.registry[id];
+
+    this.DOMGen.removeElementIDFromBranch(SK, self);
+
     delete this.registry[id];
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13797,7 +13797,7 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-dom@17.0.2, react-dom@^17.0.1:
+react-dom@17.0.2, react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -13921,7 +13921,7 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react@17.0.2, react@^17.0.1:
+react@17.0.2, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -16031,7 +16031,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3:
+typescript@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
   integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==


### PR DESCRIPTION
- [x] Clear Scroll instance from Store with `clearBranchesScroll` to prevent a memory leak.
- [x] Upgrade to Typescript 4.4.
- [x] Remove unnecessary `isElmSingleton` from DOM Gen.
- [x] Add clear methods: `removeElementIDFromBranch`, `destroyBranch`, `clearBranchesAndIndicator`  to DOM Gen.
- [x] Remove `setElmBranch` as it has not a clear role otherwise a direct assignment.
- [x] Remove element from the branch when `unregister` it from the store. This fixes a bug that causes branches to preserve elements even f they are deleted from the registry.
- [x] Add strict type to `scrollEventCallback`.
- [x]  Add Unit Test to the new methods.