### PR TITLE
Avoid a bug where there's an overflow in CSS but the container doesn't actually have a scroll

### DIFF
--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -183,11 +183,11 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     });
   }
 
-  private assignSiblingsBoundaries(siblingsK: string, elemOffset: Rect) {
+  private assignSiblingsBoundaries(SK: string, elemOffset: Rect) {
     const elmRight = elemOffset.left + elemOffset.width;
 
-    if (!this.siblingsBoundaries[siblingsK]) {
-      this.siblingsBoundaries[siblingsK] = {
+    if (!this.siblingsBoundaries[SK]) {
+      this.siblingsBoundaries[SK] = {
         top: elemOffset.top,
         maxLeft: elemOffset.left,
         minRight: elmRight,
@@ -197,7 +197,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       return;
     }
 
-    const $ = this.siblingsBoundaries[siblingsK];
+    const $ = this.siblingsBoundaries[SK];
 
     if ($.maxLeft < elemOffset.left) {
       $.maxLeft = elemOffset.left;

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -153,6 +153,8 @@ class Scroll implements ScrollInterface {
       position === "fixed" ||
       !scrollContainer
     ) {
+      this.hasDocumentAsContainer = true;
+
       return getScrollFromDocument();
     }
 

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -12,7 +12,7 @@ import { ThresholdPercentages } from "../Threshold/types";
 import { ScrollInput, ScrollInterface } from "./types";
 
 const OVERFLOW_REGEX = /(auto|scroll|overlay)/;
-const MAX_LOOP_ELEMENTS_TO_WARN = 12;
+const MAX_LOOP_ELEMENTS_TO_WARN = 16;
 
 function getScrollFromDocument() {
   return document.scrollingElement || document.documentElement;

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -15,17 +15,18 @@ function getScrollFromDocument() {
   return document.scrollingElement || document.documentElement;
 }
 
-function hasOverflow(element: Element) {
-  const overflowRegex = /(auto|scroll|overlay)/;
-  const computedStyle = getComputedStyle(element);
+const overflowRegex = /(auto|scroll|overlay)/;
 
-  const overflow =
-    computedStyle.getPropertyValue("overflow") +
-    computedStyle.getPropertyValue("overflow-y") +
-    computedStyle.getPropertyValue("overflow-x");
+// function hasOverflow(element: Element) {
+//   const computedStyle = getComputedStyle(element);
 
-  return overflowRegex.test(overflow);
-}
+//   const overflow =
+//     computedStyle.getPropertyValue("overflow") +
+//     computedStyle.getPropertyValue("overflow-y") +
+//     computedStyle.getPropertyValue("overflow-x");
+
+//   return overflowRegex.test(overflow);
+// }
 
 function isStaticallyPositioned(element: Element) {
   const computedStyle = getComputedStyle(element);
@@ -105,6 +106,7 @@ class Scroll implements ScrollInterface {
 
     if (!element) {
       this.hasDocumentAsContainer = true;
+
       return getScrollFromDocument();
     }
 
@@ -118,11 +120,39 @@ class Scroll implements ScrollInterface {
       if (excludeStaticParents && isStaticallyPositioned(parent)) {
         return false;
       }
-      return hasOverflow(parent);
+
+      const parentComputedStyle = getComputedStyle(parent);
+
+      const parentRect = parent.getBoundingClientRect();
+
+      const overflowY = parentComputedStyle.getPropertyValue("overflow-y");
+
+      if (overflowRegex.test(overflowY)) {
+        if (parent.scrollHeight === Math.round(parentRect.height)) {
+          this.hasDocumentAsContainer = true;
+        }
+
+        return true;
+      }
+
+      const overflowX = parentComputedStyle.getPropertyValue("overflow-x");
+
+      if (overflowRegex.test(overflowX)) {
+        if (parent.scrollWidth === Math.round(parentRect.width)) {
+          this.hasDocumentAsContainer = true;
+        }
+
+        return true;
+      }
+
+      return false;
     });
 
-    if (position === "fixed" || !scrollContainer) {
-      this.hasDocumentAsContainer = true;
+    if (
+      this.hasDocumentAsContainer ||
+      position === "fixed" ||
+      !scrollContainer
+    ) {
       return getScrollFromDocument();
     }
 


### PR DESCRIPTION
- [x] Avoid a bug where there's an overflow in CSS but the container doesn't actually have a scroll.
- [x] Add a warning about performance issues for looping after a max number to find a scroll container.