### PR TITLE
Handle invalid elements in the registry & elements accumulation to the same branch

### DIFF
--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -35,6 +35,8 @@ class CoreInstance
 
   keys: Keys;
 
+  depth: number;
+
   isVisible: boolean;
 
   hasToTransform!: boolean;
@@ -42,12 +44,14 @@ class CoreInstance
   animatedFrame: number | null;
 
   constructor(elementWithPointer: CoreInput) {
-    const { order, keys, scrollX, scrollY, ...element } = elementWithPointer;
+    const { order, keys, depth, scrollX, scrollY, ...element } =
+      elementWithPointer;
 
     super(element);
 
     this.order = order;
     this.keys = keys;
+    this.depth = depth;
 
     this.isVisible = element.isInitialized && !element.isPaused;
 

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -70,6 +70,7 @@ export interface Pointer {
 export interface CoreEssential {
   order: Order;
   keys: Keys;
+  depth: number;
   scrollX: number;
   scrollY: number;
 }
@@ -95,6 +96,7 @@ export interface CoreInstanceInterface extends AbstractCoreInterface {
   currentLeft?: number;
   order: Order;
   keys: Keys;
+  depth: number;
   animatedFrame: number | null;
   resume(scrollX: number, scrollY: number): void;
   changeVisibility(isVisible: boolean): void;

--- a/packages/dnd/src/DnD.ts
+++ b/packages/dnd/src/DnD.ts
@@ -42,9 +42,7 @@ class DnD extends Droppable {
      * In case it is not already initiated in the store. We do it here guarantee
      * all the branch is updated.
      */
-    if (!store.siblingsScrollElement[SK]) {
-      store.initSiblingsScrollAndVisibility(SK);
-    }
+    store.initSiblingsScrollAndVisibilityIfNecessary(SK);
 
     const draggable = new Draggable(
       id,

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -157,15 +157,23 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       ? requiredBranch
       : [requiredBranch];
 
-    branch.forEach((elmID, i) => {
-      if (elmID) {
-        if (this.registry[elmID].ref) {
-          if (!this.registry[elmID].ref!.isConnected) {
-            this.DOMGen.removeElementIDFromBranch(branchKey, i);
-          }
+    let shiftedIndexes = 0;
+
+    for (let i = 0; i < branch.length; i += 1) {
+      const elmID = branch[i];
+
+      if (elmID && this.registry[elmID].ref) {
+        if (!this.registry[elmID].ref!.isConnected) {
+          shiftedIndexes += 1;
         }
       }
-    });
+    }
+
+    for (let i = shiftedIndexes; i < branch.length; i += 1) {
+      this.registry[branch[i]!].order.self -= shiftedIndexes;
+    }
+
+    branch.splice(0, shiftedIndexes);
   }
 
   initSiblingsScrollAndVisibilityIfNecessary(key: string) {

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -159,19 +159,22 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
     const extractedOldBranch: string[] = [];
 
+    let depth: null | number = null;
+
     for (let i = 0; i < branch.length; i += 1) {
       const elmID = branch[i];
 
       if (elmID && this.registry[elmID].ref) {
         if (!this.registry[elmID].ref!.isConnected) {
+          if (depth === null) depth = this.registry[elmID].depth;
           extractedOldBranch.push(elmID);
         }
       }
     }
 
-    this.DOMGen.getElmPointer(`${Date.now()}`, 1);
+    this.DOMGen.getElmPointer(`${Date.now()}`, depth as number);
 
-    const { SK } = this.DOMGen.accumulateIndicators(0);
+    const { SK } = this.DOMGen.accumulateIndicators(depth as number);
 
     // Swap branches
     this.DOMGen.branches[SK] = this.DOMGen.branches[branchKey];
@@ -234,7 +237,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
         }
 
         const newKey = this.cleanupUnconnectedElements(key);
-
+        delete this.siblingsScrollElement[key];
         this.initSiblingsScrollAndVisibilityIfNecessary(newKey);
       }
 

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -151,10 +151,23 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
   }
 
   initSiblingsScrollAndVisibilityIfNecessary(key: string) {
+    const hasSiblings = Array.isArray(this.DOMGen.branches[key]);
+
+    const firstElemID = hasSiblings
+      ? this.DOMGen.branches[key]![0]
+      : (this.DOMGen.branches[key] as string);
+
     // Avoid multiple calls that runs function multiple times. This happens
     // when there's a delay in firing load event and clicking on the element.
     // It's fine.
     if (this.siblingsScrollElement[key]) {
+      if (!this.registry[firstElemID].isPaused) {
+        throwIfElementIsNotConnected(
+          this.registry[firstElemID].ref!,
+          firstElemID
+        );
+      }
+
       /**
        * When does it happen?
        * When the branch is cleared but the scroll element is still there.
@@ -170,18 +183,12 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
        *
        * All these cases are not considered a bug. A problem, but not a bug.
        */
-      if (!this.siblingsScrollElement[key].scrollContainer.isConnected) {
-        delete this.siblingsScrollElement[key];
+      if (this.siblingsScrollElement[key].scrollContainer.isConnected) {
+        return;
       }
 
-      return;
+      delete this.siblingsScrollElement[key];
     }
-
-    const hasSiblings = Array.isArray(this.DOMGen.branches[key]);
-
-    const firstElemID = hasSiblings
-      ? this.DOMGen.branches[key]![0]
-      : (this.DOMGen.branches[key] as string);
 
     if (!this.registry[firstElemID].isPaused) {
       throwIfElementIsNotConnected(

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -183,7 +183,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
        *
        * All these cases are not considered a bug. A problem, but not a bug.
        */
-      if (this.siblingsScrollElement[key].scrollContainer.isConnected) {
+      if (this.siblingsScrollElement[key].scrollContainerRef.isConnected) {
         return;
       }
 

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -170,7 +170,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
        *
        * All these cases are not considered a bug. A problem, but not a bug.
        */
-      if (this.siblingsScrollElement[key].scrollContainer.isConnected) {
+      if (!this.siblingsScrollElement[key].scrollContainer.isConnected) {
         delete this.siblingsScrollElement[key];
       }
 

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -157,11 +157,11 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       ? requiredBranch
       : [requiredBranch];
 
-    branch.forEach((elmID) => {
+    branch.forEach((elmID, i) => {
       if (elmID) {
         if (this.registry[elmID].ref) {
           if (!this.registry[elmID].ref!.isConnected) {
-            this.unregister(elmID);
+            this.DOMGen.removeElementIDFromBranch(branchKey, i);
           }
         }
       }
@@ -421,6 +421,18 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     this.siblingsScrollElement = {};
   }
 
+  /**
+   * Unregister DnD element.
+   *
+   * Note: This will remove the element registry and the branch array. But,
+   * in case all the branches will be removed.
+   * This means, if, in rare cases when the user removes one element and keeps
+   * the rest this methods going to generate a bug. It's going to remove an
+   * element without updating the indexes inside registry instances.
+   *
+   * @param id -
+   *
+   */
   unregister(id: string) {
     const {
       keys: { SK },

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -157,17 +157,19 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       ? requiredBranch
       : [requiredBranch];
 
-    let shiftedIndexes = 0;
+    const newBranch: string[] = [];
 
     for (let i = 0; i < branch.length; i += 1) {
       const elmID = branch[i];
 
       if (elmID && this.registry[elmID].ref) {
         if (!this.registry[elmID].ref!.isConnected) {
-          shiftedIndexes += 1;
+          newBranch.push(elmID);
         }
       }
     }
+
+    const shiftedIndexes = newBranch.length;
 
     for (let i = shiftedIndexes; i < branch.length; i += 1) {
       const elmID = branch[i];

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -18,7 +18,7 @@ import canUseDOM from "../utils/canUseDOM";
 function throwIfElementIsNotConnected(elm: Element, id: string) {
   if (!elm.isConnected) {
     throw new Error(
-      `DFlex: elements in the branch is not valid. Trying to validate ${id} but failed.
+      `DFlex: elements in the branch are not valid. Trying to validate element with an id:${id} but failed.
 Did you forget to call store.unregister(${id})?`
     );
   }

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -17,7 +17,8 @@ import canUseDOM from "../utils/canUseDOM";
 
 function throwIfElementIsNotConnected(elm: Element, id: string) {
   if (!elm.isConnected) {
-    throw new Error(
+    // eslint-disable-next-line no-console
+    console.error(
       `DFlex: elements in the branch are not valid. Trying to validate element with an id:${id} but failed.
 Did you forget to call store.unregister(${id})?`
     );

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -170,7 +170,9 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     }
 
     for (let i = shiftedIndexes; i < branch.length; i += 1) {
-      this.registry[branch[i]!].order.self -= shiftedIndexes;
+      const elmID = branch[i];
+
+      if (elmID) this.registry[elmID].order.self -= shiftedIndexes;
     }
 
     branch.splice(0, shiftedIndexes);

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -34,8 +34,11 @@ export interface Translate {
   translateY: number;
 }
 
-interface RegisterInputDepth {
+interface RegisterInputEssential {
+  /** provide a depth if you want to drag the parent container  */
   depth?: number;
+  /** Unique key to connect elements with the same parent together */
+  parenID?: string;
 }
 
 interface RegisterInputID {
@@ -54,9 +57,9 @@ interface RegisterInputAll {
 }
 
 export type RegisterInput =
-  | (RegisterInputDepth & RegisterInputAll)
-  | (RegisterInputDepth & RegisterInputID)
-  | (RegisterInputDepth & RegisterInputRef);
+  | (RegisterInputEssential & RegisterInputAll)
+  | (RegisterInputEssential & RegisterInputID)
+  | (RegisterInputEssential & RegisterInputRef);
 
 export interface ScrollThreshold {
   maxX: number;

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -612,8 +612,11 @@ class Droppable {
 
     const { SK } = store.registry[this.draggable.draggedElm.id].keys;
 
-    const { scrollHeight, scrollContainer, scrollRect } =
-      store.siblingsScrollElement[SK];
+    const {
+      scrollHeight,
+      scrollContainerRef: scrollContainer,
+      scrollRect,
+    } = store.siblingsScrollElement[SK];
 
     if (direction === 1) {
       if (currentBottom <= scrollHeight) {
@@ -648,8 +651,11 @@ class Droppable {
 
     const { SK } = store.registry[this.draggable.draggedElm.id].keys;
 
-    const { scrollHeight, scrollContainer, scrollRect } =
-      store.siblingsScrollElement[SK];
+    const {
+      scrollHeight,
+      scrollContainerRef: scrollContainer,
+      scrollRect,
+    } = store.siblingsScrollElement[SK];
 
     if (direction === 1) {
       if (currentRight <= scrollHeight) {

--- a/packages/dnd/src/Plugins/Scroll/types.ts
+++ b/packages/dnd/src/Plugins/Scroll/types.ts
@@ -9,7 +9,7 @@ import { Rect } from "packages/core-instance/src/types";
 import type { ThresholdInterface } from "../Threshold";
 
 export interface ScrollInput {
-  element: Element;
+  element: HTMLElement;
   requiredBranchKey: string;
   scrollEventCallback:
     | ((SK: string, isCalledFromScroll: true) => unknown)
@@ -26,7 +26,7 @@ export interface ScrollInterface {
   hasOverflowX: boolean;
   hasOverflowY: boolean;
   allowDynamicVisibility: boolean;
-  scrollContainer: Element;
+  scrollContainerRef: HTMLElement;
   hasDocumentAsContainer: boolean;
   scrollEventCallback: ScrollInput["scrollEventCallback"];
   hasThrottledFrame: number | null;

--- a/packages/dnd/src/utils/loopInDOM.ts
+++ b/packages/dnd/src/utils/loopInDOM.ts
@@ -6,18 +6,18 @@
  */
 
 function loopInDOM(
-  fromElement: Element,
+  fromElement: HTMLElement,
   // eslint-disable-next-line no-unused-vars
-  cb: (arg: Element) => boolean
+  cb: (arg: HTMLElement) => boolean
 ) {
-  let current: Element | null = fromElement;
+  let current: HTMLElement | null = fromElement;
 
   do {
     if (cb(current)) {
       return current;
     }
 
-    current = current.parentNode as Element;
+    current = current.parentNode as HTMLElement;
   } while (current && !current.isSameNode(document.body));
 
   return null;

--- a/packages/dnd/test/Store/__snapshots__/dndStore.test.ts.snap
+++ b/packages/dnd/test/Store/__snapshots__/dndStore.test.ts.snap
@@ -4,6 +4,7 @@ exports[`DnD Store Element is initiated 1`] = `
 Object {
   "id-1": CoreInstance {
     "animatedFrame": null,
+    "depth": 0,
     "id": "id-1",
     "isInitialized": true,
     "isPaused": true,
@@ -23,6 +24,7 @@ Object {
   },
   "id-2": CoreInstance {
     "animatedFrame": null,
+    "depth": 0,
     "id": "id-2",
     "isInitialized": true,
     "isPaused": true,
@@ -42,6 +44,7 @@ Object {
   },
   "id-3": CoreInstance {
     "animatedFrame": null,
+    "depth": 0,
     "id": "id-3",
     "isInitialized": true,
     "isPaused": true,
@@ -61,6 +64,7 @@ Object {
   },
   "id-4": CoreInstance {
     "animatedFrame": null,
+    "depth": 0,
     "id": "id-4",
     "isInitialized": true,
     "isPaused": true,
@@ -94,6 +98,7 @@ Object {
   },
   "element": CoreInstance {
     "animatedFrame": null,
+    "depth": 0,
     "id": "id-1",
     "isInitialized": true,
     "isPaused": true,

--- a/packages/dom-gen/src/Generator.ts
+++ b/packages/dom-gen/src/Generator.ts
@@ -131,15 +131,7 @@ class Generator implements GeneratorInterface {
     return this.branches[SK];
   }
 
-  /**
-   * Main method.
-   *
-   * Add element to branches.
-   *
-   * @param id - element id
-   * @param depth - element depth
-   */
-  getElmPointer(id: string, depth: number): Pointer {
+  private accumulateIndicators(depth: number) {
     if (depth !== this.prevDepth) {
       this.initIndicators(depth);
     }
@@ -152,10 +144,13 @@ class Generator implements GeneratorInterface {
     /**
      * get siblings unique key (sK) and parents key (pK)
      */
-    const siblingsKey = genKey(depth, parentIndex);
-    const parentKey = genKey(depth + 1, this.indicator[depth + 2]);
+    const SK = genKey(depth, parentIndex);
+    const PK = genKey(depth + 1, this.indicator[depth + 2]);
 
-    const selfIndex = this.addElementIDToSiblingsBranch(id, siblingsKey);
+    const CHK = depth === 0 ? null : this.prevKey;
+    this.prevKey = SK;
+
+    this.indicator[depth] += 1;
 
     if (depth < this.prevDepth) {
       /**
@@ -166,15 +161,31 @@ class Generator implements GeneratorInterface {
 
     this.prevDepth = depth;
 
-    const childrenKey = this.prevKey;
-    this.prevKey = siblingsKey;
+    return {
+      CHK,
+      SK,
+      PK,
+      parentIndex,
+    };
+  }
 
-    this.indicator[depth] += 1;
+  /**
+   * Main method.
+   *
+   * Add element to branches.
+   *
+   * @param id - element id
+   * @param depth - element depth
+   */
+  getElmPointer(id: string, depth: number): Pointer {
+    const { CHK, SK, PK, parentIndex } = this.accumulateIndicators(depth);
+
+    const selfIndex = this.addElementIDToSiblingsBranch(id, SK);
 
     const keys: Keys = {
-      SK: siblingsKey,
-      PK: parentKey,
-      CHK: depth === 0 ? null : childrenKey,
+      SK,
+      PK,
+      CHK,
     };
 
     const order: Order = {

--- a/packages/dom-gen/src/Generator.ts
+++ b/packages/dom-gen/src/Generator.ts
@@ -131,7 +131,7 @@ class Generator implements GeneratorInterface {
     return this.branches[SK];
   }
 
-  private accumulateIndicators(depth: number) {
+  accumulateIndicators(depth: number) {
     if (depth !== this.prevDepth) {
       this.initIndicators(depth);
     }

--- a/packages/dom-gen/src/types.ts
+++ b/packages/dom-gen/src/types.ts
@@ -37,6 +37,9 @@ export interface GeneratorInterface {
   };
   getElmBranch(SK: string): ELmBranch;
   getElmPointer(id: string, depth: number): Pointer;
+  accumulateIndicators(depth: number): Keys & {
+    parentIndex: number;
+  };
   removeElementIDFromBranch(SK: string, index: number): string | null;
   destroyBranch(SK: string, cb: (elmID: string) => unknown): void;
   clearBranchesAndIndicator(): void;

--- a/packages/draggable/test/__snapshots__/draggableStore.test.ts.snap
+++ b/packages/draggable/test/__snapshots__/draggableStore.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     "animatedFrame": null,
     "currentLeft": NaN,
     "currentTop": NaN,
+    "depth": 0,
     "hasToTransform": false,
     "id": "id-0",
     "isInitialized": true,

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -20,10 +20,45 @@ class Store<T = ElmWithPointerWithProps> implements StoreInterface<T> {
 
   DOMGen: Generator;
 
+  private lastKeyIdentifier: string | null;
+
   constructor() {
+    this.lastKeyIdentifier = null;
+
     this.registry = {};
 
     this.DOMGen = new Generator();
+  }
+
+  /**
+   * Create element and add it to registry.
+   *
+   * @param element - Element to be added to registry.
+   * @param CustomInstance - Custom class to be used for element.
+   * @param opts - Options to be passed to CustomInstance.
+   */
+  private submitElementToRegistry(
+    element: ElmInstanceWithProps,
+    CustomInstance?: Class<T>,
+    opts?: {}
+  ) {
+    const { id, depth, ...rest } = element;
+
+    const { order, keys } = this.DOMGen.getElmPointer(id, depth);
+
+    const coreElement: ElmWithPointerWithProps = {
+      id,
+      order,
+      keys,
+      ...rest,
+    };
+
+    // TODO: fix TS error here.
+    // @ts-ignore
+    this.registry[id] =
+      CustomInstance && typeof CustomInstance.constructor === "function"
+        ? new CustomInstance(coreElement, opts)
+        : coreElement;
   }
 
   /**
@@ -38,18 +73,32 @@ class Store<T = ElmWithPointerWithProps> implements StoreInterface<T> {
     CustomInstance?: Class<T>,
     opts?: {}
   ) {
-    const { id, depth, ...rest } = element;
+    // Why using parentID?
+    // Because it's impossible to know if this element belongs to the same
+    // branch or not. Unless the input is strict and ask to register the parent
+    // node which can't be done. To solve this, we use parentID to identify
+    // elements belong to the same branch.
+    // Another thing could be: but why not call the parent node from the DOM?
+    // Well, it solves the issue temporarily. But it breaks the rule of DFlex:
+    // Extensibility.
+    if (element.parentId) {
+      // This is the first element in the branch then.
+      if (!this.lastKeyIdentifier) {
+        this.lastKeyIdentifier = element.parentId;
+        // Change means new branch.
+      } else if (element.parentId !== this.lastKeyIdentifier) {
+        // Create parent node to close the branch.
+        this.submitElementToRegistry(
+          {
+            id: element.parentId,
+            depth: element.depth + 1,
+          },
+          CustomInstance
+        );
+      }
+    }
 
-    const { order, keys } = this.DOMGen.getElmPointer(id, depth);
-
-    const coreElement: ElmWithPointerWithProps = { id, order, keys, ...rest };
-
-    // TODO: fix TS error here.
-    // @ts-ignore
-    this.registry[id] =
-      CustomInstance && typeof CustomInstance.constructor === "function"
-        ? new CustomInstance(coreElement, opts)
-        : coreElement;
+    this.submitElementToRegistry(element, CustomInstance, opts);
   }
 
   unregister(id: string) {

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -9,11 +9,11 @@ import type { ELmBranch } from "@dflex/dom-gen";
 import type {
   Class,
   ElmInstanceWithProps,
-  ElmWithPointerWithProps,
+  ElmPointerWithProps,
   StoreInterface,
 } from "./types";
 
-class Store<T = ElmWithPointerWithProps> implements StoreInterface<T> {
+class Store<T = ElmPointerWithProps> implements StoreInterface<T> {
   registry: {
     [id: string]: T;
   };
@@ -46,10 +46,11 @@ class Store<T = ElmWithPointerWithProps> implements StoreInterface<T> {
 
     const { order, keys } = this.DOMGen.getElmPointer(id, depth);
 
-    const coreElement: ElmWithPointerWithProps = {
+    const coreElement: ElmPointerWithProps = {
       id,
       order,
       keys,
+      depth,
       ...rest,
     };
 

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -12,9 +12,14 @@ export type Class<classInstance> = new (...args: any[]) => classInstance;
 export interface ElmInstance {
   id: string;
   depth: number;
+  parentId?: string;
 }
 
-export interface ElmInstanceWithProps extends Required<ElmInstance> {
+export interface ElmInstanceWithProps
+  extends Required<Omit<ElmInstance, "parentId">> {
+  // This seems wrong, but without omitting parentID, TS enforced string value
+  // and ignored undefined.
+  parentId?: string;
   [key: string]: any;
 }
 

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -23,8 +23,7 @@ export interface ElmInstanceWithProps
   [key: string]: any;
 }
 
-export interface ElmWithPointerWithProps
-  extends Omit<ElmInstanceWithProps, "depth"> {
+export interface ElmPointerWithProps extends ElmInstanceWithProps {
   order: Order;
   keys: Keys;
 }

--- a/packages/store/test/__snapshots__/store.test.ts.snap
+++ b/packages/store/test/__snapshots__/store.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Testing Store Package Snaps shot registry 1`] = `
 Object {
   "id-0": Object {
+    "depth": 0,
     "id": "id-0",
     "keys": Object {
       "CHK": null,
@@ -16,6 +17,7 @@ Object {
     "ref": <div />,
   },
   "id-1": Object {
+    "depth": 0,
     "id": "id-1",
     "keys": Object {
       "CHK": null,
@@ -29,6 +31,7 @@ Object {
     "ref": <div />,
   },
   "id-2": Object {
+    "depth": 0,
     "id": "id-2",
     "keys": Object {
       "CHK": null,
@@ -42,6 +45,7 @@ Object {
     "ref": <div />,
   },
   "p-id-0": Object {
+    "depth": 1,
     "id": "p-id-0",
     "keys": Object {
       "CHK": "0-0",
@@ -60,6 +64,7 @@ Object {
 exports[`Testing Store Package Snaps shot registry after delete 1`] = `
 Object {
   "id-0": Object {
+    "depth": 0,
     "id": "id-0",
     "keys": Object {
       "CHK": null,
@@ -73,6 +78,7 @@ Object {
     "ref": <div />,
   },
   "id-1": Object {
+    "depth": 0,
     "id": "id-1",
     "keys": Object {
       "CHK": null,
@@ -86,6 +92,7 @@ Object {
     "ref": <div />,
   },
   "id-2": Object {
+    "depth": 0,
     "id": "id-2",
     "keys": Object {
       "CHK": null,
@@ -99,6 +106,7 @@ Object {
     "ref": <div />,
   },
   "p-id-0": Object {
+    "depth": 1,
     "id": "p-id-0",
     "keys": Object {
       "CHK": "0-0",

--- a/packages/store/test/store.test.ts
+++ b/packages/store/test/store.test.ts
@@ -65,6 +65,7 @@ describe("Testing Store Package", () => {
 
     expect(elemInstance).toStrictEqual({
       id: "id-0",
+      depth: 0,
       keys: {
         CHK: null,
         PK: "1-0",


### PR DESCRIPTION
- [x] Validate elements before creating draggable.
- [x] Throw an error when elements found in the branch are not connected when not in production.
- [x] Add `cleanupUnconnectedElements` for production usage.
- [x] Isolate indicators from adding a new element process. Open the room for more flexible add/remove when it comes to modifying existing branches. Done by adding  `accumulateIndicators`.
- [x] Refactor native store to pass depth to the Core. (need depth when modifying branches).
- [x] Add new property `parentID: string` to match elements from the same branch for input in the registry. 