### PR TITLE
Refactor comparison to the core instance and extend the mechanism to include both axes

### DIFF
--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -131,6 +131,10 @@ class CoreInstance
     return elmCurrentOffsetTop < this.currentTop!;
   }
 
+  isPositionedLeft(elmCurrentOffsetLeft: number) {
+    return elmCurrentOffsetLeft < this.currentLeft!;
+  }
+
   transformElm() {
     if (this.animatedFrame !== null) {
       window.cancelAnimationFrame(this.animatedFrame);

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -127,6 +127,10 @@ class CoreInstance
     if (!this.isVisible) this.hasToTransform = true;
   }
 
+  isPositionedUnder(elmCurrentOffsetTop: number) {
+    return elmCurrentOffsetTop < this.currentTop!;
+  }
+
   transformElm() {
     if (this.animatedFrame !== null) {
       window.cancelAnimationFrame(this.animatedFrame);

--- a/packages/dnd/playgrounds/dflex-react-dnd/src/App.tsx
+++ b/packages/dnd/playgrounds/dflex-react-dnd/src/App.tsx
@@ -48,6 +48,10 @@ function App() {
           path="/component-based-event"
           element={<ComponentBasedEvent />}
         />
+        <Route
+          path="/horizontal"
+          element={<ContainerBasedEvent isHorizontal />}
+        ></Route>
         <Route path="/" element={<ContainerBasedEvent />}></Route>
       </Routes>
     </BrowserRouter>

--- a/packages/dnd/playgrounds/dflex-react-dnd/src/components/essential/List.css
+++ b/packages/dnd/playgrounds/dflex-react-dnd/src/components/essential/List.css
@@ -20,14 +20,12 @@
 }
 
 .list-container ul {
-  /* display: flex; */
   flex-direction: column;
   list-style: none;
   margin: 10px;
   padding: 8px;
   border: 4px #bac5c7 solid;
   background: #cecece;
-  /* height: fit-content; */
 }
 
 .list-container li {
@@ -46,5 +44,38 @@
   border-image: initial;
   border-color: transparent;
   padding: 8px;
+  transition: transform 0.2s cubic-bezier(0.2, 0, 0, 1) 0s;
+}
+
+.list-container-horizontal ul {
+  display: flex;
+  list-style: none;
+  margin: 50px;
+  padding: 8px;
+  border-radius: 30px;
+  border: 2px #bac5c7 solid;
+  background: #cecece;
+}
+
+.list-container-horizontal li {
+  display: flex;
+  justify-content: center;
+  justify-items: center;
+  align-items: center;
+  position: relative;
+  width: 180px;
+  height: 75px;
+  margin: 12px;
+  padding: 1px;
+  box-shadow: none;
+  user-select: none;
+  text-align: center;
+  font-size: small;
+  background: whitesmoke;
+  border-radius: 12px;
+  border-width: 2px;
+  border-style: solid;
+  border-image: initial;
+  border-color: violet;
   transition: transform 0.2s cubic-bezier(0.2, 0, 0, 1) 0s;
 }

--- a/packages/dnd/playgrounds/dflex-react-dnd/src/components/essential/Lists.tsx
+++ b/packages/dnd/playgrounds/dflex-react-dnd/src/components/essential/Lists.tsx
@@ -41,10 +41,15 @@ interface props {
     | typeof ContainerInContainerBasedEvent;
 
   Core: typeof CoreInComponentBasedEvent | typeof CoreInContainerBasedEvent;
+  className?: string;
 }
 
-const BaseApp = ({ Container, Core }: props) => (
-  <Container className="list-container list-height-fit">
+const BaseApp = ({
+  Container,
+  Core,
+  className = "list-container list-height-fit",
+}: props) => (
+  <Container className={className}>
     <Core id={`id-${ID_PARENT_1}`} component="ul" depth={1}>
       {firstContainer.map(({ label, id }) => (
         <Core depth={0} id={`id-${id}`} key={`k${id}`} component="li">
@@ -69,18 +74,20 @@ const BaseApp = ({ Container, Core }: props) => (
   </Container>
 );
 
-function ComponentBasedEvent() {
+function ComponentBasedEvent({ className }: { className?: string }) {
   return (
     <BaseApp
+      className={className}
       Core={CoreInComponentBasedEvent}
       Container={ContainerInComponentBasedEvent}
     />
   );
 }
 
-function ContainerBasedEvent() {
+function ContainerBasedEvent({ isHorizontal }: { isHorizontal?: boolean }) {
   return (
     <BaseApp
+      className={isHorizontal ? "list-container-horizontal" : undefined}
       Core={CoreInContainerBasedEvent}
       Container={ContainerInContainerBasedEvent}
     />

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -120,15 +120,14 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     let lastElemID = "";
 
     if (branch) {
-      hasSiblings = Array.isArray(branch);
-
-      if (hasSiblings) {
+      if (Array.isArray(branch)) {
+        hasSiblings = true;
         [firstElemID] = branch as string[];
 
         lastElemID = branch[branch.length - 1];
+      } else {
+        firstElemID = branch!;
       }
-    } else {
-      firstElemID = branch!;
     }
 
     return {
@@ -148,7 +147,7 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       this.registry[elmID].resume(scroll.scrollX, scroll.scrollY);
     }
 
-    this.assignSiblingsBoundaries(
+    this.assignSiblingsBoundariesAndAlignment(
       this.registry[elmID].keys.SK,
       this.registry[elmID].offset!
     );
@@ -356,20 +355,13 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
     }
   }
 
-  private setBranchDirection(key: string) {
-    // DO something here.
-  }
-
   onLoadListeners() {
     Object.keys(this.DOMGen.branches).forEach((branchKey) => {
       this.initSiblingsScrollAndVisibilityIfNecessary(branchKey);
-
-      // set branch elements direction.
-      this.setBranchDirection(branchKey);
     });
   }
 
-  private assignSiblingsBoundaries(SK: string, elemOffset: Rect) {
+  private assignSiblingsBoundariesAndAlignment(SK: string, elemOffset: Rect) {
     const elmRight = elemOffset.left + elemOffset.width;
 
     if (!this.siblingsBoundaries[SK]) {
@@ -385,8 +377,13 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
 
     const $ = this.siblingsBoundaries[SK];
 
+    let isHorizontal = false;
+
     if ($.maxLeft < elemOffset.left) {
       $.maxLeft = elemOffset.left;
+
+      isHorizontal = true;
+      this.siblingsAlignment[SK] = "Horizontal";
     }
 
     if ($.minRight > elmRight) {
@@ -397,6 +394,10 @@ class DnDStoreImp extends Store<CoreInstance> implements DnDStoreInterface {
       $.top = elemOffset.top;
     } else {
       $.bottom = elemOffset.top + elemOffset.height;
+    }
+
+    if (!isHorizontal) {
+      this.siblingsAlignment[SK] = "Vertical";
     }
   }
 

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -71,6 +71,7 @@ export interface DnDStoreInterface {
   tracker: TrackerInterface;
   siblingsBoundaries: { [siblingKey: string]: BoundariesOffset };
   siblingsScrollElement: { [siblingKey: string]: ScrollInterface };
+  siblingsAlignment: { [siblingKey: string]: "Horizontal" | "Vertical" | null };
   layoutState: LayoutState;
   onStateChange(state: LayoutState): void;
   emitEvent(event: DraggedEvent): void;

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -71,7 +71,7 @@ export interface DnDStoreInterface {
   tracker: TrackerInterface;
   siblingsBoundaries: { [siblingKey: string]: BoundariesOffset };
   siblingsScrollElement: { [siblingKey: string]: ScrollInterface };
-  siblingsAlignment: { [siblingKey: string]: "Horizontal" | "Vertical" | null };
+  siblingsAlignment: { [siblingKey: string]: "Horizontal" | "Vertical" };
   layoutState: LayoutState;
   onStateChange(state: LayoutState): void;
   emitEvent(event: DraggedEvent): void;

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -5,6 +5,11 @@ import type { DraggableDnDInterface } from "../Draggable";
 
 import store from "../DnDStore";
 
+import type {
+  DistanceCalculatorInterface,
+  EffectedElemDirection,
+} from "./types";
+
 function emitInteractiveEvent(
   type: InteractivityEvent["type"],
   element: CoreInstanceInterface
@@ -23,10 +28,10 @@ function emitInteractiveEvent(
  * Calculates the distance between two elements and update the targeted element
  * accordingly.
  */
-class DistanceCalculator {
+class DistanceCalculator implements DistanceCalculatorInterface {
   protected draggable: DraggableDnDInterface;
 
-  protected effectedElemDirection: 1 | -1;
+  protected effectedElemDirection: EffectedElemDirection;
 
   private elmTransitionY: number;
 
@@ -56,13 +61,16 @@ class DistanceCalculator {
     /**
      * Elements effected by dragged direction.
      */
-    this.effectedElemDirection = 1;
+    this.effectedElemDirection = {
+      x: 1,
+      y: 1,
+    };
 
     this.siblingsEmptyElmIndex = -1;
   }
 
-  protected setEffectedElemDirection(isUp: boolean) {
-    this.effectedElemDirection = isUp ? -1 : 1;
+  protected setEffectedElemDirectionV(isUp: boolean) {
+    this.effectedElemDirection.y = isUp ? -1 : 1;
   }
 
   private calculateYDistance(element: CoreInstanceInterface) {
@@ -102,7 +110,7 @@ class DistanceCalculator {
     if (draggedHight < elmHight) {
       // console.log("elmHight is bigger");
 
-      if (this.effectedElemDirection === -1) {
+      if (this.effectedElemDirection.x === -1) {
         // console.log("elm going up");
 
         this.draggedAccumulatedTransitionY += heightOffset;
@@ -118,7 +126,7 @@ class DistanceCalculator {
 
     // console.log("elmHight is smaller");
 
-    if (this.effectedElemDirection === -1) {
+    if (this.effectedElemDirection.x === -1) {
       // console.log("elm going up");
 
       this.draggedAccumulatedTransitionY -= heightOffset;
@@ -157,7 +165,7 @@ class DistanceCalculator {
 
     this.calculateYDistance(element);
 
-    this.draggable.incNumOfElementsTransformed(this.effectedElemDirection);
+    this.draggable.incNumOfElementsTransformed(this.effectedElemDirection.x);
 
     // TODO: always true for the first element
     if (!this.draggable.isOutActiveSiblingsContainer) {
@@ -206,7 +214,7 @@ class DistanceCalculator {
      */
     this.siblingsEmptyElmIndex = element.setYPosition(
       store.getElmSiblingsListById(this.draggable.draggedElm.id)!,
-      this.effectedElemDirection,
+      this.effectedElemDirection.y,
       this.elmTransitionY,
 
       this.draggable.operationID,

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -90,11 +90,6 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     this.effectedElemDirection.y = isUp ? -1 : 1;
   }
 
-  private resetIndicators() {
-    this.elmTransition.set(0, 0);
-    this.draggedOffset.set(0, 0);
-  }
-
   private calculateYDistance(element: CoreInstanceInterface) {
     const {
       currentLeft: elmLeft,
@@ -111,7 +106,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       },
     } = this.draggable;
 
-    this.resetIndicators();
+    this.elmTransition.set(0, 0);
+    this.draggedOffset.set(0, 0);
 
     // eslint-disable-next-line no-unused-vars
     const leftDifference = Math.abs(elmLeft! - draggedLeft);

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -36,7 +36,7 @@ class AxesCoordinates {
     this.y = y;
   }
 
-  set(x: number, y: number) {
+  setAxes(x: number, y: number) {
     this.x = x;
     this.y = y;
   }
@@ -106,8 +106,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       },
     } = this.draggable;
 
-    this.elmTransition.set(0, 0);
-    this.draggedOffset.set(0, 0);
+    this.elmTransition.setAxes(0, 0);
+    this.draggedOffset.setAxes(0, 0);
 
     // eslint-disable-next-line no-unused-vars
     const leftDifference = Math.abs(elmLeft! - draggedLeft);

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -55,17 +55,12 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   private draggedOffset: AxesCoordinates;
 
-  private draggedAccumulatedTransitionY: number;
-
-  private draggedAccumulatedTransitionX: number;
+  private draggedAccumulatedTransition: AxesCoordinates;
 
   private siblingsEmptyElmIndex: number;
 
   constructor(draggable: DraggableDnDInterface) {
     this.draggable = draggable;
-
-    this.draggedAccumulatedTransitionY = 0;
-    this.draggedAccumulatedTransitionX = 0;
 
     /**
      * Next element calculated transition space.
@@ -76,6 +71,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
      * Same as elmTransition but for dragged.
      */
     this.draggedOffset = new AxesCoordinates();
+
+    this.draggedAccumulatedTransition = new AxesCoordinates();
 
     /**
      * Elements effected by dragged direction.
@@ -121,7 +118,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
     const topDifference = Math.abs(elmTop! - draggedTop);
 
-    this.draggedAccumulatedTransitionY = topDifference;
+    this.draggedAccumulatedTransition.y = topDifference;
     this.elmTransition.y = topDifference;
 
     const heightOffset = Math.abs(draggedHight - elmHight);
@@ -134,7 +131,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       if (this.effectedElemDirection.y === -1) {
         // console.log("elm going up");
 
-        this.draggedAccumulatedTransitionY += heightOffset;
+        this.draggedAccumulatedTransition.y += heightOffset;
         this.draggedOffset.y = heightOffset;
       } else {
         // console.log("elm going down");
@@ -150,7 +147,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     if (this.effectedElemDirection.y === -1) {
       // console.log("elm going up");
 
-      this.draggedAccumulatedTransitionY -= heightOffset;
+      this.draggedAccumulatedTransition.y -= heightOffset;
       this.draggedOffset.y = -heightOffset;
     } else {
       // console.log("elm going down");
@@ -166,7 +163,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   private updateOccupiedTranslate(direction: 1 | -1) {
     this.draggable.occupiedTranslate.y +=
-      direction * this.draggedAccumulatedTransitionY;
+      direction * this.draggedAccumulatedTransition.y;
 
     this.draggable.occupiedTranslate.x += 0;
   }

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,0 +1,220 @@
+import type { CoreInstanceInterface } from "@dflex/core-instance";
+
+import type { InteractivityEvent } from "../types";
+import type { DraggableDnDInterface } from "../Draggable";
+
+import store from "../DnDStore";
+
+function emitInteractiveEvent(
+  type: InteractivityEvent["type"],
+  element: CoreInstanceInterface
+) {
+  const evt: InteractivityEvent = {
+    id: element.id,
+    index: element.order.self,
+    target: element.ref!,
+    timeStamp: Date.now(),
+    type,
+  };
+
+  store.emitEvent(evt);
+}
+/**
+ * Calculates the distance between two elements and update the targeted element
+ * accordingly.
+ */
+class DistanceCalculator {
+  protected draggable: DraggableDnDInterface;
+
+  protected effectedElemDirection: 1 | -1;
+
+  private elmTransitionY: number;
+
+  private elmTransitionX: number;
+
+  private draggedAccumulatedTransitionY: number;
+
+  private draggedAccumulatedTransitionX: number;
+
+  private draggedYOffset: number;
+
+  private draggedXOffset: number;
+
+  private siblingsEmptyElmIndex: number;
+
+  constructor(draggable: DraggableDnDInterface) {
+    this.draggable = draggable;
+
+    this.elmTransitionY = 0;
+    this.elmTransitionX = 0;
+
+    this.draggedAccumulatedTransitionY = 0;
+    this.draggedAccumulatedTransitionX = 0;
+    this.draggedYOffset = 0;
+    this.draggedXOffset = 0;
+
+    /**
+     * Elements effected by dragged direction.
+     */
+    this.effectedElemDirection = 1;
+
+    this.siblingsEmptyElmIndex = -1;
+  }
+
+  protected setEffectedElemDirection(isUp: boolean) {
+    this.effectedElemDirection = isUp ? -1 : 1;
+  }
+
+  private calculateYDistance(element: CoreInstanceInterface) {
+    const {
+      currentLeft: elmLeft,
+      currentTop: elmTop,
+      // @ts-expect-error
+      offset: { height: elmHight },
+    } = element;
+
+    const {
+      occupiedOffset: { currentLeft: draggedLeft, currentTop: draggedTop },
+      draggedElm: {
+        // @ts-expect-error
+        offset: { height: draggedHight },
+      },
+    } = this.draggable;
+
+    this.draggedYOffset = 0;
+    this.draggedXOffset = 0;
+
+    this.elmTransitionY = 0;
+    this.elmTransitionX = 0;
+
+    // eslint-disable-next-line no-unused-vars
+    const leftDifference = Math.abs(elmLeft! - draggedLeft);
+
+    const topDifference = Math.abs(elmTop! - draggedTop);
+
+    this.draggedAccumulatedTransitionY = topDifference;
+    this.elmTransitionY = topDifference;
+
+    const heightOffset = Math.abs(draggedHight - elmHight);
+
+    if (heightOffset === 0) return;
+
+    if (draggedHight < elmHight) {
+      // console.log("elmHight is bigger");
+
+      if (this.effectedElemDirection === -1) {
+        // console.log("elm going up");
+
+        this.draggedAccumulatedTransitionY += heightOffset;
+        this.draggedYOffset = heightOffset;
+      } else {
+        // console.log("elm going down");
+
+        this.elmTransitionY -= heightOffset;
+      }
+
+      return;
+    }
+
+    // console.log("elmHight is smaller");
+
+    if (this.effectedElemDirection === -1) {
+      // console.log("elm going up");
+
+      this.draggedAccumulatedTransitionY -= heightOffset;
+      this.draggedYOffset = -heightOffset;
+    } else {
+      // console.log("elm going down");
+
+      this.elmTransitionY += heightOffset;
+    }
+  }
+
+  protected updateOccupiedOffset(elmTop: number, elmLeft: number) {
+    this.draggable.occupiedOffset.currentTop = elmTop + this.draggedYOffset;
+    this.draggable.occupiedOffset.currentLeft = elmLeft;
+  }
+
+  private updateOccupiedTranslate(direction: 1 | -1) {
+    this.draggable.occupiedTranslate.y +=
+      direction * this.draggedAccumulatedTransitionY;
+
+    this.draggable.occupiedTranslate.x += 0;
+  }
+
+  /**
+   * Updates element instance and calculates the required transform distance. It
+   * invokes for each eligible element in the parent container.
+   *
+   * @param id -
+   */
+  protected updateElement(
+    id: string,
+    isUpdateDraggedTranslate: boolean,
+    draggedDirection?: 1 | -1
+  ) {
+    const element = store.registry[id];
+
+    this.calculateYDistance(element);
+
+    this.draggable.incNumOfElementsTransformed(this.effectedElemDirection);
+
+    // TODO: always true for the first element
+    if (!this.draggable.isOutActiveSiblingsContainer) {
+      /**
+       * By updating the dragged translate, we guarantee that dragged
+       * transformation will not triggered until dragged is over threshold
+       * which will be detected by isDraggedOutPosition.
+       *
+       * However, this is only effective when dragged is fit in its new
+       * translate.
+       *
+       * And we have new translate only once. The first element matched the
+       * condition is the breaking point element.
+       */
+
+      const {
+        // @ts-expect-error
+        offset: { width, height },
+        currentLeft,
+        currentTop,
+      } = element;
+
+      this.draggable.threshold.updateElementThresholdMatrix(
+        {
+          width,
+          height,
+          left: currentLeft!,
+          top: currentTop!,
+        },
+        false
+      );
+    }
+
+    emitInteractiveEvent("onDragOver", element);
+
+    const { currentLeft: elmLeft, currentTop: elmTop } = element;
+
+    this.updateOccupiedOffset(elmTop!, elmLeft!);
+
+    if (isUpdateDraggedTranslate) {
+      this.updateOccupiedTranslate(draggedDirection!);
+    }
+
+    /**
+     * Start transforming process
+     */
+    this.siblingsEmptyElmIndex = element.setYPosition(
+      store.getElmSiblingsListById(this.draggable.draggedElm.id)!,
+      this.effectedElemDirection,
+      this.elmTransitionY,
+
+      this.draggable.operationID,
+      this.siblingsEmptyElmIndex
+    );
+
+    emitInteractiveEvent("onDragLeave", element);
+  }
+}
+
+export default DistanceCalculator;

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,5 +1,5 @@
+/* eslint-disable max-classes-per-file */
 import type { CoreInstanceInterface } from "@dflex/core-instance";
-import type { Coordinates } from "@dflex/draggable";
 
 import type { InteractivityEvent } from "../types";
 import type { DraggableDnDInterface } from "../Draggable";
@@ -25,6 +25,23 @@ function emitInteractiveEvent(
 
   store.emitEvent(evt);
 }
+
+class AxesCoordinates {
+  x: number;
+
+  y: number;
+
+  constructor(x = 0, y = 0) {
+    this.x = x;
+    this.y = y;
+  }
+
+  set(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+}
+
 /**
  * Calculates the distance between two elements and update the targeted element
  * accordingly.
@@ -34,15 +51,13 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   protected effectedElemDirection: EffectedElemDirection;
 
-  private elmTransition: Coordinates;
+  private elmTransition: AxesCoordinates;
+
+  private draggedOffset: AxesCoordinates;
 
   private draggedAccumulatedTransitionY: number;
 
   private draggedAccumulatedTransitionX: number;
-
-  private draggedYOffset: number;
-
-  private draggedXOffset: number;
 
   private siblingsEmptyElmIndex: number;
 
@@ -51,16 +66,16 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
     this.draggedAccumulatedTransitionY = 0;
     this.draggedAccumulatedTransitionX = 0;
-    this.draggedYOffset = 0;
-    this.draggedXOffset = 0;
 
     /**
      * Next element calculated transition space.
      */
-    this.elmTransition = {
-      x: 0,
-      y: 0,
-    };
+    this.elmTransition = new AxesCoordinates();
+
+    /**
+     * Same as elmTransition but for dragged.
+     */
+    this.draggedOffset = new AxesCoordinates();
 
     /**
      * Elements effected by dragged direction.
@@ -79,10 +94,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
   }
 
   private resetIndicators() {
-    this.elmTransition = {
-      x: 0,
-      y: 0,
-    };
+    this.elmTransition.set(0, 0);
+    this.draggedOffset.set(0, 0);
   }
 
   private calculateYDistance(element: CoreInstanceInterface) {
@@ -100,9 +113,6 @@ class DistanceCalculator implements DistanceCalculatorInterface {
         offset: { height: draggedHight },
       },
     } = this.draggable;
-
-    this.draggedYOffset = 0;
-    this.draggedXOffset = 0;
 
     this.resetIndicators();
 
@@ -125,7 +135,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
         // console.log("elm going up");
 
         this.draggedAccumulatedTransitionY += heightOffset;
-        this.draggedYOffset = heightOffset;
+        this.draggedOffset.y = heightOffset;
       } else {
         // console.log("elm going down");
 
@@ -141,7 +151,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       // console.log("elm going up");
 
       this.draggedAccumulatedTransitionY -= heightOffset;
-      this.draggedYOffset = -heightOffset;
+      this.draggedOffset.y = -heightOffset;
     } else {
       // console.log("elm going down");
 
@@ -150,7 +160,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
   }
 
   protected updateOccupiedOffset(elmTop: number, elmLeft: number) {
-    this.draggable.occupiedOffset.currentTop = elmTop + this.draggedYOffset;
+    this.draggable.occupiedOffset.currentTop = elmTop + this.draggedOffset.y;
     this.draggable.occupiedOffset.currentLeft = elmLeft;
   }
 

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -57,7 +57,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   private draggedAccumulatedTransition: AxesCoordinates;
 
-  private siblingsEmptyElmIndex: number;
+  private siblingsEmptyElmIndex: AxesCoordinates;
 
   constructor(draggable: DraggableDnDInterface) {
     this.draggable = draggable;
@@ -74,6 +74,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
     this.draggedAccumulatedTransition = new AxesCoordinates();
 
+    this.siblingsEmptyElmIndex = new AxesCoordinates(-1, -1);
+
     /**
      * Elements effected by dragged direction.
      * Positive for up and right.
@@ -82,8 +84,6 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       x: 1,
       y: 1,
     };
-
-    this.siblingsEmptyElmIndex = -1;
   }
 
   protected setEffectedElemDirectionV(isUp: boolean) {
@@ -230,13 +230,13 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     /**
      * Start transforming process
      */
-    this.siblingsEmptyElmIndex = element.setYPosition(
+    this.siblingsEmptyElmIndex.y = element.setYPosition(
       store.getElmSiblingsListById(this.draggable.draggedElm.id)!,
       this.effectedElemDirection.y,
       this.elmTransition.y,
 
       this.draggable.operationID,
-      this.siblingsEmptyElmIndex
+      this.siblingsEmptyElmIndex.y
     );
 
     emitInteractiveEvent("onDragLeave", element);

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,4 +1,5 @@
 import type { CoreInstanceInterface } from "@dflex/core-instance";
+import type { Coordinates } from "@dflex/draggable";
 
 import type { InteractivityEvent } from "../types";
 import type { DraggableDnDInterface } from "../Draggable";
@@ -33,9 +34,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   protected effectedElemDirection: EffectedElemDirection;
 
-  private elmTransitionY: number;
-
-  private elmTransitionX: number;
+  private elmTransition: Coordinates;
 
   private draggedAccumulatedTransitionY: number;
 
@@ -50,16 +49,22 @@ class DistanceCalculator implements DistanceCalculatorInterface {
   constructor(draggable: DraggableDnDInterface) {
     this.draggable = draggable;
 
-    this.elmTransitionY = 0;
-    this.elmTransitionX = 0;
-
     this.draggedAccumulatedTransitionY = 0;
     this.draggedAccumulatedTransitionX = 0;
     this.draggedYOffset = 0;
     this.draggedXOffset = 0;
 
     /**
+     * Next element calculated transition space.
+     */
+    this.elmTransition = {
+      x: 0,
+      y: 0,
+    };
+
+    /**
      * Elements effected by dragged direction.
+     * Positive for up and right.
      */
     this.effectedElemDirection = {
       x: 1,
@@ -71,6 +76,13 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   protected setEffectedElemDirectionV(isUp: boolean) {
     this.effectedElemDirection.y = isUp ? -1 : 1;
+  }
+
+  private resetIndicators() {
+    this.elmTransition = {
+      x: 0,
+      y: 0,
+    };
   }
 
   private calculateYDistance(element: CoreInstanceInterface) {
@@ -92,8 +104,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     this.draggedYOffset = 0;
     this.draggedXOffset = 0;
 
-    this.elmTransitionY = 0;
-    this.elmTransitionX = 0;
+    this.resetIndicators();
 
     // eslint-disable-next-line no-unused-vars
     const leftDifference = Math.abs(elmLeft! - draggedLeft);
@@ -101,7 +112,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     const topDifference = Math.abs(elmTop! - draggedTop);
 
     this.draggedAccumulatedTransitionY = topDifference;
-    this.elmTransitionY = topDifference;
+    this.elmTransition.y = topDifference;
 
     const heightOffset = Math.abs(draggedHight - elmHight);
 
@@ -110,7 +121,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     if (draggedHight < elmHight) {
       // console.log("elmHight is bigger");
 
-      if (this.effectedElemDirection.x === -1) {
+      if (this.effectedElemDirection.y === -1) {
         // console.log("elm going up");
 
         this.draggedAccumulatedTransitionY += heightOffset;
@@ -118,7 +129,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       } else {
         // console.log("elm going down");
 
-        this.elmTransitionY -= heightOffset;
+        this.elmTransition.y -= heightOffset;
       }
 
       return;
@@ -126,7 +137,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
     // console.log("elmHight is smaller");
 
-    if (this.effectedElemDirection.x === -1) {
+    if (this.effectedElemDirection.y === -1) {
       // console.log("elm going up");
 
       this.draggedAccumulatedTransitionY -= heightOffset;
@@ -134,7 +145,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     } else {
       // console.log("elm going down");
 
-      this.elmTransitionY += heightOffset;
+      this.elmTransition.y += heightOffset;
     }
   }
 
@@ -215,7 +226,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     this.siblingsEmptyElmIndex = element.setYPosition(
       store.getElmSiblingsListById(this.draggable.draggedElm.id)!,
       this.effectedElemDirection.y,
-      this.elmTransitionY,
+      this.elmTransition.y,
 
       this.draggable.operationID,
       this.siblingsEmptyElmIndex

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -287,7 +287,8 @@ class Droppable extends DistanceCalculator {
   private switchElement() {
     const siblings = store.getElmSiblingsListById(this.draggable.draggedElm.id);
 
-    const elmIndex = this.draggable.tempIndex + -1 * this.effectedElemDirection;
+    const elmIndex =
+      this.draggable.tempIndex + -1 * this.effectedElemDirection.y;
     const id = siblings![elmIndex];
 
     if (
@@ -299,7 +300,11 @@ class Droppable extends DistanceCalculator {
     ) {
       this.setDraggedTempIndex(elmIndex);
 
-      this.updateElement(id, true, this.effectedElemDirection === -1 ? 1 : -1);
+      this.updateElement(
+        id,
+        true,
+        this.effectedElemDirection.y === -1 ? 1 : -1
+      );
     }
   }
 
@@ -375,7 +380,7 @@ class Droppable extends DistanceCalculator {
        */
 
       // move element up if it's vertical or fill when it's horizontal.
-      this.setEffectedElemDirection(true);
+      this.setEffectedElemDirectionV(true);
 
       // lock the parent
       this.setDraggedPositionFlagInSiblingsContainer(true);
@@ -403,7 +408,7 @@ class Droppable extends DistanceCalculator {
         // Is is out parent?
 
         // move element up
-        this.setEffectedElemDirection(true);
+        this.setEffectedElemDirectionV(true);
 
         // lock the parent
         this.setDraggedPositionFlagInSiblingsContainer(true);
@@ -418,7 +423,7 @@ class Droppable extends DistanceCalculator {
        */
 
       // inside the list, effected should be related to mouse movement
-      this.setEffectedElemDirection(this.draggable.isMovingDown);
+      this.setEffectedElemDirectionV(this.draggable.isMovingDown);
 
       this.switchElement();
     }
@@ -478,7 +483,7 @@ class Droppable extends DistanceCalculator {
     /**
      * Moving element down by setting is up to false
      */
-    this.setEffectedElemDirection(false);
+    this.setEffectedElemDirectionV(false);
 
     if (hasToMoveSiblingsDown) {
       this.moveDown(to);
@@ -488,9 +493,9 @@ class Droppable extends DistanceCalculator {
        */
       const isElmUp = this.leftAtIndex > this.draggable.tempIndex;
 
-      this.setEffectedElemDirection(isElmUp);
+      this.setEffectedElemDirectionV(isElmUp);
     } else {
-      this.setEffectedElemDirection(true);
+      this.setEffectedElemDirectionV(true);
     }
 
     /**

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -567,19 +567,21 @@ class Droppable {
     }
   }
 
-  private draggedOutPosition() {
+  private draggedOutPosition(branchKey: string) {
     if (this.draggable.isLeavingFromTop()) {
       /**
        * If leaving and parent locked, do nothing.
        */
 
-      // move element up
-      this.setEffectedElemDirection(true);
+      if (store.siblingsAlignment[branchKey] === "Vertical") {
+        // move element up
+        this.setEffectedElemDirection(true);
 
-      // lock the parent
-      this.setDraggedPositionFlagInSiblingsContainer(true);
+        // lock the parent
+        this.setDraggedPositionFlagInSiblingsContainer(true);
 
-      this.liftUp();
+        this.liftUp();
+      }
 
       return;
     }
@@ -929,7 +931,7 @@ class Droppable {
       this.scrollManager(x, y);
 
       if (!this.draggable.isOutActiveSiblingsContainer) {
-        this.draggedOutPosition();
+        this.draggedOutPosition(SK);
 
         return;
       }

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -894,10 +894,6 @@ class Droppable {
       // TODO: Handle this case later.
       // eslint-disable-next-line no-unused-vars
       const parentContainerInstance = store.registry[parentID];
-      console.log(
-        "file: Droppable.ts ~ line 910 ~ parentContainerInstance",
-        parentContainerInstance
-      );
     });
   }
 

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -417,9 +417,9 @@ class Droppable {
       ) {
         const element = store.registry[id];
 
-        const { currentTop } = element;
-
-        const isQualified = this.isElemAboveDragged(currentTop!);
+        const isQualified = !element.isPositionedUnder(
+          this.draggable.tempOffset.currentTop
+        );
 
         if (isQualified) {
           isLast = true;
@@ -452,19 +452,6 @@ class Droppable {
     return isLast;
   }
 
-  /**
-   * Compares the dragged offset with element offset and returns
-   * true if element is matched.
-   *
-   * @param elmCurrentOffsetTop -
-   */
-  private isElemUnderDragged(elmCurrentOffsetTop: number) {
-    /**
-     * Element is Switchable when it's under dragged.
-     */
-    return elmCurrentOffsetTop > this.draggable.tempOffset.currentTop;
-  }
-
   private detectDroppableIndex() {
     let droppableIndex = null;
     const siblings = store.getElmSiblingsListById(this.draggable.draggedElm.id);
@@ -481,9 +468,9 @@ class Droppable {
       ) {
         const element = store.registry[id];
 
-        const { currentTop } = element;
-
-        const isQualified = this.isElemUnderDragged(currentTop!);
+        const isQualified = element.isPositionedUnder(
+          this.draggable.tempOffset.currentTop
+        );
 
         if (isQualified) {
           droppableIndex = i;
@@ -907,6 +894,10 @@ class Droppable {
       // TODO: Handle this case later.
       // eslint-disable-next-line no-unused-vars
       const parentContainerInstance = store.registry[parentID];
+      console.log(
+        "file: Droppable.ts ~ line 910 ~ parentContainerInstance",
+        parentContainerInstance
+      );
     });
   }
 

--- a/packages/dnd/src/Droppable/types.ts
+++ b/packages/dnd/src/Droppable/types.ts
@@ -1,0 +1,8 @@
+type UP_DOWN = 1 | -1;
+
+export interface EffectedElemDirection {
+  x: UP_DOWN;
+  y: UP_DOWN;
+}
+
+export interface DistanceCalculatorInterface {}


### PR DESCRIPTION
- [x] Add a new playground for dealing with horizontal lists.
- [x] Refactor position comparison to `core-instance` for more usability. Add a new method `isPositionedLeft` to check horizontal position.
- [x] Add new utils to store `getBranchHeadAndTail` and avoid bugs caused by not checking the availability if there's only one element in the branch.
- [x] Extract distance calculations methods to a new class.  So that calculating x and y can be done separately from the main droppable class. 