### PR TITLE
Add scroll dataset to the scroll container setting dynamic visibility as its value

### DIFF
--- a/packages/core-instance/src/AbstractCoreInstance.ts
+++ b/packages/core-instance/src/AbstractCoreInstance.ts
@@ -62,24 +62,28 @@ class AbstractCoreInstance implements AbstractCoreInterface {
     }
 
     this.ref = incomingRef;
+    this.isInitialized = true;
   }
 
   detach() {
+    this.isInitialized = false;
+    this.isPaused = true;
     this.ref = null;
-  }
-
-  initialize(ref: HTMLElement | null) {
-    this.attach(ref);
-    this.isInitialized = true;
   }
 
   initTranslate() {
     /**
      * Since element render once and being transformed later we keep the data
      * stored to navigate correctly.
+     *
+     * If it's already initiated we don't need to do it again.
+     * Reason: You may detach ref set flag to false and then attach it again. Do
+     * you want to start from zero or maintain the last position.
+     *
+     * Continuity is fundamental in DFlex, please keep that in your mind.
      */
-    this.translateY = 0;
-    this.translateX = 0;
+    if (typeof this.translateY !== "number") this.translateY = 0;
+    if (typeof this.translateX !== "number") this.translateX = 0;
 
     this.isPaused = false;
   }

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -74,7 +74,9 @@ class CoreInstance
    * So, basically any working element in DnD should be initiated first.
    */
   private initIndicators(scrollX: number, scrollY: number) {
-    this.prevTranslateY = [];
+    if (!Array.isArray(this.prevTranslateY)) {
+      this.prevTranslateY = [];
+    }
 
     const { height, width, left, top } = this.ref!.getBoundingClientRect();
 
@@ -98,12 +100,11 @@ class CoreInstance
   }
 
   resume(scrollX: number, scrollY: number) {
-    if (!this.isInitialized) this.initialize(null);
+    if (!this.isInitialized) this.attach(null);
 
     this.initTranslate();
-    this.initIndicators(scrollX, scrollY);
 
-    this.isPaused = false;
+    this.initIndicators(scrollX, scrollY);
   }
 
   changeVisibility(isVisible: boolean) {

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -33,7 +33,6 @@ export interface AbstractCoreInterface {
   isInitialized: boolean;
   translateY?: number;
   translateX?: number;
-  initialize(ref: HTMLElement | null): void;
   initTranslate(): void;
   attach(ref: HTMLElement | null): void;
   detach(): void;

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -19,7 +19,7 @@ function throwElementIsNotConnected(id: string) {
   // eslint-disable-next-line no-console
   console.error(
     `DFlex: elements in the branch are not valid. Trying to validate element with an id:${id} but failed.
-Did you forget to call store.unregister(${id})?`
+Did you forget to call store.unregister(${id}) or add parenID when register the element?`
   );
 }
 
@@ -184,6 +184,8 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       if (elmID) {
         this.registry[elmID].order.self -= shiftedIndexes;
         this.registry[elmID].keys.SK = SK;
+        // TODO: Add detach and test it.
+        // this.registry[elmID].detach();
       }
     }
 
@@ -334,7 +336,6 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       if (this.registry[id].isInitialized) {
         this.registry[id].attach(element.ref || null);
       }
-
       if (this.registry[id].isVisible) {
         // Preserves last changes.
         this.registry[id].transformElm();

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -208,13 +208,7 @@ Please provide scroll container by ref/id when registering the element or turn o
       this.scrollRect = { height, width, left, top };
     }
 
-    this.hasOverflowY = this.scrollRect.height < scrollHeight;
-    console.log(
-      "file: Scroll.ts ~ line 212 ~ this.scrollRect.height",
-      this.scrollRect.height,
-      scrollHeight
-    );
-
+    this.hasOverflowY = this.scrollHeight > this.scrollRect.height;
     this.hasOverflowX = this.scrollRect.width < scrollWidth;
 
     /**

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -254,7 +254,10 @@ Please provide scroll container by ref/id when registering the element or turn o
       if (this.hasDocumentAsContainer) {
         // Find the first div in the document body.
         for (let i = 0; i < document.body.childNodes.length; i += 1) {
-          if (document.body.childNodes[i].nodeName === "DIV") {
+          if (
+            document.body.childNodes[i].ELEMENT_NODE === 1 &&
+            document.body.childNodes[i].nodeName === "DIV"
+          ) {
             // @ts-expect-error
             elm = document.body.childNodes[i];
 

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -209,6 +209,11 @@ Please provide scroll container by ref/id when registering the element or turn o
     }
 
     this.hasOverflowY = this.scrollRect.height < scrollHeight;
+    console.log(
+      "file: Scroll.ts ~ line 212 ~ this.scrollRect.height",
+      this.scrollRect.height,
+      scrollHeight
+    );
 
     this.hasOverflowX = this.scrollRect.width < scrollWidth;
 
@@ -268,7 +273,9 @@ Please provide scroll container by ref/id when registering the element or turn o
 
       if (elm) {
         if (attach) {
-          elm.dataset.dflexScrollListener = this.siblingKey;
+          elm.dataset[
+            `dflexScrollListener-${this.siblingKey}`
+          ] = `${this.allowDynamicVisibility}`;
 
           return;
         }

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -249,14 +249,28 @@ Please provide scroll container by ref/id when registering the element or turn o
     if (hasScrollListener) {
       container[type]("scroll", this.animatedScrollListener, opts);
 
-      if (!this.hasDocumentAsContainer) {
+      let elm: HTMLElement = this.scrollContainerRef;
+
+      if (this.hasDocumentAsContainer) {
+        // Find the first div in the document body.
+        for (let i = 0; i < document.body.childNodes.length; i += 1) {
+          if (document.body.childNodes[i].nodeName === "DIV") {
+            // @ts-expect-error
+            elm = document.body.childNodes[i];
+
+            break;
+          }
+        }
+      }
+
+      if (elm) {
         if (attach) {
-          this.scrollContainerRef.dataset.dflexScrollListener = this.siblingKey;
+          elm.dataset.dflexScrollListener = this.siblingKey;
 
           return;
         }
 
-        delete this.scrollContainerRef.dataset.dflexScrollListener;
+        delete elm.dataset.dflexScrollListener;
       }
     }
   }


### PR DESCRIPTION
- [ ] Fix a bug when the scroll container has multiple elements, so it detects overflow **but** the parent container of the element branch is not overflowed. (what a nightmare!). This is basically a side effect that emerges from  #332
- [x] Refactor initialize to attach (no need for separate method).
- [x] Add another reason for throwing an error when there's no parent-id.
- [x] Add scroll `dataset` when the scroll is the document. Previously,  when not the document. Currently, add the dataset to the first div inside the body document. When to add the dataset? Only if the algorithm detects an overflow. (It's also so much easier for the test and debugging),