### PR TITLE
Enhance cleaning up branches when elements not connected

### DIFF
--- a/packages/core-instance/src/AbstractCoreInstance.ts
+++ b/packages/core-instance/src/AbstractCoreInstance.ts
@@ -50,7 +50,11 @@ class AbstractCoreInstance implements AbstractCoreInterface {
   }
 
   attach(incomingRef: HTMLElement | null) {
+    // Cleanup.
+    this.ref = null;
+
     if (!incomingRef) {
+      // TODO: Is this always running when document is valid? Or it's buggy?
       const ref = document.getElementById(this.id);
       if (!ref) {
         throw new Error(`DFlex: Element with ID: ${this.id} is not found.`);

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -275,6 +275,15 @@ Please provide scroll container by ref/id when registering the element or turn o
         }
 
         delete elm.dataset.dflexScrollListener;
+
+        return;
+      }
+
+      if (process.env.NODE_ENV !== "production") {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `DFlex: Failed to add scroll listener dataset. Unable to detect the first valid div inside document.body`
+        );
       }
     }
   }


### PR DESCRIPTION
- [x] Detach elements ref when cleaning the branch.
- [x] Clear old reference when calling `attach`. There's a possibility of throwing an error while validating the new one without clearing the old one. Avoid any potential memory leaks.
- [x] Add a warning if not being able to add scroll dataset.
- [x] Refactor `cleanupUnconnectedElements` so we can dynamically clean connected/unconnected dom elements.