### PR TITLE
Enhance `Threshold` for dragged and containers

### DIFF
--- a/packages/core-instance/src/AbstractInstance.ts
+++ b/packages/core-instance/src/AbstractInstance.ts
@@ -1,5 +1,5 @@
-/* eslint-disable max-classes-per-file */
 import { AxesCoordinates } from "@dflex/utils";
+import type { AxesCoordinatesInterface } from "@dflex/utils";
 
 import type {
   AbstractInterface,
@@ -15,7 +15,7 @@ class AbstractInstance implements AbstractInterface {
 
   id: string;
 
-  translate!: AxesCoordinates;
+  translate!: AxesCoordinatesInterface;
 
   isInitialized!: boolean;
 

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -1,7 +1,14 @@
 /* eslint-disable no-param-reassign */
-import { Axes, AxesCoordinates } from "@dflex/utils";
 
-import type { Rect, EffectedElemDirection } from "@dflex/utils";
+import { AxesCoordinates } from "@dflex/utils";
+
+import type {
+  Rect,
+  EffectedElemDirection,
+  Axes,
+  AxesCoordinatesInterface,
+} from "@dflex/utils";
+
 import AbstractInstance from "./AbstractInstance";
 
 import type {
@@ -18,10 +25,10 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
   offset!: Rect;
 
   /** Store history of Y-transition according to unique ID. */
-  translateHistory?: AxesCoordinates<TransitionHistory>;
+  translateHistory?: AxesCoordinatesInterface<TransitionHistory>;
 
   /** Current element offset (x-left, y-top) */
-  currentPosition!: AxesCoordinates;
+  currentPosition!: AxesCoordinatesInterface;
 
   order: Order;
 

--- a/packages/dnd/cypress/integration/differentHeights/strict/strict.draggedSmaller.noRelease.spec.ts
+++ b/packages/dnd/cypress/integration/differentHeights/strict/strict.draggedSmaller.noRelease.spec.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 let elmBox;
 // let startingPointX;
 let startingPointY;

--- a/packages/dnd/cypress/integration/differentHeights/strict/strict.draggedSmaller.release.spec.ts
+++ b/packages/dnd/cypress/integration/differentHeights/strict/strict.draggedSmaller.release.spec.ts
@@ -33,7 +33,7 @@ context(
           force: true,
         });
         // eslint-disable-next-line cypress/no-unnecessary-waiting
-        // cy.wait(0);
+        cy.wait(0);
       }
     });
 
@@ -80,7 +80,7 @@ context(
           force: true,
         });
         // eslint-disable-next-line cypress/no-unnecessary-waiting
-        // cy.wait(0);
+        cy.wait(0);
       }
     });
 
@@ -131,7 +131,7 @@ context(
           force: true,
         });
         // eslint-disable-next-line cypress/no-unnecessary-waiting
-        // cy.wait(0);
+        cy.wait(0);
       }
     });
 
@@ -241,7 +241,7 @@ context(
           force: true,
         });
         // eslint-disable-next-line cypress/no-unnecessary-waiting
-        // cy.wait(0);
+        cy.wait(0);
       }
     });
 
@@ -296,7 +296,7 @@ context(
           force: true,
         });
         // eslint-disable-next-line cypress/no-unnecessary-waiting
-        // cy.wait(0);
+        cy.wait(0);
       }
     });
 
@@ -351,7 +351,7 @@ context(
           force: true,
         });
         // eslint-disable-next-line cypress/no-unnecessary-waiting
-        // cy.wait(0);
+        cy.wait(0);
       }
     });
 

--- a/packages/dnd/cypress/integration/extended/general/inOut.spec.ts
+++ b/packages/dnd/cypress/integration/extended/general/inOut.spec.ts
@@ -37,7 +37,7 @@ context("Working with visibility, changing positions and continuity", () => {
       cy.wait(0);
     }
 
-    stepsY = 110;
+    stepsY = 80;
     for (let i = 0; i <= stepsY; i += 10) {
       cy.get("#1-extended").trigger("mousemove", {
         clientY: startingPointY + i,
@@ -218,7 +218,7 @@ context("Working with visibility, changing positions and continuity", () => {
       cy.wait(0);
     }
 
-    stepsY = 260;
+    stepsY = 230;
     for (let i = 0; i <= stepsY; i += 10) {
       cy.get("#1-extended").trigger("mousemove", {
         clientY: startingPointY + i,
@@ -252,7 +252,7 @@ context("Working with visibility, changing positions and continuity", () => {
   });
 
   it("Transom element down", () => {
-    stepsY = 620;
+    stepsY = 470;
 
     for (let i = 260; i <= stepsY; i += 10) {
       cy.get("#1-extended").trigger("mousemove", {

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -1,9 +1,11 @@
 import { AbstractDraggable } from "@dflex/draggable";
 import type { DraggedStyle, Coordinates } from "@dflex/draggable";
 
+import { AxesCoordinates } from "@dflex/utils";
+import type { Axes, AxesCoordinatesInterface } from "@dflex/utils";
+
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 
-import { Axes, AxesCoordinates } from "@dflex/utils";
 import store from "../DnDStore";
 
 import type { DraggableDnDInterface, Restrictions } from "./types";
@@ -40,15 +42,15 @@ class Draggable
 
   isViewportRestricted: boolean;
 
-  innerOffset: AxesCoordinates;
+  innerOffset: AxesCoordinatesInterface;
 
-  tempOffset: AxesCoordinates;
+  tempOffset: AxesCoordinatesInterface;
 
-  occupiedOffset: AxesCoordinates;
+  occupiedOffset: AxesCoordinatesInterface;
 
-  occupiedTranslate: AxesCoordinates;
+  occupiedTranslate: AxesCoordinatesInterface;
 
-  mousePoints: AxesCoordinates;
+  mousePoints: AxesCoordinatesInterface;
 
   isMovingDown: boolean;
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -145,13 +145,22 @@ class Draggable
 
     const siblingsBoundaries = store.siblingsBoundaries[SK];
 
-    this.threshold = new Threshold(opts.threshold);
-
     const {
       offset: { width, height },
       currentPosition,
       translate,
     } = this.draggedElm;
+
+    this.threshold = new Threshold(
+      opts.threshold,
+      {
+        width,
+        height,
+        left: currentPosition.x,
+        top: currentPosition.y,
+      },
+      { isContainer: false }
+    );
 
     this.threshold.updateElementThresholdMatrix(
       { width, height, left: currentPosition.x, top: currentPosition.y },
@@ -435,10 +444,20 @@ class Draggable
     );
   }
 
-  private isOutPositionV($: ThresholdMatrix) {
-    return this.isMovingDown
-      ? this.offsetPlaceholder.y > $.maxBottom
-      : this.offsetPlaceholder.y < $.maxTop;
+  private isOutPositionV() {
+    const { top } = this.threshold.main;
+
+    const { y } = this.offsetPlaceholder;
+
+    return this.isMovingDown ? y > top.min : y < top.max;
+  }
+
+  private isOutPositionH() {
+    const { left } = this.threshold.main;
+
+    const { x } = this.offsetPlaceholder;
+
+    return this.isMovingLeft ? x > left.min : x < left.max;
   }
 
   private isOutContainerV($: ThresholdMatrix) {
@@ -461,7 +480,7 @@ class Draggable
       return true;
     }
 
-    if (this.isOutPositionV($)) {
+    if (this.isOutPositionV() || this.isOutPositionH()) {
       return true;
     }
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -24,7 +24,7 @@ class Draggable
 {
   private isLayoutStateUpdated: boolean;
 
-  tempIndex: number;
+  indexPlaceholder: number;
 
   operationID: string;
 
@@ -44,7 +44,7 @@ class Draggable
 
   innerOffset: AxesCoordinatesInterface;
 
-  tempOffset: AxesCoordinatesInterface;
+  offsetPlaceholder: AxesCoordinatesInterface;
 
   occupiedOffset: AxesCoordinatesInterface;
 
@@ -91,7 +91,7 @@ class Draggable
      * Initialize temp index that refers to element new position after
      * transformation happened.
      */
-    this.tempIndex = order.self;
+    this.indexPlaceholder = order.self;
 
     // This tiny bug caused an override  options despite it's actually freezed!
     this.scroll = { ...opts.scroll };
@@ -205,7 +205,10 @@ class Draggable
     const lm = Math.round(parseFloat(style.marginLeft));
     this.marginX = rm + lm;
 
-    this.tempOffset = new AxesCoordinates(currentPosition.x, currentPosition.y);
+    this.offsetPlaceholder = new AxesCoordinates(
+      currentPosition.x,
+      currentPosition.y
+    );
 
     this.occupiedOffset = new AxesCoordinates(
       currentPosition.x,
@@ -324,11 +327,11 @@ class Draggable
   private isFirstOrOutside() {
     const siblings = store.getElmSiblingsListById(this.draggedElm.id);
 
-    return siblings !== null && this.tempIndex <= 0;
+    return siblings !== null && this.indexPlaceholder <= 0;
   }
 
   private isLastELm() {
-    return this.tempIndex === this.getLastElmIndex();
+    return this.indexPlaceholder === this.getLastElmIndex();
   }
 
   /**
@@ -419,20 +422,23 @@ class Draggable
     /**
      * Every time we got new translate, offset should be updated
      */
-    this.tempOffset.setAxes(
+    this.offsetPlaceholder.setAxes(
       filteredX - this.innerOffset.x,
       filteredY - this.innerOffset.y
     );
   }
 
   private isOutThresholdH($: ThresholdMatrix) {
-    return this.tempOffset.x < $.maxLeft || this.tempOffset.x > $.maxRight;
+    return (
+      this.offsetPlaceholder.x < $.maxLeft ||
+      this.offsetPlaceholder.x > $.maxRight
+    );
   }
 
   private isOutPositionV($: ThresholdMatrix) {
     return this.isMovingDown
-      ? this.tempOffset.y > $.maxBottom
-      : this.tempOffset.y < $.maxTop;
+      ? this.offsetPlaceholder.y > $.maxBottom
+      : this.offsetPlaceholder.y < $.maxTop;
   }
 
   private isOutContainerV($: ThresholdMatrix) {
@@ -441,8 +447,8 @@ class Draggable
      * and outside the container?
      */
     return (
-      (this.isLastELm() && this.tempOffset.y > $.maxBottom) ||
-      (this.tempIndex < 0 && this.tempOffset.y < $.maxTop)
+      (this.isLastELm() && this.offsetPlaceholder.y > $.maxBottom) ||
+      (this.indexPlaceholder < 0 && this.offsetPlaceholder.y < $.maxTop)
     );
   }
 
@@ -586,10 +592,10 @@ class Draggable
     this.draggedElm.transformElm();
 
     if (siblings) {
-      this.draggedElm.assignNewPosition(siblings, this.tempIndex);
+      this.draggedElm.assignNewPosition(siblings, this.indexPlaceholder);
     }
 
-    this.draggedElm.order.self = this.tempIndex;
+    this.draggedElm.order.self = this.indexPlaceholder;
   }
 
   endDragging(isFallback: boolean) {

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -27,7 +27,7 @@ export interface Restrictions {
 
 export interface DraggableDnDInterface
   extends AbstractDraggableInterface<CoreInstanceInterface> {
-  tempIndex: number;
+  indexPlaceholder: number;
   operationID: string;
   setOfTransformedIds?: Set<string>;
   siblingsContainer: CoreInstanceInterface | null;
@@ -35,7 +35,7 @@ export interface DraggableDnDInterface
   threshold: ThresholdInterface;
   layoutThresholds: SiblingsThresholdMatrix;
   innerOffset: AxesCoordinatesInterface;
-  tempOffset: AxesCoordinatesInterface;
+  offsetPlaceholder: AxesCoordinatesInterface;
   occupiedOffset: AxesCoordinatesInterface;
   occupiedTranslate: AxesCoordinatesInterface;
   mousePoints: AxesCoordinatesInterface;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -1,4 +1,4 @@
-import { AxesCoordinates, Axes } from "@dflex/utils";
+import type { AxesCoordinatesInterface, Axes } from "@dflex/utils";
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 import type { AbstractDraggableInterface } from "@dflex/draggable";
 
@@ -34,11 +34,11 @@ export interface DraggableDnDInterface
   scroll: ScrollOptWithThreshold;
   threshold: ThresholdInterface;
   layoutThresholds: SiblingsThresholdMatrix;
-  innerOffset: AxesCoordinates;
-  tempOffset: AxesCoordinates;
-  occupiedOffset: AxesCoordinates;
-  occupiedTranslate: AxesCoordinates;
-  mousePoints: AxesCoordinates;
+  innerOffset: AxesCoordinatesInterface;
+  tempOffset: AxesCoordinatesInterface;
+  occupiedOffset: AxesCoordinatesInterface;
+  occupiedTranslate: AxesCoordinatesInterface;
+  mousePoints: AxesCoordinatesInterface;
   numberOfElementsTransformed: number;
   isViewportRestricted: boolean;
   isMovingDown: boolean;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -4,10 +4,13 @@ import type { AbstractDraggableInterface } from "@dflex/draggable";
 
 import type { ScrollOptWithThreshold } from "../types";
 
-import type { ThresholdInterface, ThresholdMatrix } from "../Plugins/Threshold";
+import type {
+  ThresholdInterface,
+  ThresholdCoordinate,
+} from "../Plugins/Threshold";
 
 export interface SiblingsThresholdMatrix {
-  [sk: string]: ThresholdMatrix;
+  [sk: string]: ThresholdCoordinate;
 }
 
 export interface Restrictions {

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -239,6 +239,16 @@ class DistanceCalculator implements DistanceCalculatorInterface {
         },
         false
       );
+
+      this.draggable.threshold.setMainThreshold(
+        {
+          width,
+          height,
+          left: x,
+          top: y,
+        },
+        false
+      );
     }
 
     emitInteractiveEvent("onDragOver", element);

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,7 +1,12 @@
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 
 import { AxesCoordinates } from "@dflex/utils";
-import type { Direction, EffectedElemDirection, Axes } from "@dflex/utils";
+import type {
+  AxesCoordinatesInterface,
+  Direction,
+  EffectedElemDirection,
+  Axes,
+} from "@dflex/utils";
 
 import type { InteractivityEvent } from "../types";
 import type { DraggableDnDInterface } from "../Draggable";
@@ -39,13 +44,13 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   protected effectedElemDirection: EffectedElemDirection;
 
-  private elmTransition: AxesCoordinates;
+  private elmTransition: AxesCoordinatesInterface;
 
-  private draggedOffset: AxesCoordinates;
+  private draggedOffset: AxesCoordinatesInterface;
 
-  private draggedAccumulatedTransition: AxesCoordinates;
+  private draggedAccumulatedTransition: AxesCoordinatesInterface;
 
-  private siblingsEmptyElmIndex: AxesCoordinates;
+  private siblingsEmptyElmIndex: AxesCoordinatesInterface;
 
   constructor(draggable: DraggableDnDInterface) {
     this.draggable = draggable;

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -230,16 +230,6 @@ class DistanceCalculator implements DistanceCalculatorInterface {
         currentPosition: { x, y },
       } = element;
 
-      this.draggable.threshold.updateElementThresholdMatrix(
-        {
-          width,
-          height,
-          left: x,
-          top: y,
-        },
-        false
-      );
-
       this.draggable.threshold.setMainThreshold(
         {
           width,

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -172,11 +172,11 @@ class Droppable extends DistanceCalculator {
    * Gets the temporary index of dragged before it occupies new position.
    */
   getDraggedTempIndex() {
-    return this.draggable.tempIndex;
+    return this.draggable.indexPlaceholder;
   }
 
   private setDraggedTempIndex(tempIndex: number) {
-    this.draggable.tempIndex = tempIndex;
+    this.draggable.indexPlaceholder = tempIndex;
     this.draggable.draggedElm.setDataset("index", tempIndex);
   }
 
@@ -222,7 +222,7 @@ class Droppable extends DistanceCalculator {
         const element = store.registry[id];
 
         const isQualified = !element.isPositionedUnder(
-          this.draggable.tempOffset.y
+          this.draggable.offsetPlaceholder.y
         );
 
         if (isQualified) {
@@ -273,7 +273,7 @@ class Droppable extends DistanceCalculator {
         const element = store.registry[id];
 
         const isQualified = element.isPositionedUnder(
-          this.draggable.tempOffset.y
+          this.draggable.offsetPlaceholder.y
         );
 
         if (isQualified) {
@@ -291,7 +291,8 @@ class Droppable extends DistanceCalculator {
     const siblings = store.getElmSiblingsListById(this.draggable.draggedElm.id);
 
     const elmIndex =
-      this.draggable.tempIndex + -1 * this.effectedElemDirection[this.axes];
+      this.draggable.indexPlaceholder +
+      -1 * this.effectedElemDirection[this.axes];
 
     const id = siblings![elmIndex];
 
@@ -320,9 +321,9 @@ class Droppable extends DistanceCalculator {
       this.draggable.draggedElm.id
     ) as string[];
 
-    const from = this.draggable.tempIndex + 1;
+    const from = this.draggable.indexPlaceholder + 1;
 
-    this.leftAtIndex = this.draggable.tempIndex;
+    this.leftAtIndex = this.draggable.indexPlaceholder;
 
     emitSiblingsEvent("onLiftUpSiblings", {
       siblings,
@@ -468,7 +469,7 @@ class Droppable extends DistanceCalculator {
      * Otherwise, detect where it coming from and update tempIndex
      * accordingly.
      */
-    if (this.draggable.tempIndex !== 0) {
+    if (this.draggable.indexPlaceholder !== 0) {
       to = this.detectDroppableIndex();
 
       if (typeof to !== "number") {
@@ -504,7 +505,7 @@ class Droppable extends DistanceCalculator {
       /**
        * Now, resitting direction by figuring out if dragged settled up/dwn.
        */
-      const isElmUp = this.leftAtIndex > this.draggable.tempIndex;
+      const isElmUp = this.leftAtIndex > this.draggable.indexPlaceholder;
 
       this.setEffectedElemDirection(isElmUp, this.axes);
     } else {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -241,6 +241,16 @@ class Droppable extends DistanceCalculator {
             false
           );
 
+          this.draggable.threshold.setMainThreshold(
+            {
+              width: this.draggable.draggedElm.offset.width,
+              height: this.draggable.draggedElm.offset.height,
+              left: this.preserveLastElmOffset!.x,
+              top: this.preserveLastElmOffset!.y,
+            },
+            false
+          );
+
           this.updateOccupiedOffset(
             this.preserveLastElmOffset!.y,
             this.preserveLastElmOffset!.x

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -1,4 +1,5 @@
-import { Axes, AxesCoordinates } from "@dflex/utils";
+import { AxesCoordinates } from "@dflex/utils";
+import type { Axes, AxesCoordinatesInterface } from "@dflex/utils";
 import type { DraggedEvent, SiblingsEvent } from "../types";
 
 import store from "../DnDStore";
@@ -65,7 +66,7 @@ function isIDEligible2Move(
 class Droppable extends DistanceCalculator {
   private leftAtIndex: number;
 
-  private preserveLastElmOffset?: AxesCoordinates;
+  private preserveLastElmOffset?: AxesCoordinatesInterface;
 
   private scrollAnimatedFrame: number | null;
 

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -231,16 +231,6 @@ class Droppable extends DistanceCalculator {
           /**
            * Update threshold from here since there's no calling to updateElement.
            */
-          this.draggable.threshold.updateElementThresholdMatrix(
-            {
-              width: this.draggable.draggedElm.offset.width,
-              height: this.draggable.draggedElm.offset.height,
-              left: this.preserveLastElmOffset!.x,
-              top: this.preserveLastElmOffset!.y,
-            },
-            false
-          );
-
           this.draggable.threshold.setMainThreshold(
             {
               width: this.draggable.draggedElm.offset.width,
@@ -649,7 +639,7 @@ class Droppable extends DistanceCalculator {
 
         if (
           this.draggable.isMovingDown &&
-          y >= threshold!.thresholdMatrix.maxBottom &&
+          y >= threshold!.main.top.min &&
           this.scrollTop + scrollRect.height < scrollHeight
         ) {
           this.scrollElement(x, y, 1, "scrollElementOnY");
@@ -657,7 +647,7 @@ class Droppable extends DistanceCalculator {
           return;
         }
 
-        if (y <= threshold!.thresholdMatrix.maxTop && this.scrollTop > 0) {
+        if (y <= threshold!.main.top.max && this.scrollTop > 0) {
           this.scrollElement(x, y, -1, "scrollElementOnY");
 
           return;
@@ -669,7 +659,7 @@ class Droppable extends DistanceCalculator {
           store.siblingsScrollElement[SK];
 
         if (
-          x >= threshold!.thresholdMatrix.maxLeft &&
+          x >= threshold!.main.left.max &&
           this.scrollLeft + scrollRect.width < scrollHeight
         ) {
           this.scrollElement(x, y, 1, "scrollElementOnX");
@@ -677,7 +667,7 @@ class Droppable extends DistanceCalculator {
           return;
         }
 
-        if (x <= threshold!.thresholdMatrix.maxRight && this.scrollLeft > 0) {
+        if (x <= threshold!.main.left.min && this.scrollLeft > 0) {
           this.scrollElement(x, y, -1, "scrollElementOnX");
         }
       }

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -405,42 +405,40 @@ class Droppable extends DistanceCalculator {
       return;
     }
 
-    if (!this.draggable.isOutActiveSiblingsContainer) {
-      /**
-       * normal movement inside the parent
-       */
+    /**
+     * normal movement inside the parent
+     */
 
-      /**
-       * Going out from the list: Right/left.
-       */
-      if (this.draggable.isOutPositionHorizontally) {
-        // Is is out parent?
+    /**
+     * Going out from the list: Right/left.
+     */
+    if (this.draggable.isOutPositionHorizontally) {
+      // Is is out parent?
 
-        // move element up
-        this.setEffectedElemDirection(true, this.axes);
+      // move element up
+      this.setEffectedElemDirection(true, this.axes);
 
-        // lock the parent
-        this.setDraggedPositionFlagInSiblingsContainer(true);
+      // lock the parent
+      this.setDraggedPositionFlagInSiblingsContainer(true);
 
-        this.fillHeadUp();
+      this.fillHeadUp();
 
-        return;
-      }
-
-      /**
-       * Normal state, switch.
-       */
-
-      // inside the list, effected should be related to mouse movement
-      this.setEffectedElemDirection(
-        this.axes === "y"
-          ? this.draggable.isMovingDown
-          : this.draggable.isMovingLeft,
-        this.axes
-      );
-
-      this.switchElement();
+      return;
     }
+
+    /**
+     * Normal state, switch.
+     */
+
+    // inside the list, effected should be related to mouse movement
+    this.setEffectedElemDirection(
+      this.axes === "y"
+        ? this.draggable.isMovingDown
+        : this.draggable.isMovingLeft,
+      this.axes
+    );
+
+    this.switchElement();
   }
 
   private setDraggedPositionFlagInSiblingsContainer(isOut: boolean) {

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -258,7 +258,9 @@ Please provide scroll container by ref/id when registering the element or turn o
   }
 
   setThresholdMatrix(threshold: ThresholdPercentages) {
-    this.threshold = new Threshold(threshold);
+    this.threshold = new Threshold(threshold, this.scrollRect, {
+      isContainer: true,
+    });
 
     this.threshold.updateElementThresholdMatrix(this.scrollRect, true, true);
   }

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -261,8 +261,6 @@ Please provide scroll container by ref/id when registering the element or turn o
     this.threshold = new Threshold(threshold, this.scrollRect, {
       isContainer: true,
     });
-
-    this.threshold.updateElementThresholdMatrix(this.scrollRect, true, true);
   }
 
   private setScrollCoordinates() {

--- a/packages/dnd/src/Plugins/Scroll/types.ts
+++ b/packages/dnd/src/Plugins/Scroll/types.ts
@@ -27,8 +27,6 @@ export interface ScrollInterface {
   getMaximumScrollContainerTop(): number;
   isElementVisibleViewportX(currentLeft: number): boolean;
   isElementVisibleViewportY(currentTop: number): boolean;
-  setThresholdMatrix(
-    threshold: ThresholdInterface["thresholdPercentages"]
-  ): void;
+  setThresholdMatrix(threshold: ThresholdInterface["percentages"]): void;
   destroy(): void;
 }

--- a/packages/dnd/src/Plugins/Threshold/index.ts
+++ b/packages/dnd/src/Plugins/Threshold/index.ts
@@ -1,5 +1,5 @@
 import Threshold from "./Threshold";
 
-export type { ThresholdInterface, ThresholdMatrix } from "./types";
+export type { ThresholdInterface, ThresholdCoordinate } from "./types";
 
 export default Threshold;

--- a/packages/dnd/src/Plugins/Threshold/types.ts
+++ b/packages/dnd/src/Plugins/Threshold/types.ts
@@ -8,40 +8,19 @@ export interface ThresholdPercentages {
   horizontal: number;
 }
 
-/**
- * Four directions threshold.
- */
-export interface ThresholdMatrix {
-  maxBottom: number;
-  maxTop: number;
-  maxLeft: number;
-  maxRight: number;
-}
-
 export interface ThresholdPointInterface {
   max: number;
   min: number;
 }
 
-export interface IMain {
+export interface ThresholdCoordinate {
   top: ThresholdPointInterface;
   left: ThresholdPointInterface;
 }
 
 export interface ThresholdInterface {
   percentages: ThresholdPercentages;
-  thresholdMatrix: ThresholdMatrix;
-  main: IMain;
+  main: ThresholdCoordinate;
+  getThreshold(rect: Rect, isContainer: boolean): ThresholdCoordinate;
   setMainThreshold(rect: Rect, isContainer: boolean): void;
-  getThresholdMatrix(
-    top: number,
-    left: number,
-    height?: number,
-    relativeToViewport?: boolean
-  ): ThresholdMatrix;
-  updateElementThresholdMatrix(
-    elementRect: Rect,
-    relativeToContainer: boolean,
-    relativeToViewport?: boolean
-  ): void;
 }

--- a/packages/dnd/src/Plugins/Threshold/types.ts
+++ b/packages/dnd/src/Plugins/Threshold/types.ts
@@ -9,14 +9,6 @@ export interface ThresholdPercentages {
 }
 
 /**
- * Threshold in pixel relevant to input percentages.
- */
-export interface ThresholdInPixels {
-  x: number;
-  y: number;
-}
-
-/**
  * Four directions threshold.
  */
 export interface ThresholdMatrix {
@@ -26,10 +18,21 @@ export interface ThresholdMatrix {
   maxRight: number;
 }
 
+export interface ThresholdPointInterface {
+  max: number;
+  min: number;
+}
+
+export interface IMain {
+  top: ThresholdPointInterface;
+  left: ThresholdPointInterface;
+}
+
 export interface ThresholdInterface {
-  thresholdPercentages: ThresholdPercentages;
-  thresholdPixels: ThresholdInPixels;
+  percentages: ThresholdPercentages;
   thresholdMatrix: ThresholdMatrix;
+  main: IMain;
+  setMainThreshold(rect: Rect, isContainer: boolean): void;
   getThresholdMatrix(
     top: number,
     left: number,

--- a/packages/dnd/src/types.ts
+++ b/packages/dnd/src/types.ts
@@ -84,11 +84,11 @@ export interface ScrollOptWithoutThreshold {
 
 export interface ScrollOptWithPartialThreshold
   extends ScrollOptWithoutThreshold {
-  threshold: Partial<ThresholdInterface["thresholdPercentages"]>;
+  threshold: Partial<ThresholdInterface["percentages"]>;
 }
 
 export interface ScrollOptWithThreshold extends ScrollOptWithoutThreshold {
-  threshold: ThresholdInterface["thresholdPercentages"];
+  threshold: ThresholdInterface["percentages"];
 }
 
 export interface RestrictionsStatus {
@@ -97,7 +97,7 @@ export interface RestrictionsStatus {
 }
 
 export interface FinalDndOpts {
-  threshold: ThresholdInterface["thresholdPercentages"];
+  threshold: ThresholdInterface["percentages"];
   restrictions: Restrictions;
   restrictionsStatus: RestrictionsStatus;
   scroll: ScrollOptWithThreshold;
@@ -105,7 +105,7 @@ export interface FinalDndOpts {
 }
 
 export interface DndOpts {
-  threshold?: Partial<ThresholdInterface["thresholdPercentages"]>;
+  threshold?: Partial<ThresholdInterface["percentages"]>;
   restrictions?: {
     self?: Partial<Restrictions["self"]>;
     container?: Partial<Restrictions["container"]>;

--- a/packages/draggable/src/AbstractDraggable.ts
+++ b/packages/draggable/src/AbstractDraggable.ts
@@ -1,5 +1,6 @@
 import type { AbstractCoreInterface } from "@dflex/core-instance";
 import { AxesCoordinates } from "@dflex/utils";
+import type { AxesCoordinatesInterface } from "@dflex/utils";
 
 import type {
   AbstractDraggableInterface,
@@ -22,9 +23,9 @@ class AbstractDraggable<T extends AbstractCoreInterface>
    * equating: initX = X. Taking into considerations translate value.
    *
    */
-  outerOffset: AxesCoordinates;
+  outerOffset: AxesCoordinatesInterface;
 
-  translatePlaceholder: AxesCoordinates;
+  translatePlaceholder: AxesCoordinatesInterface;
 
   static draggedStyle: DraggedStyle = [
     {

--- a/packages/draggable/src/types.ts
+++ b/packages/draggable/src/types.ts
@@ -1,5 +1,5 @@
 import type { AbstractCoreInterface } from "@dflex/core-instance";
-import { AxesCoordinates } from "@dflex/utils";
+import type { AxesCoordinatesInterface } from "@dflex/utils";
 
 export interface Coordinates {
   x: number;
@@ -45,7 +45,7 @@ export interface AbstractDraggableInterface<T extends AbstractCoreInterface> {
    * equating: initX = X. Taking into considerations translate value.
    *
    */
-  outerOffset: AxesCoordinates;
-  translatePlaceholder: AxesCoordinates;
+  outerOffset: AxesCoordinatesInterface;
+  translatePlaceholder: AxesCoordinatesInterface;
   changeStyle(style: DraggedStyle, shouldAddPosition: boolean): void;
 }

--- a/packages/utils/src/AxesCoordinates.ts
+++ b/packages/utils/src/AxesCoordinates.ts
@@ -1,4 +1,6 @@
-class AxesCoordinates<T = number> {
+import type { AxesCoordinatesInterface } from "./types";
+
+class AxesCoordinates<T = number> implements AxesCoordinatesInterface<T> {
   x!: T;
 
   y!: T;
@@ -12,11 +14,11 @@ class AxesCoordinates<T = number> {
     this.y = y;
   }
 
-  clone(target: AxesCoordinates<T>) {
+  clone(target: AxesCoordinatesInterface<T>) {
     this.setAxes(target.x, target.y);
   }
 
-  isEqual(target: AxesCoordinates<T>) {
+  isEqual(target: AxesCoordinatesInterface<T>) {
     return this.x === target.x && this.y === target.y;
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,9 @@
 export { default as AxesCoordinates } from "./AxesCoordinates";
 
-export type { Rect, Axes, Direction, EffectedElemDirection } from "./types";
+export type {
+  Rect,
+  Axes,
+  Direction,
+  EffectedElemDirection,
+  AxesCoordinatesInterface,
+} from "./types";

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -14,3 +14,11 @@ export interface EffectedElemDirection {
 }
 
 export type Axes = "x" | "y";
+
+export interface AxesCoordinatesInterface<T = number> {
+  x: T;
+  y: T;
+  setAxes(x: T, y: T): void;
+  clone(target: AxesCoordinatesInterface<T>): void;
+  isEqual(target: AxesCoordinatesInterface<T>): boolean;
+}


### PR DESCRIPTION
- [x] Add Interface to Axes Coordinate.
- [x] Keep `draggedOutPosition` to dragged inside the parent container. Removing unnecessary flags.
- [x] Enhance threshold to have `main` object contains the main element threshold instead of the previous approach which included unclear properties. The new threshold has max and min for each defined point defined as follows: 
```ts
interface ThresholdPointInterface {
  max: number;
  min: number;
}
```
- [x] Add utility class `ThresholdPoint` for each point. 