### PR TITLE
Next release 2

### DIFF
--- a/packages/dnd/src/DnD.ts
+++ b/packages/dnd/src/DnD.ts
@@ -9,6 +9,7 @@ import type { Coordinates } from "@dflex/draggable";
 
 import Draggable from "./Draggable";
 import Droppable from "./Droppable";
+import store from "./DnDStore";
 
 import type { DndOpts, FinalDndOpts } from "./types";
 import { extractOpts, defaultOpts } from "./utils/extractOpts";
@@ -25,7 +26,25 @@ class DnD extends Droppable {
     initCoordinates: Coordinates,
     opts: DndOpts = defaultOpts
   ) {
+    if (!store.registry[id]) {
+      throw new Error(`DFlex: ${id} is not registered in the Store.`);
+    }
+
     const options = extractOpts(opts);
+
+    const { SK } = store.registry[id].keys;
+
+    if (!SK) {
+      throw new Error(`DFlex: unable to find element list key in the Store.`);
+    }
+
+    /**
+     * In case it is not already initiated in the store. We do it here guarantee
+     * all the branch is updated.
+     */
+    if (!store.siblingsScrollElement[SK]) {
+      store.initSiblingsScrollAndVisibility(SK);
+    }
 
     const draggable = new Draggable(
       id,

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -84,16 +84,6 @@ class Draggable
   constructor(id: string, initCoordinates: Coordinates, opts: FinalDndOpts) {
     const { element, parent } = store.getElmTreeById(id);
 
-    const { SK } = store.registry[id].keys;
-
-    /**
-     * In case it is not already initiated in the store. We do it here guarantee
-     * all the branch is updated.
-     */
-    if (!store.siblingsScrollElement[SK]) {
-      store.initSiblingsScrollAndVisibility(SK);
-    }
-
     super(element, initCoordinates);
 
     const { order } = element;
@@ -106,6 +96,8 @@ class Draggable
 
     // This tiny bug caused an override  options despite it's actually freezed!
     this.scroll = { ...opts.scroll };
+
+    const { SK } = store.registry[id].keys;
 
     const { hasOverflowX, hasOverflowY } = store.siblingsScrollElement[SK];
 


### PR DESCRIPTION
- [ ] Define new errors when `id` is not registered or can't find siblings key (`SK`).
- [ ] Add scroll and visibility initializing inside the `Store` instead of `Draggable`.