### PR TITLE
Introduce DnD events & layout state

### DIFF
--- a/packages/dnd/playgrounds/dflex-react-dnd/src/components/todo/basic/Todo.tsx
+++ b/packages/dnd/playgrounds/dflex-react-dnd/src/components/todo/basic/Todo.tsx
@@ -9,6 +9,12 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
 import React from "react";
+import type {
+  DraggedEvent,
+  InteractivityEvent,
+  SiblingsEvent,
+  LayoutStateEvent,
+} from "@dflex/dnd";
 import s from "../../Demo.module.css";
 
 import DnDComponent from "../../DnDComponent";
@@ -25,12 +31,62 @@ const TodoList = () => {
     { id: "gym", msg: "Hit the gym", style: { height: "4.5rem" } },
   ];
 
+  const onDragOver = (e: InteractivityEvent) => {
+    // eslint-disable-next-line no-console
+    console.log("onDragOver", e);
+  };
+
+  const onDragLeave = (e: InteractivityEvent) => {
+    // eslint-disable-next-line no-console
+    console.log("onDragLeave", e);
+  };
+
+  const onStateChange = (e: LayoutStateEvent) => {
+    // eslint-disable-next-line no-console
+    console.log("onStateChange", e);
+  };
+
+  const onDragOutContainer = (e: DraggedEvent) => {
+    // eslint-disable-next-line no-console
+    console.log("onDragOutContainer", e);
+  };
+
+  const onDragOutThreshold = (e: DraggedEvent) => {
+    // eslint-disable-next-line no-console
+    console.log("onDragOutThreshold", e);
+  };
+
+  const onLiftUpSiblings = (e: SiblingsEvent) => {
+    // eslint-disable-next-line no-console
+    console.log("onLiftUpSiblings", e);
+  };
+
+  const onMoveDownSiblings = (e: SiblingsEvent) => {
+    // eslint-disable-next-line no-console
+    console.log("onMoveDownSiblings", e);
+  };
+
   return (
     <div className={s.root}>
       <div className={s.todo}>
         <ul>
           {tasks.map(({ msg, id, style }) => (
-            <DnDComponent id={id} key={id} style={style}>
+            <DnDComponent
+              id={id}
+              key={id}
+              style={style}
+              opts={{
+                events: {
+                  onDragLeave,
+                  onDragOver,
+                  onStateChange,
+                  onDragOutContainer,
+                  onDragOutThreshold,
+                  onLiftUpSiblings,
+                  onMoveDownSiblings,
+                },
+              }}
+            >
               {msg}
             </DnDComponent>
           ))}

--- a/packages/dnd/src/DnD.ts
+++ b/packages/dnd/src/DnD.ts
@@ -21,11 +21,25 @@ class DnD extends Droppable {
    * @param initCoordinates -
    * @param opts -
    */
+  // eslint-disable-next-line constructor-super
   constructor(
     id: string,
     initCoordinates: Coordinates,
     opts: DndOpts = defaultOpts
   ) {
+    const isLayoutAvailable = ["pending", "dragEnd", "dragCancel"].includes(
+      store.layoutState
+    );
+
+    if (!isLayoutAvailable) {
+      if (process.env.NODE_ENV !== "production") {
+        // eslint-disable-next-line no-console
+        console.error(
+          `DFlex: received multiple dragging request while layout is still occupied`
+        );
+      }
+    }
+
     if (!store.registry[id]) {
       throw new Error(`DFlex: ${id} is not registered in the Store.`);
     }
@@ -50,7 +64,9 @@ class DnD extends Droppable {
       options as FinalDndOpts
     );
 
-    super(draggable);
+    super(draggable, options.events);
+
+    store.layoutState = "ready";
   }
 }
 

--- a/packages/dnd/src/DnD.ts
+++ b/packages/dnd/src/DnD.ts
@@ -66,7 +66,10 @@ class DnD extends Droppable {
 
     super(draggable, options.events);
 
-    store.layoutState = "ready";
+    // @ts-expect-error It's there. I don't want expose it to the user.
+    store.stateChangeHandler = options.events.onStateChange;
+
+    store.onStateChange("ready");
   }
 }
 

--- a/packages/dnd/src/DnD.ts
+++ b/packages/dnd/src/DnD.ts
@@ -64,10 +64,10 @@ class DnD extends Droppable {
       options as FinalDndOpts
     );
 
-    super(draggable, options.events);
+    super(draggable);
 
-    // @ts-expect-error It's there. I don't want expose it to the user.
-    store.stateChangeHandler = options.events.onStateChange;
+    // @ts-expect-error
+    store.events = options.events;
 
     store.onStateChange("ready");
   }

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -14,6 +14,7 @@ import Scroll from "../Plugins/Scroll";
 import Tracker from "../Plugins/Tracker";
 
 import canUseDOM from "../utils/canUseDOM";
+import type { LayoutState, Events } from "../types";
 
 function throwElementIsNotConnected(id: string) {
   // eslint-disable-next-line no-console
@@ -31,6 +32,8 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
   siblingsScrollElement: DnDStoreInterface["siblingsScrollElement"];
 
   layoutState: DnDStoreInterface["layoutState"];
+
+  private stateChangeHandler: Events["onStateChange"];
 
   private isDOM: boolean;
 
@@ -52,6 +55,9 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
     this.layoutState = "pending";
 
+    // @ts-expect-error Should be initialized when calling DnD instance.
+    this.stateChangeHandler = null;
+
     this.tracker = new Tracker();
 
     this.initELmIndicator();
@@ -61,6 +67,12 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
     this.onLoadListeners = this.onLoadListeners.bind(this);
     this.updateBranchVisibility = this.updateBranchVisibility.bind(this);
+  }
+
+  onStateChange(state: LayoutState) {
+    this.layoutState = state;
+
+    this.stateChangeHandler.call(state);
   }
 
   private init() {

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -14,7 +14,14 @@ import Scroll from "../Plugins/Scroll";
 import Tracker from "../Plugins/Tracker";
 
 import canUseDOM from "../utils/canUseDOM";
-import type { LayoutState, Events } from "../types";
+import type {
+  LayoutState,
+  Events,
+  InteractivityEvent,
+  DraggedEvent,
+  SiblingsEvent,
+  LayoutStateEvent,
+} from "../types";
 
 function throwElementIsNotConnected(id: string) {
   // eslint-disable-next-line no-console
@@ -33,7 +40,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
   layoutState: DnDStoreInterface["layoutState"];
 
-  private stateChangeHandler: Events["onStateChange"];
+  private events: Events;
 
   private isDOM: boolean;
 
@@ -56,7 +63,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     this.layoutState = "pending";
 
     // @ts-expect-error Should be initialized when calling DnD instance.
-    this.stateChangeHandler = null;
+    this.events = null;
 
     this.tracker = new Tracker();
 
@@ -72,7 +79,18 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
   onStateChange(state: LayoutState) {
     this.layoutState = state;
 
-    this.stateChangeHandler.call(state);
+    this.emitEvent({
+      layoutState: state,
+      timeStamp: Date.now(),
+      type: "onStateChange",
+    } as LayoutStateEvent);
+  }
+
+  emitEvent(
+    event: DraggedEvent | SiblingsEvent | InteractivityEvent | LayoutStateEvent
+  ) {
+    // @ts-expect-error
+    this.events[event.type](event);
   }
 
   private init() {

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -30,6 +30,8 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
   siblingsScrollElement: DnDStoreInterface["siblingsScrollElement"];
 
+  layoutState: DnDStoreInterface["layoutState"];
+
   private isDOM: boolean;
 
   private isInitialized: boolean;
@@ -47,6 +49,8 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
     this.siblingsBoundaries = {};
     this.siblingsScrollElement = {};
+
+    this.layoutState = "pending";
 
     this.tracker = new Tracker();
 

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -77,6 +77,10 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
   }
 
   onStateChange(state: LayoutState) {
+    // Prevent emit a state change event if the state is not changing.
+    // May change this behaviour later.
+    if (state === this.layoutState) return;
+
     this.layoutState = state;
 
     this.emitEvent({

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -8,9 +8,9 @@
 import type { CoreInstanceInterface, Rect } from "@dflex/core-instance";
 import type { ELmBranch } from "@dflex/dom-gen";
 import type { ElmInstance } from "@dflex/store";
+import type { LayoutState } from "../types";
 
 import type { ScrollInterface } from "../Plugins/Scroll";
-import type { ThresholdInterface } from "../Plugins/Threshold";
 import type { TrackerInterface } from "../Plugins/Tracker";
 
 export interface BoundariesOffset {
@@ -77,7 +77,8 @@ export interface DnDStoreInterface {
   tracker: TrackerInterface;
   siblingsBoundaries: { [siblingKey: string]: BoundariesOffset };
   siblingsScrollElement: { [siblingKey: string]: ScrollInterface };
-  layoutState: "pending" | "ready" | "dragging" | "dragEnd" | "dragCancel";
+  layoutState: LayoutState;
+  onStateChange: (state: LayoutState) => void;
   register(element: ElmInstance, x?: boolean): void;
   getInitialELmRectById(id: string): Rect | undefined;
   getELmTranslateById(id: string): Translate;

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -77,6 +77,7 @@ export interface DnDStoreInterface {
   tracker: TrackerInterface;
   siblingsBoundaries: { [siblingKey: string]: BoundariesOffset };
   siblingsScrollElement: { [siblingKey: string]: ScrollInterface };
+  layoutState: "pending" | "ready" | "dragging" | "dragEnd" | "dragCancel";
   register(element: ElmInstance, x?: boolean): void;
   getInitialELmRectById(id: string): Rect | undefined;
   getELmTranslateById(id: string): Translate;

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -8,7 +8,13 @@
 import type { CoreInstanceInterface, Rect } from "@dflex/core-instance";
 import type { ELmBranch } from "@dflex/dom-gen";
 import type { ElmInstance } from "@dflex/store";
-import type { LayoutState } from "../types";
+
+import type {
+  Events,
+  DnDEventTypes,
+  DraggedEvent,
+  LayoutState,
+} from "../types";
 
 import type { ScrollInterface } from "../Plugins/Scroll";
 import type { TrackerInterface } from "../Plugins/Tracker";
@@ -78,7 +84,8 @@ export interface DnDStoreInterface {
   siblingsBoundaries: { [siblingKey: string]: BoundariesOffset };
   siblingsScrollElement: { [siblingKey: string]: ScrollInterface };
   layoutState: LayoutState;
-  onStateChange: (state: LayoutState) => void;
+  onStateChange(state: LayoutState): void;
+  emitEvent(event: DraggedEvent): void;
   register(element: ElmInstance, x?: boolean): void;
   getInitialELmRectById(id: string): Rect | undefined;
   getELmTranslateById(id: string): Translate;

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -26,6 +26,8 @@ class Draggable
   extends AbstractDraggable<CoreInstanceInterface>
   implements DraggableDnDInterface
 {
+  private isLayoutStateUpdated: boolean;
+
   tempIndex: number;
 
   operationID: string;
@@ -85,6 +87,8 @@ class Draggable
     const { element, parent } = store.getElmTreeById(id);
 
     super(element, initCoordinates);
+
+    this.isLayoutStateUpdated = false;
 
     const { order } = element;
 
@@ -365,6 +369,11 @@ class Draggable
    * @param y -
    */
   dragAt(x: number, y: number) {
+    if (!this.isLayoutStateUpdated) {
+      this.isLayoutStateUpdated = true;
+      store.layoutState = "dragging";
+    }
+
     let filteredY = y;
     let filteredX = x;
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -371,7 +371,7 @@ class Draggable
   dragAt(x: number, y: number) {
     if (!this.isLayoutStateUpdated) {
       this.isLayoutStateUpdated = true;
-      store.layoutState = "dragging";
+      store.onStateChange("dragging");
     }
 
     let filteredY = y;

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -9,6 +9,7 @@ import type { CoreInstanceInterface } from "@dflex/core-instance";
 import store from "../DnDStore";
 
 import type { TempOffset, DraggableDnDInterface } from "../Draggable";
+import type { FinalDndOpts } from "../types";
 
 /**
  * Class includes all transformation methods related to droppable.
@@ -48,8 +49,15 @@ class Droppable {
 
   private regularDragging: boolean;
 
-  constructor(draggable: DraggableDnDInterface) {
+  protected eventHandlers: FinalDndOpts["events"];
+
+  constructor(
+    draggable: DraggableDnDInterface,
+    eventHandlers: FinalDndOpts["events"]
+  ) {
     this.draggable = draggable;
+
+    this.eventHandlers = eventHandlers;
 
     this.elmTransitionY = 0;
 
@@ -272,7 +280,7 @@ class Droppable {
       );
     }
 
-    // element.onDragOver();
+    this.eventHandlers.onDragOver(element.id, element.order.self);
 
     const { currentLeft: elmLeft, currentTop: elmTop } = element;
 
@@ -294,7 +302,7 @@ class Droppable {
       this.siblingsEmptyElmIndex
     );
 
-    // element.onDragLeave();
+    this.eventHandlers.onDragOver(element.id, element.order.self);
   }
 
   private isElemAboveDragged(elmCurrentOffsetTop: number) {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -280,7 +280,7 @@ class Droppable {
       );
     }
 
-    this.eventHandlers.onDragOver(element.id, element.order.self);
+    this.eventHandlers.onDragOver.call(this, element.id, element.order.self);
 
     const { currentLeft: elmLeft, currentTop: elmTop } = element;
 
@@ -302,7 +302,7 @@ class Droppable {
       this.siblingsEmptyElmIndex
     );
 
-    this.eventHandlers.onDragOver(element.id, element.order.self);
+    this.eventHandlers.onDragOver.call(this, element.id, element.order.self);
   }
 
   private isElemAboveDragged(elmCurrentOffsetTop: number) {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -52,6 +52,8 @@ class Droppable {
 
   private isOnDragOutContainerEvtEmitted: boolean;
 
+  private isOnDragOutThresholdEvtEmitted: boolean;
+
   constructor(draggable: DraggableDnDInterface) {
     this.draggable = draggable;
 
@@ -111,6 +113,7 @@ class Droppable {
     }
 
     this.isOnDragOutContainerEvtEmitted = false;
+    this.isOnDragOutThresholdEvtEmitted = false;
   }
 
   /**
@@ -831,12 +834,16 @@ class Droppable {
     this.draggable.setDraggedMovingDown(y);
 
     if (this.draggable.isOutThreshold()) {
-      store.emitEvent({
-        id: this.draggable.draggedElm.id,
-        index: this.getDraggedTempIndex(),
-        timeStamp: Date.now(),
-        type: "onDragOutThreshold",
-      } as DraggedEvent);
+      if (!this.isOnDragOutThresholdEvtEmitted) {
+        store.emitEvent({
+          id: this.draggable.draggedElm.id,
+          index: this.getDraggedTempIndex(),
+          timeStamp: Date.now(),
+          type: "onDragOutThreshold",
+        } as DraggedEvent);
+
+        this.isOnDragOutThresholdEvtEmitted = true;
+      }
 
       this.scrollManager(x, y);
 
@@ -867,6 +874,10 @@ class Droppable {
       }
 
       return;
+    }
+
+    if (this.isOnDragOutThresholdEvtEmitted) {
+      this.isOnDragOutThresholdEvtEmitted = false;
     }
 
     /**

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -175,9 +175,9 @@ class EndDroppable extends Droppable {
         isFallback = true;
 
         this.undoList(siblings);
-        store.onStateChange("dragCancel");
       }
-      store.onStateChange("dragEnd");
+
+      store.onStateChange(isFallback ? "dragCancel" : "dragEnd");
     }
 
     this.draggable.endDragging(isFallback);

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -8,15 +8,19 @@
 import type { ELmBranch } from "@dflex/dom-gen";
 
 import store from "../DnDStore";
-import type { DraggableDnDInterface } from "../Draggable";
-
 import Droppable from "./Droppable";
+
+import type { DraggableDnDInterface } from "../Draggable";
+import type { FinalDndOpts } from "../types";
 
 class EndDroppable extends Droppable {
   private spliceAt: number;
 
-  constructor(draggable: DraggableDnDInterface) {
-    super(draggable);
+  constructor(
+    draggable: DraggableDnDInterface,
+    eventHandlers: FinalDndOpts["events"]
+  ) {
+    super(draggable, eventHandlers);
     this.spliceAt = -1;
   }
 
@@ -175,7 +179,9 @@ class EndDroppable extends Droppable {
         isFallback = true;
 
         this.undoList(siblings);
+        store.layoutState = "dragCancel";
       }
+      store.layoutState = "dragEnd";
     }
 
     this.draggable.endDragging(isFallback);

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -11,16 +11,12 @@ import store from "../DnDStore";
 import Droppable from "./Droppable";
 
 import type { DraggableDnDInterface } from "../Draggable";
-import type { FinalDndOpts } from "../types";
 
 class EndDroppable extends Droppable {
   private spliceAt: number;
 
-  constructor(
-    draggable: DraggableDnDInterface,
-    eventHandlers: FinalDndOpts["events"]
-  ) {
-    super(draggable, eventHandlers);
+  constructor(draggable: DraggableDnDInterface) {
+    super(draggable);
     this.spliceAt = -1;
   }
 

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -179,9 +179,9 @@ class EndDroppable extends Droppable {
         isFallback = true;
 
         this.undoList(siblings);
-        store.layoutState = "dragCancel";
+        store.onStateChange("dragCancel");
       }
-      store.layoutState = "dragEnd";
+      store.onStateChange("dragEnd");
     }
 
     this.draggable.endDragging(isFallback);

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -14,21 +14,6 @@ import { ScrollInput, ScrollInterface } from "./types";
 const OVERFLOW_REGEX = /(auto|scroll|overlay)/;
 const MAX_LOOP_ELEMENTS_TO_WARN = 16;
 
-function getScrollFromDocument(): Element | HTMLElement {
-  return document.scrollingElement || document.documentElement;
-}
-
-// function hasOverflow(element: Element) {
-//   const computedStyle = getComputedStyle(element);
-
-//   const overflow =
-//     computedStyle.getPropertyValue("overflow") +
-//     computedStyle.getPropertyValue("overflow-y") +
-//     computedStyle.getPropertyValue("overflow-x");
-
-//   return overflowRegex.test(overflow);
-// }
-
 function isStaticallyPositioned(element: Element) {
   const computedStyle = getComputedStyle(element);
   const position = computedStyle.getPropertyValue("position");
@@ -42,14 +27,6 @@ class Scroll implements ScrollInterface {
   threshold: ScrollInterface["threshold"] | null;
 
   siblingKey: string;
-
-  viewportHeight!: number;
-
-  viewportWidth!: number;
-
-  offsetHeight?: number;
-
-  offsetWidth?: number;
 
   scrollEventCallback: ScrollInterface["scrollEventCallback"];
 
@@ -92,7 +69,6 @@ class Scroll implements ScrollInterface {
 
     this.siblingKey = requiredBranchKey;
 
-    // @ts-expect-error
     this.scrollContainerRef = this.getScrollContainer(element);
 
     this.setScrollRect();
@@ -111,7 +87,7 @@ class Scroll implements ScrollInterface {
     if (!element) {
       this.hasDocumentAsContainer = true;
 
-      return getScrollFromDocument();
+      return document.documentElement;
     }
 
     const computedStyle = getComputedStyle(element);
@@ -172,7 +148,7 @@ Please provide scroll container by ref/id when registering the element or turn o
     ) {
       this.hasDocumentAsContainer = true;
 
-      return getScrollFromDocument();
+      return document.documentElement;
     }
 
     return scrollContainer;

--- a/packages/dnd/src/index.ts
+++ b/packages/dnd/src/index.ts
@@ -7,4 +7,4 @@
 export { default as store } from "./DnDStore";
 export { default as DnD } from "./DnD";
 
-export type { DndOpts } from "./types";
+export type { DndOpts, LayoutState } from "./types";

--- a/packages/dnd/src/index.ts
+++ b/packages/dnd/src/index.ts
@@ -7,4 +7,12 @@
 export { default as store } from "./DnDStore";
 export { default as DnD } from "./DnD";
 
-export type { DndOpts, LayoutState } from "./types";
+export type {
+  DndOpts,
+  DnDEventTypes,
+  LayoutState,
+  DraggedEvent,
+  InteractivityEvent,
+  SiblingsEvent,
+  LayoutStateEvent,
+} from "./types";

--- a/packages/dnd/src/types.ts
+++ b/packages/dnd/src/types.ts
@@ -27,11 +27,17 @@ export interface RestrictionsStatus {
   isSelfRestricted: boolean;
 }
 
+interface events {
+  onDragOver: (elementID: string, index: number) => unknown;
+  onDragLeave: (elementID: string, index: number) => unknown;
+}
+
 export interface FinalDndOpts {
   threshold: ThresholdInterface["thresholdPercentages"];
   restrictions: Restrictions;
   restrictionsStatus: RestrictionsStatus;
   scroll: ScrollOptWithThreshold;
+  events: events;
 }
 
 export interface DndOpts {
@@ -41,4 +47,5 @@ export interface DndOpts {
     container?: Partial<Restrictions["container"]>;
   };
   scroll?: Partial<ScrollOptWithPartialThreshold>;
+  events?: Partial<events>;
 }

--- a/packages/dnd/src/types.ts
+++ b/packages/dnd/src/types.ts
@@ -8,6 +8,81 @@ import type { Restrictions } from "./Draggable";
 
 import type { ThresholdInterface } from "./Plugins/Threshold";
 
+export type DnDEventTypes =
+  | "onDragOver"
+  | "onDragLeave"
+  | "onDragOutContainer"
+  | "onDragOutThreshold"
+  | "onLiftUpSiblings"
+  | "onMoveDownSiblings"
+  | "onStateChange";
+
+export type LayoutState =
+  | "pending"
+  | "ready"
+  | "dragging"
+  | "dragEnd"
+  | "dragCancel";
+
+interface DnDEvent {
+  /** Returns the element that is being dragged */
+  type: DnDEventTypes;
+
+  /** Returns the time at which the event was created  */
+  timeStamp: number;
+}
+
+export interface DraggedEvent extends DnDEvent {
+  /** Returns element id in the registry  */
+  id: string;
+
+  /** Returns dragged temp index */
+  index: number;
+}
+
+export interface InteractivityEvent extends DnDEvent {
+  /** Returns element id in the registry  */
+  id: string;
+
+  /** Returns element current index */
+  index: number;
+
+  /** Returns the element that triggered the event  */
+  target: HTMLElement;
+}
+
+export interface SiblingsEvent extends DnDEvent {
+  /** Returns the index where the dragged left  */
+  from: number;
+
+  /** Returns the last index effected of the dragged leaving/entering  */
+  to: number;
+
+  /** Returns an array of sibling ids in order  */
+  siblings: Array<string>;
+}
+
+export interface LayoutStateEvent extends DnDEvent {
+  layoutState: LayoutState;
+}
+
+export interface Events {
+  /** Drag events  */
+  onDragOutContainer: (event: DraggedEvent) => unknown;
+  onDragOutThreshold: (event: DraggedEvent) => unknown;
+
+  /** Interactivity events  */
+  onDragOver: (event: InteractivityEvent) => unknown;
+  onDragLeave: (event: InteractivityEvent) => unknown;
+
+  /** Sibling events  */
+  onLiftUpSiblings: (event: SiblingsEvent) => unknown;
+  onMoveDownSiblings: (event: SiblingsEvent) => unknown;
+
+  /** Layout events  */
+  onStateChange: (layoutState: LayoutStateEvent) => unknown;
+}
+
 export interface ScrollOptWithoutThreshold {
   enable: boolean;
   initialSpeed: number;
@@ -25,19 +100,6 @@ export interface ScrollOptWithThreshold extends ScrollOptWithoutThreshold {
 export interface RestrictionsStatus {
   isContainerRestricted: boolean;
   isSelfRestricted: boolean;
-}
-
-export type LayoutState =
-  | "pending"
-  | "ready"
-  | "dragging"
-  | "dragEnd"
-  | "dragCancel";
-
-export interface Events {
-  onDragOver: (elementID: string, index: number) => unknown;
-  onDragLeave: (elementID: string, index: number) => unknown;
-  onStateChange: () => LayoutState;
 }
 
 export interface FinalDndOpts {

--- a/packages/dnd/src/types.ts
+++ b/packages/dnd/src/types.ts
@@ -27,9 +27,17 @@ export interface RestrictionsStatus {
   isSelfRestricted: boolean;
 }
 
-interface events {
+export type LayoutState =
+  | "pending"
+  | "ready"
+  | "dragging"
+  | "dragEnd"
+  | "dragCancel";
+
+export interface Events {
   onDragOver: (elementID: string, index: number) => unknown;
   onDragLeave: (elementID: string, index: number) => unknown;
+  onStateChange: () => LayoutState;
 }
 
 export interface FinalDndOpts {
@@ -37,7 +45,7 @@ export interface FinalDndOpts {
   restrictions: Restrictions;
   restrictionsStatus: RestrictionsStatus;
   scroll: ScrollOptWithThreshold;
-  events: events;
+  events: Events;
 }
 
 export interface DndOpts {
@@ -47,5 +55,5 @@ export interface DndOpts {
     container?: Partial<Restrictions["container"]>;
   };
   scroll?: Partial<ScrollOptWithPartialThreshold>;
-  events?: Partial<events>;
+  events?: Partial<Events>;
 }

--- a/packages/dnd/src/utils/extractOpts.ts
+++ b/packages/dnd/src/utils/extractOpts.ts
@@ -14,7 +14,7 @@ import type { DndOpts, FinalDndOpts } from "../types";
 
 function noop() {}
 
-export const defaultOpts: DndOpts = Object.freeze({
+export const defaultOpts: FinalDndOpts = Object.freeze({
   threshold: {
     vertical: 60,
     horizontal: 60,
@@ -47,6 +47,7 @@ export const defaultOpts: DndOpts = Object.freeze({
   events: {
     onDragOver: noop,
     onDragLeave: noop,
+    onStateChange: noop,
   },
 });
 

--- a/packages/dnd/src/utils/extractOpts.ts
+++ b/packages/dnd/src/utils/extractOpts.ts
@@ -12,6 +12,8 @@
 
 import type { DndOpts, FinalDndOpts } from "../types";
 
+function noop() {}
+
 export const defaultOpts: DndOpts = Object.freeze({
   threshold: {
     vertical: 60,
@@ -40,6 +42,11 @@ export const defaultOpts: DndOpts = Object.freeze({
       vertical: 15,
       horizontal: 15,
     },
+  },
+
+  events: {
+    onDragOver: noop,
+    onDragLeave: noop,
   },
 });
 
@@ -107,6 +114,12 @@ export function extractOpts(opts: DndOpts) {
 
       options.restrictionsStatus.isSelfRestricted = isSelfRestricted;
       options.restrictionsStatus.isContainerRestricted = isContainerRestricted;
+    } else if (props === "events") {
+      Object.keys(options.events).forEach((event) => {
+        if (typeof options.events[event] !== "function") {
+          options.events[event] = noop;
+        }
+      });
     }
   });
 

--- a/packages/dnd/src/utils/extractOpts.ts
+++ b/packages/dnd/src/utils/extractOpts.ts
@@ -47,6 +47,10 @@ export const defaultOpts: FinalDndOpts = Object.freeze({
   events: {
     onDragOver: noop,
     onDragLeave: noop,
+    onDragOutContainer: noop,
+    onDragOutThreshold: noop,
+    onLiftUpSiblings: noop,
+    onMoveDownSiblings: noop,
     onStateChange: noop,
   },
 });

--- a/packages/dnd/test/utils/__snapshots__/extractOpts.test.ts.snap
+++ b/packages/dnd/test/utils/__snapshots__/extractOpts.test.ts.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Returns the default options with input restrictions/threshold/scroll 1`] = `
+exports[`extractOpts Returns default options when empty object is passed 1`] = `
 Object {
+  "events": Object {
+    "onDragLeave": [Function],
+    "onDragOver": [Function],
+  },
   "restrictions": Object {
     "container": Object {
-      "allowLeavingFromBottom": false,
+      "allowLeavingFromBottom": true,
       "allowLeavingFromLeft": true,
       "allowLeavingFromRight": true,
       "allowLeavingFromTop": true,
@@ -13,30 +17,34 @@ Object {
       "allowLeavingFromBottom": true,
       "allowLeavingFromLeft": true,
       "allowLeavingFromRight": true,
-      "allowLeavingFromTop": false,
+      "allowLeavingFromTop": true,
     },
   },
   "restrictionsStatus": Object {
-    "isContainerRestricted": true,
-    "isSelfRestricted": true,
+    "isContainerRestricted": false,
+    "isSelfRestricted": false,
   },
   "scroll": Object {
     "enable": true,
     "initialSpeed": 10,
     "threshold": Object {
-      "horizontal": 9000,
+      "horizontal": 15,
       "vertical": 15,
     },
   },
   "threshold": Object {
-    "horizontal": 9000,
+    "horizontal": 60,
     "vertical": 60,
   },
 }
 `;
 
-exports[`extractOpts Returns default options when empty object is passed 1`] = `
+exports[`extractOpts Returns the correct event handler function 1`] = `
 Object {
+  "events": Object {
+    "onDragLeave": [Function],
+    "onDragOver": [Function],
+  },
   "restrictions": Object {
     "container": Object {
       "allowLeavingFromBottom": true,
@@ -72,6 +80,10 @@ Object {
 
 exports[`extractOpts Returns the default options with input restrictions/allowLeavingFromBottom 1`] = `
 Object {
+  "events": Object {
+    "onDragLeave": [Function],
+    "onDragOver": [Function],
+  },
   "restrictions": Object {
     "container": Object {
       "allowLeavingFromBottom": false,
@@ -105,8 +117,51 @@ Object {
 }
 `;
 
+exports[`extractOpts Returns the default options with input restrictions/threshold/scroll 1`] = `
+Object {
+  "events": Object {
+    "onDragLeave": [Function],
+    "onDragOver": [Function],
+  },
+  "restrictions": Object {
+    "container": Object {
+      "allowLeavingFromBottom": false,
+      "allowLeavingFromLeft": true,
+      "allowLeavingFromRight": true,
+      "allowLeavingFromTop": true,
+    },
+    "self": Object {
+      "allowLeavingFromBottom": true,
+      "allowLeavingFromLeft": true,
+      "allowLeavingFromRight": true,
+      "allowLeavingFromTop": false,
+    },
+  },
+  "restrictionsStatus": Object {
+    "isContainerRestricted": true,
+    "isSelfRestricted": true,
+  },
+  "scroll": Object {
+    "enable": true,
+    "initialSpeed": 10,
+    "threshold": Object {
+      "horizontal": 9000,
+      "vertical": 15,
+    },
+  },
+  "threshold": Object {
+    "horizontal": 9000,
+    "vertical": 60,
+  },
+}
+`;
+
 exports[`extractOpts Returns the default options with input scroll/threshold 1`] = `
 Object {
+  "events": Object {
+    "onDragLeave": [Function],
+    "onDragOver": [Function],
+  },
   "restrictions": Object {
     "container": Object {
       "allowLeavingFromBottom": true,
@@ -142,6 +197,10 @@ Object {
 
 exports[`extractOpts Returns the default options with input scroll/threshold/enable 1`] = `
 Object {
+  "events": Object {
+    "onDragLeave": [Function],
+    "onDragOver": [Function],
+  },
   "restrictions": Object {
     "container": Object {
       "allowLeavingFromBottom": true,
@@ -177,6 +236,10 @@ Object {
 
 exports[`extractOpts Returns the default options with self restrictions/allowLeavingFromLeft+right 1`] = `
 Object {
+  "events": Object {
+    "onDragLeave": [Function],
+    "onDragOver": [Function],
+  },
   "restrictions": Object {
     "container": Object {
       "allowLeavingFromBottom": true,

--- a/packages/dnd/test/utils/__snapshots__/extractOpts.test.ts.snap
+++ b/packages/dnd/test/utils/__snapshots__/extractOpts.test.ts.snap
@@ -4,7 +4,11 @@ exports[`extractOpts Returns default options when empty object is passed 1`] = `
 Object {
   "events": Object {
     "onDragLeave": [Function],
+    "onDragOutContainer": [Function],
+    "onDragOutThreshold": [Function],
     "onDragOver": [Function],
+    "onLiftUpSiblings": [Function],
+    "onMoveDownSiblings": [Function],
     "onStateChange": [Function],
   },
   "restrictions": Object {
@@ -44,7 +48,11 @@ exports[`extractOpts Returns the correct event handler function 1`] = `
 Object {
   "events": Object {
     "onDragLeave": [Function],
+    "onDragOutContainer": [Function],
+    "onDragOutThreshold": [Function],
     "onDragOver": [Function],
+    "onLiftUpSiblings": [Function],
+    "onMoveDownSiblings": [Function],
     "onStateChange": [Function],
   },
   "restrictions": Object {
@@ -84,7 +92,11 @@ exports[`extractOpts Returns the default options with input restrictions/allowLe
 Object {
   "events": Object {
     "onDragLeave": [Function],
+    "onDragOutContainer": [Function],
+    "onDragOutThreshold": [Function],
     "onDragOver": [Function],
+    "onLiftUpSiblings": [Function],
+    "onMoveDownSiblings": [Function],
     "onStateChange": [Function],
   },
   "restrictions": Object {
@@ -124,7 +136,11 @@ exports[`extractOpts Returns the default options with input restrictions/thresho
 Object {
   "events": Object {
     "onDragLeave": [Function],
+    "onDragOutContainer": [Function],
+    "onDragOutThreshold": [Function],
     "onDragOver": [Function],
+    "onLiftUpSiblings": [Function],
+    "onMoveDownSiblings": [Function],
     "onStateChange": [Function],
   },
   "restrictions": Object {
@@ -164,7 +180,11 @@ exports[`extractOpts Returns the default options with input scroll/threshold 1`]
 Object {
   "events": Object {
     "onDragLeave": [Function],
+    "onDragOutContainer": [Function],
+    "onDragOutThreshold": [Function],
     "onDragOver": [Function],
+    "onLiftUpSiblings": [Function],
+    "onMoveDownSiblings": [Function],
     "onStateChange": [Function],
   },
   "restrictions": Object {
@@ -204,7 +224,11 @@ exports[`extractOpts Returns the default options with input scroll/threshold/ena
 Object {
   "events": Object {
     "onDragLeave": [Function],
+    "onDragOutContainer": [Function],
+    "onDragOutThreshold": [Function],
     "onDragOver": [Function],
+    "onLiftUpSiblings": [Function],
+    "onMoveDownSiblings": [Function],
     "onStateChange": [Function],
   },
   "restrictions": Object {
@@ -244,7 +268,11 @@ exports[`extractOpts Returns the default options with self restrictions/allowLea
 Object {
   "events": Object {
     "onDragLeave": [Function],
+    "onDragOutContainer": [Function],
+    "onDragOutThreshold": [Function],
     "onDragOver": [Function],
+    "onLiftUpSiblings": [Function],
+    "onMoveDownSiblings": [Function],
     "onStateChange": [Function],
   },
   "restrictions": Object {

--- a/packages/dnd/test/utils/__snapshots__/extractOpts.test.ts.snap
+++ b/packages/dnd/test/utils/__snapshots__/extractOpts.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "events": Object {
     "onDragLeave": [Function],
     "onDragOver": [Function],
+    "onStateChange": [Function],
   },
   "restrictions": Object {
     "container": Object {
@@ -44,6 +45,7 @@ Object {
   "events": Object {
     "onDragLeave": [Function],
     "onDragOver": [Function],
+    "onStateChange": [Function],
   },
   "restrictions": Object {
     "container": Object {
@@ -83,6 +85,7 @@ Object {
   "events": Object {
     "onDragLeave": [Function],
     "onDragOver": [Function],
+    "onStateChange": [Function],
   },
   "restrictions": Object {
     "container": Object {
@@ -122,6 +125,7 @@ Object {
   "events": Object {
     "onDragLeave": [Function],
     "onDragOver": [Function],
+    "onStateChange": [Function],
   },
   "restrictions": Object {
     "container": Object {
@@ -161,6 +165,7 @@ Object {
   "events": Object {
     "onDragLeave": [Function],
     "onDragOver": [Function],
+    "onStateChange": [Function],
   },
   "restrictions": Object {
     "container": Object {
@@ -200,6 +205,7 @@ Object {
   "events": Object {
     "onDragLeave": [Function],
     "onDragOver": [Function],
+    "onStateChange": [Function],
   },
   "restrictions": Object {
     "container": Object {
@@ -239,6 +245,7 @@ Object {
   "events": Object {
     "onDragLeave": [Function],
     "onDragOver": [Function],
+    "onStateChange": [Function],
   },
   "restrictions": Object {
     "container": Object {

--- a/packages/dnd/test/utils/extractOpts.test.ts
+++ b/packages/dnd/test/utils/extractOpts.test.ts
@@ -64,36 +64,51 @@ describe("extractOpts", () => {
 
     expect(opts.restrictions.container.allowLeavingFromBottom).toEqual(false);
   });
-});
 
-it("Returns the default options with input restrictions/threshold/scroll", () => {
-  const opts = extractOpts({
-    restrictions: {
-      container: {
-        allowLeavingFromBottom: false,
+  it("Returns the default options with input restrictions/threshold/scroll", () => {
+    const opts = extractOpts({
+      restrictions: {
+        container: {
+          allowLeavingFromBottom: false,
+        },
+        self: {
+          allowLeavingFromTop: false,
+        },
       },
-      self: {
-        allowLeavingFromTop: false,
-      },
-    },
-    threshold: {
-      horizontal: 9000,
-    },
-    scroll: {
       threshold: {
         horizontal: 9000,
       },
-    },
+      scroll: {
+        threshold: {
+          horizontal: 9000,
+        },
+      },
+    });
+
+    expect(opts).toMatchSnapshot();
+
+    expect(opts.restrictions.container.allowLeavingFromBottom).toEqual(false);
+    expect(opts.restrictions.self.allowLeavingFromTop).toEqual(false);
+
+    expect(opts.restrictionsStatus.isContainerRestricted).toEqual(true);
+    expect(opts.restrictionsStatus.isSelfRestricted).toEqual(true);
+
+    expect(opts.threshold.horizontal).toEqual(9000);
+    expect(opts.scroll.threshold.horizontal).toEqual(9000);
   });
 
-  expect(opts).toMatchSnapshot();
+  it("Returns the correct event handler function", () => {
+    function onDragLeave(index, id) {
+      // eslint-disable-next-line no-console
+      console.log(index, id);
+    }
 
-  expect(opts.restrictions.container.allowLeavingFromBottom).toEqual(false);
-  expect(opts.restrictions.self.allowLeavingFromTop).toEqual(false);
+    const opts = extractOpts({
+      events: {
+        onDragLeave,
+      },
+    });
 
-  expect(opts.restrictionsStatus.isContainerRestricted).toEqual(true);
-  expect(opts.restrictionsStatus.isSelfRestricted).toEqual(true);
-
-  expect(opts.threshold.horizontal).toEqual(9000);
-  expect(opts.scroll.threshold.horizontal).toEqual(9000);
+    expect(opts).toMatchSnapshot();
+  });
 });

--- a/packages/dnd/test/utils/extractOpts.test.ts
+++ b/packages/dnd/test/utils/extractOpts.test.ts
@@ -97,6 +97,14 @@ describe("extractOpts", () => {
     expect(opts.scroll.threshold.horizontal).toEqual(9000);
   });
 
+  it("All three events handlers are defined", () => {
+    const opts = extractOpts({});
+
+    expect(opts.events.onDragLeave).toBeDefined();
+    expect(opts.events.onDragOver).toBeDefined();
+    expect(opts.events.onStateChange).toBeDefined();
+  });
+
   it("Returns the correct event handler function", () => {
     function onDragLeave(index, id) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
- [x] Remove unnecessary instances from Scroll. 
- [x] Refactor auto-scroll to a manager method (make more sense rn).
- [x] Add  event `onStateChange` with  **5 different states** for the layout: "pending" | "ready" | "dragging" | "dragEnd" | "dragCancel"
   - **pending**: when DnD is not initiated but not activated yet.
   - **ready**: When clicking over the registered element.
   -  **dragging** and **dragEnd** as expected.
   - **dragCancel** when releasing the drag without settling in the new position.
```ts
type LayoutState = "pending"
  | "ready"
  | "dragging"
  | "dragEnd"
  | "dragCancel";
```
- [x] Add 5 events categories:
- **Drag events**: `onDragOutContainer` | `onDragOutThreshold` - fired with `DraggedEvent`
- **Interactivity events**:  `onDragOver` | `onDragLeave`  - fired with `InteractivityEvent`
- **Sibling events**: `onLiftUpSiblings` | `onMoveDownSiblings`  - fired with `SiblingsEvent`
- **Layout events**: `onStateChange`  - fired with `LayoutStateEvent`

- [x] Refactor Jest snaps.