### PR TITLE
Add both axes to transformers in the `Core`

### DIFF
--- a/packages/core-instance/src/AbstractInstance.ts
+++ b/packages/core-instance/src/AbstractInstance.ts
@@ -33,6 +33,11 @@ class AbstractInstance implements AbstractInterface {
     this.isPaused = true;
   }
 
+  /**
+   * Attach element DOM node to the instance.
+   *
+   * @param incomingRef
+   */
   attach(incomingRef: HTMLElement | null) {
     // Cleanup.
     this.ref = null;
@@ -53,11 +58,18 @@ class AbstractInstance implements AbstractInterface {
     this.isInitialized = true;
   }
 
+  /**
+   * Detach element DOM node from the instance.
+   */
   detach() {
     this.isInitialized = false;
     this.ref = null;
   }
 
+  /**
+   * Initialize the translate AxesCoordinates as part of abstract instance and
+   * necessary for darg only movement.
+   */
   initTranslate() {
     if (!this.translate) {
       this.translate = new AxesCoordinates(0, 0);

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -302,20 +302,24 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
   }
 
   /**
-   * Roll back element position vertically(y).
+   * Roll back element position.
    *
-   * @param operationID -
+   * @param operationID
+   * @param isForceTransform
+   * @param axes
    */
   rollBack(operationID: string, isForceTransform: boolean, axes: Axes) {
     if (
-      this.translateHistory![axes].length === 0 ||
-      this.translateHistory![axes][this.translateHistory![axes].length - 1]
-        .ID !== operationID
+      !this.translateHistory ||
+      !this.translateHistory[axes] ||
+      this.translateHistory[axes].length === 0 ||
+      this.translateHistory[axes][this.translateHistory[axes].length - 1].ID !==
+        operationID
     ) {
       return;
     }
 
-    const lastMovement = this.translateHistory![axes].pop();
+    const lastMovement = this.translateHistory[axes].pop();
 
     if (!lastMovement) return;
 

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -1,5 +1,5 @@
 import { AxesCoordinates } from "@dflex/utils";
-import type { Rect } from "@dflex/utils";
+import type { Rect, Direction, EffectedElemDirection } from "@dflex/utils";
 
 export interface AbstractOpts {
   isInitialized: boolean;
@@ -73,12 +73,12 @@ export interface CoreInstanceInterface extends AbstractInterface {
   isPositionedLeft(elmX: number): boolean;
   resume(scrollX: number, scrollY: number): void;
   changeVisibility(isVisible: boolean): void;
-  setYPosition(
+  setPosition(
     iDsInOrder: string[],
-    sign: 1 | -1,
-    topSpace: number,
+    effectedElemDirection: EffectedElemDirection,
+    elmSpace: AxesCoordinates,
     operationID: string,
-    siblingsHasEmptyElm?: number,
+    siblingsEmptyElmIndex: AxesCoordinates,
     vIncrement?: number,
     isShuffle?: boolean
   ): number;
@@ -90,5 +90,5 @@ export interface CoreInstanceInterface extends AbstractInterface {
     siblingsHasEmptyElm?: number
   ): number;
   updateDataset(index: number): void;
-  rollYBack(operationID: string, isForceTransform: boolean): void;
+  rollBack(operationID: string, isForceTransform: boolean): void;
 }

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -1,5 +1,5 @@
 import { AxesCoordinates } from "@dflex/utils";
-import type { Rect, Direction, EffectedElemDirection } from "@dflex/utils";
+import type { Rect, Axes, EffectedElemDirection } from "@dflex/utils";
 
 export interface AbstractOpts {
   isInitialized: boolean;
@@ -79,6 +79,7 @@ export interface CoreInstanceInterface extends AbstractInterface {
     elmSpace: AxesCoordinates,
     operationID: string,
     siblingsEmptyElmIndex: AxesCoordinates,
+    axes: Axes,
     vIncrement?: number,
     isShuffle?: boolean
   ): number;
@@ -90,5 +91,5 @@ export interface CoreInstanceInterface extends AbstractInterface {
     siblingsHasEmptyElm?: number
   ): number;
   updateDataset(index: number): void;
-  rollBack(operationID: string, isForceTransform: boolean): void;
+  rollBack(operationID: string, isForceTransform: boolean, axes: Axes): void;
 }

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -580,15 +580,8 @@ class Draggable
       return;
     }
 
-    this.draggedElm.currentPosition.setAxes(
-      this.occupiedOffset.x,
-      this.occupiedOffset.y
-    );
-
-    this.draggedElm.translate.setAxes(
-      this.occupiedTranslate.x,
-      this.occupiedTranslate.y
-    );
+    this.draggedElm.currentPosition.clone(this.occupiedOffset);
+    this.draggedElm.translate.clone(this.occupiedTranslate);
 
     this.draggedElm.transformElm();
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -40,9 +40,7 @@ class Draggable
 
   isViewportRestricted: boolean;
 
-  innerOffsetX: number;
-
-  innerOffsetY: number;
+  innerOffset: Coordinates;
 
   tempOffset: TempOffset;
 
@@ -52,9 +50,9 @@ class Draggable
 
   mousePoints: AxesCoordinates;
 
-  numberOfElementsTransformed: number;
-
   isMovingDown: boolean;
+
+  numberOfElementsTransformed: number;
 
   isOutPositionHorizontally: boolean;
 
@@ -190,8 +188,10 @@ class Draggable
     this.initY = y;
     this.initX = x;
 
-    this.innerOffsetX = Math.round(x - this.draggedElm.currentPosition.x);
-    this.innerOffsetY = Math.round(y - this.draggedElm.currentPosition.y);
+    this.innerOffset = new AxesCoordinates(
+      Math.round(x - this.draggedElm.currentPosition.x),
+      Math.round(y - this.draggedElm.currentPosition.y)
+    );
 
     const style = window.getComputedStyle(this.draggedElm.ref!);
 
@@ -268,18 +268,18 @@ class Draggable
     allowBottom: boolean,
     isRestrictedToThreshold: boolean // if not. Then to self.
   ) {
-    const currentTop = y - this.innerOffsetY;
+    const currentTop = y - this.innerOffset.y;
     const currentBottom = currentTop + this.draggedElm.offset.height;
 
     if (!allowTop && currentTop <= topThreshold) {
       return isRestrictedToThreshold
-        ? topThreshold + this.innerOffsetY
+        ? topThreshold + this.innerOffset.y
         : this.initY;
     }
 
     if (!allowBottom && currentBottom >= bottomThreshold) {
       return isRestrictedToThreshold
-        ? bottomThreshold + this.innerOffsetY - this.draggedElm.offset.height
+        ? bottomThreshold + this.innerOffset.y - this.draggedElm.offset.height
         : this.initY;
     }
 
@@ -294,19 +294,19 @@ class Draggable
     allowRight: boolean,
     restrictToThreshold: boolean // if not. Then to self.,
   ) {
-    const currentLeft = x - this.innerOffsetX;
+    const currentLeft = x - this.innerOffset.x;
     const currentRight = currentLeft + this.draggedElm.offset.width;
 
     if (!allowLeft && currentLeft <= leftThreshold) {
       return restrictToThreshold
-        ? leftThreshold + this.innerOffsetX
+        ? leftThreshold + this.innerOffset.x
         : this.initX;
     }
 
     if (!allowRight && currentRight + this.marginX >= rightThreshold) {
       return restrictToThreshold
         ? rightThreshold +
-            this.innerOffsetX -
+            this.innerOffset.x -
             this.draggedElm.offset.width -
             this.marginX
         : this.initX;
@@ -419,8 +419,8 @@ class Draggable
     /**
      * Every time we got new translate, offset should be updated
      */
-    this.tempOffset.currentLeft = filteredX - this.innerOffsetX;
-    this.tempOffset.currentTop = filteredY - this.innerOffsetY;
+    this.tempOffset.currentLeft = filteredX - this.innerOffset.x;
+    this.tempOffset.currentTop = filteredY - this.innerOffset.y;
   }
 
   private isOutThresholdH($: ThresholdMatrix) {

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -590,29 +590,15 @@ class Draggable
       return;
     }
 
-    // this.draggedElm.resetIndicators(
-    //   {
-    //     x: this.occupiedOffset.currentLeft,
-    //     y: this.occupiedOffset.currentTop,
-    //   },
-    //   {
-    //     x: this.occupiedTranslate.x,
-    //     y: this.occupiedTranslate.y,
-    //   }
-    // );
-
-    // @ts-expect-error
-    this.draggedElm.currentTop = this.occupiedOffset.currentTop;
-    // @ts-expect-error
-    this.draggedElm.currentLeft = this.occupiedOffset.currentLeft;
-
-    this.draggedElm.currentPosition!.setAxes(
+    this.draggedElm.currentPosition.setAxes(
       this.occupiedOffset.currentLeft,
       this.occupiedOffset.currentTop
     );
 
-    this.draggedElm.translate.x = this.occupiedTranslate.x;
-    this.draggedElm.translate.y = this.occupiedTranslate.y;
+    this.draggedElm.translate.setAxes(
+      this.occupiedTranslate.x,
+      this.occupiedTranslate.y
+    );
 
     this.draggedElm.transformElm();
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -3,6 +3,7 @@ import type { DraggedStyle, Coordinates } from "@dflex/draggable";
 
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 
+import { AxesCoordinates } from "@dflex/utils";
 import store from "../DnDStore";
 
 import type { DraggableDnDInterface, Restrictions, TempOffset } from "./types";
@@ -49,7 +50,7 @@ class Draggable
 
   readonly occupiedTranslate: Coordinates;
 
-  prevY: number;
+  mousePoints: AxesCoordinates;
 
   numberOfElementsTransformed: number;
 
@@ -217,7 +218,7 @@ class Draggable
     /**
      * previous X and Y are used to calculate mouse directions.
      */
-    this.prevY = y;
+    this.mousePoints = new AxesCoordinates(x, y);
 
     /**
      * It counts number of element that dragged has passed. This counter is
@@ -522,15 +523,12 @@ class Draggable
     );
   }
 
-  /**
-   * @param y -
-   */
   setDraggedMovingDown(y: number) {
-    if (this.prevY === y) return;
+    if (this.mousePoints.y === y) return;
 
-    this.isMovingDown = y > this.prevY;
+    this.isMovingDown = y > this.mousePoints.y;
 
-    this.prevY = y;
+    this.mousePoints.y = y;
   }
 
   incNumOfElementsTransformed(effectedElemDirection: number) {

--- a/packages/dnd/src/Draggable/index.ts
+++ b/packages/dnd/src/Draggable/index.ts
@@ -1,5 +1,5 @@
 import Draggable from "./Draggable";
 
-export type { DraggableDnDInterface, TempOffset, Restrictions } from "./types";
+export type { DraggableDnDInterface, Restrictions } from "./types";
 
 export default Draggable;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -1,3 +1,4 @@
+import { AxesCoordinates } from "@dflex/utils";
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 import type { AbstractDraggableInterface, Coordinates } from "@dflex/draggable";
 
@@ -44,7 +45,7 @@ export interface DraggableDnDInterface
   tempOffset: TempOffset;
   occupiedOffset: TempOffset;
   occupiedTranslate: Coordinates;
-  prevY: number;
+  mousePoints: AxesCoordinates;
   numberOfElementsTransformed: number;
   isMovingDown: boolean;
   isOutPositionHorizontally: boolean;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -1,6 +1,6 @@
 import { AxesCoordinates } from "@dflex/utils";
 import type { CoreInstanceInterface } from "@dflex/core-instance";
-import type { AbstractDraggableInterface, Coordinates } from "@dflex/draggable";
+import type { AbstractDraggableInterface } from "@dflex/draggable";
 
 import type { ScrollOptWithThreshold } from "../types";
 
@@ -8,11 +8,6 @@ import type { ThresholdInterface, ThresholdMatrix } from "../Plugins/Threshold";
 
 export interface SiblingsThresholdMatrix {
   [sk: string]: ThresholdMatrix;
-}
-
-export interface TempOffset {
-  currentLeft: number;
-  currentTop: number;
 }
 
 export interface Restrictions {
@@ -40,10 +35,10 @@ export interface DraggableDnDInterface
   isViewportRestricted: boolean;
   threshold: ThresholdInterface;
   layoutThresholds: SiblingsThresholdMatrix;
-  innerOffset: Coordinates;
-  tempOffset: TempOffset;
-  occupiedOffset: TempOffset;
-  occupiedTranslate: Coordinates;
+  innerOffset: AxesCoordinates;
+  tempOffset: AxesCoordinates;
+  occupiedOffset: AxesCoordinates;
+  occupiedTranslate: AxesCoordinates;
   mousePoints: AxesCoordinates;
   numberOfElementsTransformed: number;
   isMovingDown: boolean;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -40,8 +40,7 @@ export interface DraggableDnDInterface
   isViewportRestricted: boolean;
   threshold: ThresholdInterface;
   layoutThresholds: SiblingsThresholdMatrix;
-  innerOffsetX: number;
-  innerOffsetY: number;
+  innerOffset: Coordinates;
   tempOffset: TempOffset;
   occupiedOffset: TempOffset;
   occupiedTranslate: Coordinates;

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -79,8 +79,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
   }
 
   protected updateOccupiedOffset(elmTop: number, elmLeft: number) {
-    this.draggable.occupiedOffset.currentTop = elmTop + this.draggedOffset.y;
-    this.draggable.occupiedOffset.currentLeft = elmLeft + this.draggedOffset.x;
+    this.draggable.occupiedOffset.y = elmTop + this.draggedOffset.y;
+    this.draggable.occupiedOffset.x = elmLeft + this.draggedOffset.x;
   }
 
   /**
@@ -142,7 +142,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     } = element;
 
     const {
-      occupiedOffset: { currentLeft: draggedLeft, currentTop: draggedTop },
+      occupiedOffset: { x: draggedLeft, y: draggedTop },
       draggedElm: {
         offset: { height: draggedHight, width: draggedWidth },
       },

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,17 +1,14 @@
 import type { CoreInstanceInterface } from "@dflex/core-instance";
+
 import { AxesCoordinates } from "@dflex/utils";
+import type { Direction, EffectedElemDirection } from "@dflex/utils";
 
 import type { InteractivityEvent } from "../types";
 import type { DraggableDnDInterface } from "../Draggable";
 
 import store from "../DnDStore";
 
-import type {
-  DistanceCalculatorInterface,
-  EffectedElemDirection,
-  Direction,
-  Axes,
-} from "./types";
+import type { DistanceCalculatorInterface, Axes } from "./types";
 
 interface Difference {
   dragged: number;
@@ -250,12 +247,12 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     /**
      * Start transforming process
      */
-    this.siblingsEmptyElmIndex[axes] = element.setYPosition(
+    this.siblingsEmptyElmIndex[axes] = element.setPosition(
       store.getElmSiblingsListById(this.draggable.draggedElm.id)!,
-      this.effectedElemDirection[axes],
-      this.elmTransition[axes],
+      this.effectedElemDirection,
+      this.elmTransition,
       this.draggable.operationID,
-      this.siblingsEmptyElmIndex[axes]
+      this.siblingsEmptyElmIndex
     );
 
     emitInteractiveEvent("onDragLeave", element);

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,14 +1,14 @@
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 
 import { AxesCoordinates } from "@dflex/utils";
-import type { Direction, EffectedElemDirection } from "@dflex/utils";
+import type { Direction, EffectedElemDirection, Axes } from "@dflex/utils";
 
 import type { InteractivityEvent } from "../types";
 import type { DraggableDnDInterface } from "../Draggable";
 
 import store from "../DnDStore";
 
-import type { DistanceCalculatorInterface, Axes } from "./types";
+import type { DistanceCalculatorInterface } from "./types";
 
 interface Difference {
   dragged: number;
@@ -252,7 +252,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       this.effectedElemDirection,
       this.elmTransition,
       this.draggable.operationID,
-      this.siblingsEmptyElmIndex
+      this.siblingsEmptyElmIndex,
+      axes
     );
 
     emitInteractiveEvent("onDragLeave", element);

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -1,10 +1,9 @@
-import type { Axes } from "@dflex/utils";
-
+import { Axes, AxesCoordinates } from "@dflex/utils";
 import type { DraggedEvent, SiblingsEvent } from "../types";
 
 import store from "../DnDStore";
 
-import type { TempOffset, DraggableDnDInterface } from "../Draggable";
+import type { DraggableDnDInterface } from "../Draggable";
 import DistanceCalculator from "./DistanceCalculator";
 
 function emitSiblingsEvent(
@@ -66,7 +65,7 @@ function isIDEligible2Move(
 class Droppable extends DistanceCalculator {
   private leftAtIndex: number;
 
-  private preserveLastElmOffset!: TempOffset;
+  private preserveLastElmOffset?: AxesCoordinates;
 
   private scrollAnimatedFrame: number | null;
 
@@ -201,10 +200,7 @@ class Droppable extends DistanceCalculator {
       }
     }
 
-    this.preserveLastElmOffset = {
-      currentLeft,
-      currentTop,
-    };
+    this.preserveLastElmOffset = new AxesCoordinates(currentLeft, currentTop);
   }
 
   private checkIfDraggedIsLastElm() {
@@ -225,7 +221,7 @@ class Droppable extends DistanceCalculator {
         const element = store.registry[id];
 
         const isQualified = !element.isPositionedUnder(
-          this.draggable.tempOffset.currentTop
+          this.draggable.tempOffset.y
         );
 
         if (isQualified) {
@@ -238,15 +234,15 @@ class Droppable extends DistanceCalculator {
             {
               width: this.draggable.draggedElm.offset.width,
               height: this.draggable.draggedElm.offset.height,
-              left: this.preserveLastElmOffset.currentLeft,
-              top: this.preserveLastElmOffset.currentTop,
+              left: this.preserveLastElmOffset!.x,
+              top: this.preserveLastElmOffset!.y,
             },
             false
           );
 
           this.updateOccupiedOffset(
-            this.preserveLastElmOffset.currentTop,
-            this.preserveLastElmOffset.currentLeft
+            this.preserveLastElmOffset!.y,
+            this.preserveLastElmOffset!.x
           );
 
           break;
@@ -276,7 +272,7 @@ class Droppable extends DistanceCalculator {
         const element = store.registry[id];
 
         const isQualified = element.isPositionedUnder(
-          this.draggable.tempOffset.currentTop
+          this.draggable.tempOffset.y
         );
 
         if (isQualified) {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -520,7 +520,7 @@ class Droppable extends DistanceCalculator {
 
     const draggedYShift = y + nextScrollTop - this.initialScrollY;
 
-    const currentTop = draggedYShift - this.draggable.innerOffsetY;
+    const currentTop = draggedYShift - this.draggable.innerOffset.y;
 
     const currentBottom = currentTop + this.draggable.draggedElm.offset.height;
 
@@ -559,7 +559,7 @@ class Droppable extends DistanceCalculator {
 
     const draggedXShift = x + nextScrollLeft - this.initialScrollX;
 
-    const currentLeft = draggedXShift - this.draggable.innerOffsetX;
+    const currentLeft = draggedXShift - this.draggable.innerOffset.x;
 
     const currentRight = currentLeft + this.draggable.draggedElm.offset.width;
 

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -484,7 +484,7 @@ class Droppable extends DistanceCalculator {
        * coming element inside we need new value so we can assign isMoveDown
        * correctly.
        */
-      this.draggable.prevY = y;
+      this.draggable.mousePoints.y = y;
     }
 
     this.setDraggedPositionFlagInSiblingsContainer(false);

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -1,10 +1,11 @@
+import type { Axes } from "@dflex/utils";
+
 import type { DraggedEvent, SiblingsEvent } from "../types";
 
 import store from "../DnDStore";
 
 import type { TempOffset, DraggableDnDInterface } from "../Draggable";
 import DistanceCalculator from "./DistanceCalculator";
-import type { Axes } from "./types";
 
 function emitSiblingsEvent(
   type: SiblingsEvent["type"],
@@ -89,7 +90,7 @@ class Droppable extends DistanceCalculator {
    * transformation. */
   private animatedDraggedInsertionFrame: number | null;
 
-  private axes: Axes;
+  protected axes: Axes;
 
   constructor(draggable: DraggableDnDInterface) {
     super(draggable);

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -1,11 +1,10 @@
-/* eslint-disable  */
+/* eslint-disable no-param-reassign */
 import type { ELmBranch } from "@dflex/dom-gen";
 
 import store from "../DnDStore";
 import Droppable, { isIDEligible } from "./Droppable";
 
 import type { DraggableDnDInterface } from "../Draggable";
-import { Axes } from "@dflex/utils";
 
 class EndDroppable extends Droppable {
   private spliceAt: number;

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -5,6 +5,7 @@ import store from "../DnDStore";
 import Droppable, { isIDEligible } from "./Droppable";
 
 import type { DraggableDnDInterface } from "../Draggable";
+import { Axes } from "@dflex/utils";
 
 class EndDroppable extends Droppable {
   private spliceAt: number;
@@ -52,7 +53,7 @@ class EndDroppable extends Droppable {
        * Note: rolling back won't affect order array. It only deals with element
        * itself and totally ignore any instance related to store.
        */
-      element.rollBack(this.draggable.operationID, listVisibility);
+      element.rollBack(this.draggable.operationID, listVisibility, this.axes);
 
       this.draggable.numberOfElementsTransformed -= 1;
 

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -155,9 +155,7 @@ class EndDroppable extends Droppable {
     const id = lst[0];
 
     if (id.length === 0 || this.draggable.draggedElm.id === id) {
-      return (
-        Math.floor(top) === Math.floor(this.draggable.occupiedOffset.currentTop)
-      );
+      return Math.floor(top) === Math.floor(this.draggable.occupiedOffset.y);
     }
 
     const element = store.registry[id];

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -52,7 +52,7 @@ class EndDroppable extends Droppable {
        * Note: rolling back won't affect order array. It only deals with element
        * itself and totally ignore any instance related to store.
        */
-      element.rollYBack(this.draggable.operationID, listVisibility);
+      element.rollBack(this.draggable.operationID, listVisibility);
 
       this.draggable.numberOfElementsTransformed -= 1;
 

--- a/packages/dnd/src/Droppable/types.ts
+++ b/packages/dnd/src/Droppable/types.ts
@@ -1,11 +1,3 @@
-/** Negative for up and right */
-export type Direction = 1 | -1;
-
 export type Axes = "x" | "y";
-
-export interface EffectedElemDirection {
-  x: Direction;
-  y: Direction;
-}
 
 export interface DistanceCalculatorInterface {}

--- a/packages/dnd/src/Droppable/types.ts
+++ b/packages/dnd/src/Droppable/types.ts
@@ -1,3 +1,1 @@
-export type Axes = "x" | "y";
-
 export interface DistanceCalculatorInterface {}

--- a/packages/utils/src/AxesCoordinates.ts
+++ b/packages/utils/src/AxesCoordinates.ts
@@ -1,11 +1,10 @@
 class AxesCoordinates<T = number> {
-  x: T;
+  x!: T;
 
-  y: T;
+  y!: T;
 
   constructor(x: T, y: T) {
-    this.x = x;
-    this.y = y;
+    this.setAxes(x, y);
   }
 
   setAxes(x: T, y: T) {

--- a/packages/utils/src/AxesCoordinates.ts
+++ b/packages/utils/src/AxesCoordinates.ts
@@ -11,6 +11,10 @@ class AxesCoordinates<T = number> {
     this.x = x;
     this.y = y;
   }
+
+  clone(target: AxesCoordinates<T>) {
+    this.setAxes(target.x, target.y);
+  }
 }
 
 export default AxesCoordinates;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,3 @@
 export { default as AxesCoordinates } from "./AxesCoordinates";
 
-export type { Rect, Direction, EffectedElemDirection } from "./types";
+export type { Rect, Axes, Direction, EffectedElemDirection } from "./types";

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,3 @@
 export { default as AxesCoordinates } from "./AxesCoordinates";
 
-export type { Rect } from "./types";
+export type { Rect, Direction, EffectedElemDirection } from "./types";

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -4,3 +4,11 @@ export interface Rect {
   readonly left: number;
   readonly top: number;
 }
+
+export type Direction = 1 | -1;
+
+/** How the element movement effects the siblings direction */
+export interface EffectedElemDirection {
+  x: Direction;
+  y: Direction;
+}

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -12,3 +12,5 @@ export interface EffectedElemDirection {
   x: Direction;
   y: Direction;
 }
+
+export type Axes = "x" | "y";


### PR DESCRIPTION
- [x] Update `seTranslate`, `setPosition` and `rollBack` in the Core and all related classe to include both axes. 
- [x] Add more types to the utils. As part of shared types/functions to include `Axes` and `EffectedElemDirection`.
- [x] Remove legacy current position updaters and use `setAxes` instead.
- [x] Replace `TempOffset` with `AxesCoordinates`