### PR TITLE
Add a new dragging implementation for Interactive/Axes

### DIFF
--- a/packages/dnd/src/DnD.ts
+++ b/packages/dnd/src/DnD.ts
@@ -1,6 +1,6 @@
 import type { Coordinates } from "@dflex/draggable";
 
-import Draggable from "./Draggable";
+import DraggableInteractive from "./Draggable";
 import Droppable from "./Droppable";
 import store from "./DnDStore";
 
@@ -51,7 +51,7 @@ class DnD extends Droppable {
      */
     store.initSiblingsScrollAndVisibilityIfNecessary(SK);
 
-    const draggable = new Draggable(
+    const draggable = new DraggableInteractive(
       id,
       initCoordinates,
       options as FinalDndOpts

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -267,7 +267,7 @@ class Draggable
      * Add flag for undo method so we can check which  parent is being
      * transformed and which is not.
      */
-    this.isDraggedOutContainer.setAllFalse();
+    this.isDraggedOutContainer.setFalsy();
   }
 
   private axesYFilter(
@@ -453,35 +453,12 @@ class Draggable
     return x < left.max || x > left.min;
   }
 
-  private isOutPositionV() {
-    const { top } = this.threshold.main;
-
-    const { y } = this.offsetPlaceholder;
-
-    return this.isMovingDown ? y > top.min : y < top.max;
-  }
-
-  private isOutPositionH() {
-    const { left } = this.threshold.main;
-
-    const { x } = this.offsetPlaceholder;
-
-    return this.isMovingLeft ? x > left.min : x < left.max;
-  }
-
-  private isOutContainerV($: ThresholdCoordinate) {
+  private isOutThresholdV($: ThresholdCoordinate) {
     const { y } = this.offsetPlaceholder;
 
     const { top } = $;
 
-    /**
-     * Are you last element and outside the container? Or are you coming from top
-     * and outside the container?
-     */
-    return (
-      (this.isLastELm() && y > top.min) ||
-      (this.indexPlaceholder < 0 && y < top.max)
-    );
+    return y < top.max || y > top.min;
   }
 
   private isOutPosition($: ThresholdCoordinate) {
@@ -491,19 +468,19 @@ class Draggable
       return true;
     }
 
-    if (this.isOutPositionV() || this.isOutPositionH()) {
+    if (this.isOutThresholdV($)) {
       this.isDraggedOutPosition.setAxes(false, true);
 
       return true;
     }
 
-    this.isDraggedOutPosition.setAllFalse();
+    this.isDraggedOutPosition.setFalsy();
 
     return false;
   }
 
   private isOutContainer($: ThresholdCoordinate) {
-    if (this.isOutContainerV($)) {
+    if (this.isOutThresholdV($)) {
       this.isDraggedOutContainer.setAxes(false, true);
 
       return true;
@@ -515,7 +492,7 @@ class Draggable
       return true;
     }
 
-    this.isDraggedOutContainer.setAllFalse();
+    this.isDraggedOutContainer.setFalsy();
 
     return false;
   }
@@ -551,7 +528,7 @@ class Draggable
     return (
       this.isLastELm() &&
       this.isMovingDown &&
-      this.isOutContainerV(this.layoutThresholds[SK])
+      this.isOutThresholdV(this.layoutThresholds[SK])
     );
   }
 

--- a/packages/dnd/src/Draggable/Draggable.ts
+++ b/packages/dnd/src/Draggable/Draggable.ts
@@ -434,7 +434,7 @@ class Draggable
 
     const { left } = $;
 
-    return x < left.max || x > left.min;
+    return this.isMovingLeft ? x > left.min : x < left.max;
   }
 
   private isOutThresholdV($: ThresholdCoordinate) {
@@ -442,7 +442,7 @@ class Draggable
 
     const { top } = $;
 
-    return y < top.max || y > top.min;
+    return this.isMovingDown ? y > top.min : y < top.max;
   }
 
   private checkAndSetPosition(
@@ -475,30 +475,24 @@ class Draggable
       : this.checkAndSetPosition(this.threshold.main, "isDraggedOutPosition");
   }
 
-  isLeavingFromTop() {
+  isLeavingFromHead() {
     return (
-      this.indexPlaceholder <= 0 && // first our outside.
-      !this.isDraggedOutContainer.x &&
-      !this.isMovingDown
+      !this.isMovingDown && this.indexPlaceholder <= 0 // first our outside.
     );
   }
 
-  isLeavingFromBottom() {
+  isLeavingFromTail() {
     const lastElm =
       (store.getElmSiblingsListById(this.draggedElm.id) as string[]).length - 1;
 
-    return (
-      this.indexPlaceholder === lastElm &&
-      !this.isDraggedOutContainer.x &&
-      this.isMovingDown
-    );
+    return this.isMovingDown && this.indexPlaceholder === lastElm;
   }
 
   isNotSettled() {
     const { SK } = store.registry[this.draggedElm.id].keys;
 
     return (
-      !this.isLeavingFromBottom() &&
+      !this.isLeavingFromTail() &&
       (this.isOutThreshold() || this.isOutThreshold(SK))
     );
   }

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -410,10 +410,15 @@ class DraggableAxes
   }
 
   isLeavingFromTail() {
+    const { SK } = store.registry[this.draggedElm.id].keys;
+
     const lastElm =
       (store.getElmSiblingsListById(this.draggedElm.id) as string[]).length - 1;
 
-    return this.isMovingAwayFrom.y && this.indexPlaceholder === lastElm;
+    return (
+      this.indexPlaceholder === lastElm &&
+      this.isOutContainerV(this.layoutThresholds[SK])
+    );
   }
 
   isNotSettled() {

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -1,5 +1,5 @@
 import { AbstractDraggable } from "@dflex/draggable";
-import type { DraggedStyle, Coordinates } from "@dflex/draggable";
+import type { Coordinates } from "@dflex/draggable";
 
 import { AxesCoordinates, AxesCoordinatesBool } from "@dflex/utils";
 import type {
@@ -11,35 +11,31 @@ import type { CoreInstanceInterface } from "@dflex/core-instance";
 
 import store from "../DnDStore";
 
-import type { DraggableDnDInterface, Restrictions } from "./types";
-
 import type {
-  ScrollOptWithThreshold,
-  FinalDndOpts,
-  RestrictionsStatus,
-} from "../types";
+  DraggableAxesInterface,
+  SiblingsThreshold,
+  Restrictions,
+} from "./types";
 
-import Threshold, { ThresholdCoordinate } from "../Plugins/Threshold";
+import type { FinalDndOpts, RestrictionsStatus } from "../types";
 
-class Draggable
+import Threshold from "../Plugins/Threshold";
+import type {
+  ThresholdInterface,
+  ThresholdCoordinate,
+} from "../Plugins/Threshold";
+
+class DraggableAxes
   extends AbstractDraggable<CoreInstanceInterface>
-  implements DraggableDnDInterface
+  implements DraggableAxesInterface
 {
   private isLayoutStateUpdated: boolean;
 
   indexPlaceholder: number;
 
-  operationID: string;
+  threshold: ThresholdInterface;
 
-  siblingsContainer: CoreInstanceInterface | null;
-
-  setOfTransformedIds?: Set<string>;
-
-  threshold: DraggableDnDInterface["threshold"];
-
-  layoutThresholds!: DraggableDnDInterface["layoutThresholds"];
-
-  scroll: ScrollOptWithThreshold;
+  layoutThresholds: SiblingsThreshold;
 
   isViewportRestricted: boolean;
 
@@ -47,15 +43,9 @@ class Draggable
 
   offsetPlaceholder: AxesCoordinatesInterface;
 
-  occupiedOffset: AxesCoordinatesInterface;
-
-  occupiedTranslate: AxesCoordinatesInterface;
-
   mousePoints: AxesCoordinatesInterface;
 
   isMovingAwayFrom: AxesCoordinatesBoolInterface;
-
-  numberOfElementsTransformed: number;
 
   isDraggedOutPosition: AxesCoordinatesBoolInterface;
 
@@ -73,12 +63,8 @@ class Draggable
 
   private initX: number;
 
-  isDraggedPositionFixed: boolean;
-
-  private changeToFixedStyleProps: DraggedStyle;
-
   constructor(id: string, initCoordinates: Coordinates, opts: FinalDndOpts) {
-    const { element, parent } = store.getElmTreeById(id);
+    const { element } = store.getElmTreeById(id);
 
     super(element, initCoordinates);
 
@@ -92,62 +78,17 @@ class Draggable
      */
     this.indexPlaceholder = order.self;
 
-    // This tiny bug caused an override  options despite it's actually freezed!
-    this.scroll = { ...opts.scroll };
-
     const { SK } = store.registry[id].keys;
-
-    const { hasOverflowX, hasOverflowY } = store.siblingsScrollElement[SK];
 
     const siblings = store.getElmSiblingsListById(this.draggedElm.id);
 
     this.isViewportRestricted = true;
-    this.isDraggedPositionFixed = false;
-
-    this.changeToFixedStyleProps = [
-      {
-        prop: "top",
-        dragValue: `${this.draggedElm.currentPosition.y}px`,
-        afterDragValue: "",
-      },
-      {
-        prop: "left",
-        dragValue: `${this.draggedElm.currentPosition.x}px`,
-        afterDragValue: "",
-      },
-      {
-        prop: "position",
-        dragValue: "fixed",
-        afterDragValue: "",
-      },
-    ];
-
-    if (siblings === null || (!hasOverflowY && !hasOverflowX)) {
-      // Override the default options. (FYI, this is the only privilege I have.)
-      this.scroll.enable = false;
-    }
-
-    if (this.scroll.enable) {
-      this.isViewportRestricted = false;
-
-      store.siblingsScrollElement[SK].setThresholdMatrix(this.scroll.threshold);
-
-      if (!store.siblingsScrollElement[SK].hasDocumentAsContainer) {
-        /**
-         * When the scroll is the document it's good. The restriction is to the
-         * document which guarantees the free movement. Otherwise, let's do it.
-         * Change the position and transform siblings.
-         */
-        // this.isDraggedPositionFixed = true;
-      }
-    }
 
     const siblingsBoundaries = store.siblingsBoundaries[SK];
 
     const {
       offset: { width, height },
       currentPosition,
-      translate,
     } = this.draggedElm;
 
     this.threshold = new Threshold(
@@ -177,24 +118,13 @@ class Draggable
           true
         ),
       };
+    } else {
+      this.layoutThresholds = {};
     }
-
-    this.siblingsContainer = null;
 
     this.isDraggedOutPosition = new AxesCoordinatesBool(false, false);
     this.isDraggedOutContainer = new AxesCoordinatesBool(false, false);
     this.isMovingAwayFrom = new AxesCoordinatesBool(false, false);
-
-    if (parent) {
-      /**
-       * Indicator to parents that have changed. This facilitates looping in
-       * affected parents only.
-       */
-      this.setOfTransformedIds = new Set([]);
-      this.assignActiveParent(parent);
-    }
-
-    this.operationID = store.tracker.newTravel();
 
     const { x, y } = initCoordinates;
 
@@ -218,20 +148,7 @@ class Draggable
       currentPosition.y
     );
 
-    this.occupiedOffset = new AxesCoordinates(
-      currentPosition.x,
-      currentPosition.y
-    );
-
-    this.occupiedTranslate = new AxesCoordinates(translate.x, translate.y);
-
     this.mousePoints = new AxesCoordinates(x, y);
-
-    /**
-     * It counts number of element that dragged has passed. This counter is
-     * crucial to calculate drag's translate and index
-     */
-    this.numberOfElementsTransformed = 0;
 
     this.restrictions = opts.restrictions;
 
@@ -241,25 +158,6 @@ class Draggable
       siblings !== null &&
       (opts.restrictionsStatus.isContainerRestricted ||
         opts.restrictionsStatus.isSelfRestricted);
-  }
-
-  /**
-   * Assigns new container parent to the dragged.
-   *
-   * @param element -
-   */
-  private assignActiveParent(element: CoreInstanceInterface) {
-    /**
-     * Assign a new instance which represents droppable. Then
-     * assign owner parent so we have from/to.
-     */
-    this.siblingsContainer = element;
-
-    /**
-     * Add flag for undo method so we can check which  parent is being
-     * transformed and which is not.
-     */
-    this.isDraggedOutContainer.setFalsy();
   }
 
   private axesYFilter(
@@ -317,9 +215,13 @@ class Draggable
     return x;
   }
 
-  setDraggedTempIndex(i: number) {
-    this.indexPlaceholder = i;
-    this.draggedElm.setDataset("index", i);
+  private setDraggedMouseMovement(x: number, y: number) {
+    this.isMovingAwayFrom.setAxes(
+      x > this.mousePoints.x,
+      y > this.mousePoints.y
+    );
+
+    this.mousePoints.setAxes(x, y);
   }
 
   /**
@@ -340,6 +242,8 @@ class Draggable
       this.isLayoutStateUpdated = true;
       store.onStateChange("dragging");
     }
+
+    this.setDraggedMouseMovement(x, y);
 
     let filteredY = y;
     let filteredX = x;
@@ -469,7 +373,7 @@ class Draggable
 
   isLeavingFromHead() {
     return (
-      this.isMovingAwayFrom.x && this.indexPlaceholder <= 0 // first our outside.
+      this.isMovingAwayFrom.y && this.indexPlaceholder <= 0 // first our outside.
     );
   }
 
@@ -477,7 +381,7 @@ class Draggable
     const lastElm =
       (store.getElmSiblingsListById(this.draggedElm.id) as string[]).length - 1;
 
-    return this.isMovingAwayFrom.y && this.indexPlaceholder === lastElm;
+    return !this.isMovingAwayFrom.y && this.indexPlaceholder === lastElm;
   }
 
   isNotSettled() {
@@ -488,85 +392,6 @@ class Draggable
       (this.isOutThreshold() || this.isOutThreshold(SK))
     );
   }
-
-  setDraggedMouseMovement(x: number, y: number) {
-    this.isMovingAwayFrom.setAxes(
-      x > this.mousePoints.x,
-      y > this.mousePoints.y
-    );
-
-    this.mousePoints.setAxes(x, y);
-  }
-
-  updateNumOfElementsTransformed(effectedElemDirection: number) {
-    this.numberOfElementsTransformed += -1 * effectedElemDirection;
-  }
-
-  setDraggedTransformPosition(isFallback: boolean) {
-    const siblings = store.getElmSiblingsListById(this.draggedElm.id);
-
-    /**
-     * In this case, the use clicked without making any move.
-     */
-    if (
-      isFallback ||
-      siblings === null ||
-      this.numberOfElementsTransformed === 0
-    ) {
-      /**
-       * If not isDraggedOutPosition, it means dragged is out its position, inside
-       * list but didn't reach another element to replace.
-       *
-       * List's elements is in their position, just undo dragged.
-       *
-       * Restore dragged position (translateX, translateY) directly. Why? Because,
-       * dragged depends on extra instance to float in layout that is not related to element
-       * instance.
-       */
-      if (!this.draggedElm.translate.isEqual(this.translatePlaceholder)) {
-        this.draggedElm.transformElm();
-        this.draggedElm.setDataset("index", this.draggedElm.order.self);
-
-        /**
-         * There's a rare case where dragged leaves and returns to the same
-         * position. In this case, undo won't be triggered so that we have to do
-         * it manually here. Otherwise, undoing will handle repositioning. I
-         * don't like it but it is what it is.
-         */
-        if (
-          siblings &&
-          siblings[this.draggedElm.order.self] !== this.draggedElm.id
-        ) {
-          this.draggedElm.assignNewPosition(
-            siblings,
-            this.draggedElm.order.self
-          );
-        }
-      }
-
-      return;
-    }
-
-    this.draggedElm.currentPosition.clone(this.occupiedOffset);
-    this.draggedElm.translate.clone(this.occupiedTranslate);
-
-    this.draggedElm.transformElm();
-
-    if (siblings) {
-      this.draggedElm.assignNewPosition(siblings, this.indexPlaceholder);
-    }
-
-    this.draggedElm.order.self = this.indexPlaceholder;
-  }
-
-  endDragging(isFallback: boolean) {
-    this.setDragged(false);
-    this.setDraggedTransformPosition(isFallback);
-
-    if (this.isDraggedPositionFixed) {
-      this.changeStyle(this.changeToFixedStyleProps, false);
-    }
-  }
 }
 
-export default Draggable;
+export default DraggableAxes;

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -33,6 +33,8 @@ class DraggableAxes
 
   indexPlaceholder: number;
 
+  positionPlaceholder: AxesCoordinatesInterface;
+
   threshold: ThresholdInterface;
 
   layoutThresholds: SiblingsThreshold;
@@ -40,8 +42,6 @@ class DraggableAxes
   isViewportRestricted: boolean;
 
   innerOffset: AxesCoordinatesInterface;
-
-  offsetPlaceholder: AxesCoordinatesInterface;
 
   mousePoints: AxesCoordinatesInterface;
 
@@ -72,10 +72,6 @@ class DraggableAxes
 
     const { order } = element;
 
-    /**
-     * Initialize temp index that refers to element new position after
-     * transformation happened.
-     */
     this.indexPlaceholder = order.self;
 
     const { SK } = store.registry[id].keys;
@@ -143,7 +139,7 @@ class DraggableAxes
     const lm = Math.round(parseFloat(style.marginLeft));
     this.marginX = rm + lm;
 
-    this.offsetPlaceholder = new AxesCoordinates(
+    this.positionPlaceholder = new AxesCoordinates(
       currentPosition.x,
       currentPosition.y
     );
@@ -265,7 +261,6 @@ class DraggableAxes
           minRight,
           this.restrictions.container.allowLeavingFromLeft,
           this.restrictions.container.allowLeavingFromRight,
-
           false
         );
         filteredY = this.axesYFilter(
@@ -319,14 +314,14 @@ class DraggableAxes
     /**
      * Every time we got new translate, offset should be updated
      */
-    this.offsetPlaceholder.setAxes(
+    this.positionPlaceholder.setAxes(
       filteredX - this.innerOffset.x,
       filteredY - this.innerOffset.y
     );
   }
 
   private isOutThresholdH($: ThresholdCoordinate) {
-    const { x } = this.offsetPlaceholder;
+    const { x } = this.positionPlaceholder;
 
     const { left } = $;
 
@@ -334,7 +329,7 @@ class DraggableAxes
   }
 
   private isOutThresholdV($: ThresholdCoordinate) {
-    const { y } = this.offsetPlaceholder;
+    const { y } = this.positionPlaceholder;
 
     const { top } = $;
 

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -220,19 +220,6 @@ class DraggableAxes
     this.mousePoints.setAxes(x, y);
   }
 
-  /**
-   * Dragged current-offset is essential to determine dragged position in
-   * layout and parent.
-   *
-   * Is it moved form its translate? Is it out the parent or in
-   * another parent? The answer is related to currentOffset.
-   *
-   * Note: these are the current offset related only to the dragging. When the
-   * operation is done, different calculation will be set.
-   *
-   * @param x -
-   * @param y -
-   */
   dragAt(x: number, y: number) {
     if (!this.isLayoutStateUpdated) {
       this.isLayoutStateUpdated = true;
@@ -368,7 +355,7 @@ class DraggableAxes
 
   isLeavingFromHead() {
     return (
-      this.isMovingAwayFrom.y && this.indexPlaceholder <= 0 // first our outside.
+      !this.isMovingAwayFrom.y && this.indexPlaceholder <= 0 // first our outside.
     );
   }
 
@@ -376,7 +363,7 @@ class DraggableAxes
     const lastElm =
       (store.getElmSiblingsListById(this.draggedElm.id) as string[]).length - 1;
 
-    return !this.isMovingAwayFrom.y && this.indexPlaceholder === lastElm;
+    return this.isMovingAwayFrom.y && this.indexPlaceholder === lastElm;
   }
 
   isNotSettled() {

--- a/packages/dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dnd/src/Draggable/DraggableInteractive.ts
@@ -1,0 +1,216 @@
+import type { DraggedStyle, Coordinates } from "@dflex/draggable";
+
+import { AxesCoordinates } from "@dflex/utils";
+import type { AxesCoordinatesInterface } from "@dflex/utils";
+
+import type { CoreInstanceInterface } from "@dflex/core-instance";
+
+import store from "../DnDStore";
+
+import type { DraggableInteractiveInterface } from "./types";
+
+import type { ScrollOptWithThreshold, FinalDndOpts } from "../types";
+
+import DraggableAxes from "./DraggableAxes";
+
+class DraggableInteractive
+  extends DraggableAxes
+  implements DraggableInteractiveInterface
+{
+  operationID: string;
+
+  siblingsContainer: CoreInstanceInterface | null;
+
+  setOfTransformedIds?: Set<string>;
+
+  scroll: ScrollOptWithThreshold;
+
+  occupiedOffset: AxesCoordinatesInterface;
+
+  occupiedTranslate: AxesCoordinatesInterface;
+
+  numberOfElementsTransformed: number;
+
+  isDraggedPositionFixed: boolean;
+
+  private changeToFixedStyleProps: DraggedStyle;
+
+  constructor(id: string, initCoordinates: Coordinates, opts: FinalDndOpts) {
+    const { parent } = store.getElmTreeById(id);
+
+    super(id, initCoordinates, opts);
+
+    // This tiny bug caused an override  options despite it's actually freezed!
+    this.scroll = { ...opts.scroll };
+
+    const { SK } = store.registry[id].keys;
+
+    const { hasOverflowX, hasOverflowY } = store.siblingsScrollElement[SK];
+
+    const siblings = store.getElmSiblingsListById(this.draggedElm.id);
+
+    this.isDraggedPositionFixed = false;
+
+    this.changeToFixedStyleProps = [
+      {
+        prop: "top",
+        dragValue: `${this.draggedElm.currentPosition.y}px`,
+        afterDragValue: "",
+      },
+      {
+        prop: "left",
+        dragValue: `${this.draggedElm.currentPosition.x}px`,
+        afterDragValue: "",
+      },
+      {
+        prop: "position",
+        dragValue: "fixed",
+        afterDragValue: "",
+      },
+    ];
+
+    if (siblings === null || (!hasOverflowY && !hasOverflowX)) {
+      // Override the default options. (FYI, this is the only privilege I have.)
+      this.scroll.enable = false;
+    }
+
+    if (this.scroll.enable) {
+      this.isViewportRestricted = false;
+
+      store.siblingsScrollElement[SK].setThresholdMatrix(this.scroll.threshold);
+
+      if (!store.siblingsScrollElement[SK].hasDocumentAsContainer) {
+        /**
+         * When the scroll is the document it's good. The restriction is to the
+         * document which guarantees the free movement. Otherwise, let's do it.
+         * Change the position and transform siblings.
+         */
+        // this.isDraggedPositionFixed = true;
+      }
+    }
+
+    const { currentPosition, translate } = this.draggedElm;
+
+    this.siblingsContainer = null;
+
+    if (parent) {
+      /**
+       * Indicator to parents that have changed. This facilitates looping in
+       * affected parents only.
+       */
+      this.setOfTransformedIds = new Set([]);
+      this.assignActiveParent(parent);
+    }
+
+    this.operationID = store.tracker.newTravel();
+
+    this.occupiedOffset = new AxesCoordinates(
+      currentPosition.x,
+      currentPosition.y
+    );
+
+    this.occupiedTranslate = new AxesCoordinates(translate.x, translate.y);
+
+    /**
+     * It counts number of element that dragged has passed. This counter is
+     * crucial to calculate drag's translate and index
+     */
+    this.numberOfElementsTransformed = 0;
+  }
+
+  /**
+   * Assigns new container parent to the dragged.
+   *
+   * @param element -
+   */
+  private assignActiveParent(element: CoreInstanceInterface) {
+    /**
+     * Assign a new instance which represents droppable. Then
+     * assign owner parent so we have from/to.
+     */
+    this.siblingsContainer = element;
+
+    /**
+     * Add flag for undo method so we can check which  parent is being
+     * transformed and which is not.
+     */
+    this.isDraggedOutContainer.setFalsy();
+  }
+
+  setDraggedTempIndex(i: number) {
+    this.indexPlaceholder = i;
+    this.draggedElm.setDataset("index", i);
+  }
+
+  updateNumOfElementsTransformed(effectedElemDirection: number) {
+    this.numberOfElementsTransformed += -1 * effectedElemDirection;
+  }
+
+  setDraggedTransformPosition(isFallback: boolean) {
+    const siblings = store.getElmSiblingsListById(this.draggedElm.id);
+
+    /**
+     * In this case, the use clicked without making any move.
+     */
+    if (
+      isFallback ||
+      siblings === null ||
+      this.numberOfElementsTransformed === 0
+    ) {
+      /**
+       * If not isDraggedOutPosition, it means dragged is out its position, inside
+       * list but didn't reach another element to replace.
+       *
+       * List's elements is in their position, just undo dragged.
+       *
+       * Restore dragged position (translateX, translateY) directly. Why? Because,
+       * dragged depends on extra instance to float in layout that is not related to element
+       * instance.
+       */
+      if (!this.draggedElm.translate.isEqual(this.translatePlaceholder)) {
+        this.draggedElm.transformElm();
+        this.draggedElm.setDataset("index", this.draggedElm.order.self);
+
+        /**
+         * There's a rare case where dragged leaves and returns to the same
+         * position. In this case, undo won't be triggered so that we have to do
+         * it manually here. Otherwise, undoing will handle repositioning. I
+         * don't like it but it is what it is.
+         */
+        if (
+          siblings &&
+          siblings[this.draggedElm.order.self] !== this.draggedElm.id
+        ) {
+          this.draggedElm.assignNewPosition(
+            siblings,
+            this.draggedElm.order.self
+          );
+        }
+      }
+
+      return;
+    }
+
+    this.draggedElm.currentPosition.clone(this.occupiedOffset);
+    this.draggedElm.translate.clone(this.occupiedTranslate);
+
+    this.draggedElm.transformElm();
+
+    if (siblings) {
+      this.draggedElm.assignNewPosition(siblings, this.indexPlaceholder);
+    }
+
+    this.draggedElm.order.self = this.indexPlaceholder;
+  }
+
+  endDragging(isFallback: boolean) {
+    this.setDragged(false);
+    this.setDraggedTransformPosition(isFallback);
+
+    if (this.isDraggedPositionFixed) {
+      this.changeStyle(this.changeToFixedStyleProps, false);
+    }
+  }
+}
+
+export default DraggableInteractive;

--- a/packages/dnd/src/Draggable/index.ts
+++ b/packages/dnd/src/Draggable/index.ts
@@ -1,5 +1,5 @@
-import Draggable from "./Draggable";
+import DraggableInteractive from "./DraggableInteractive";
 
-export type { DraggableDnDInterface, Restrictions } from "./types";
+export type { DraggableInteractiveInterface, Restrictions } from "./types";
 
-export default Draggable;
+export default DraggableInteractive;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -57,8 +57,14 @@ export interface DraggableDnDInterface
   dragAt(x: number, y: number): void;
   updateNumOfElementsTransformed(effectedElemDirection: number): void;
   setDraggedMovementDirection(coordinate: number, axes: Axes): void;
+  /**
+   * Check if the dragged out self position or parent container and set the
+   * necessary flags.
+   */
   isOutThreshold(siblingsK?: string): boolean;
+  /** Checks if dragged is the first child and going up. */
   isLeavingFromTop(): boolean;
+  /** Checks if dragged is the last child and going down. */
   isLeavingFromBottom(): boolean;
   isNotSettled(): boolean;
   endDragging(isFallback: boolean): void;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -34,25 +34,38 @@ export interface Restrictions {
 
 export interface DraggableAxesInterface
   extends AbstractDraggableInterface<CoreInstanceInterface> {
+  /** Dragged threshold  */
   readonly threshold: ThresholdInterface;
+
+  /** Dragged parent containers threshold  */
   readonly layoutThresholds: SiblingsThreshold;
+
   readonly innerOffset: AxesCoordinatesInterface;
-  readonly offsetPlaceholder: AxesCoordinatesInterface;
+
+  /** Dragged position for both X and Y.  */
+  readonly positionPlaceholder: AxesCoordinatesInterface;
+
+  /** Temporary index for dragged  */
   readonly indexPlaceholder: number;
 
   /** Previous X and Y are used to calculate mouse directions. */
   readonly mousePoints: AxesCoordinatesInterface;
+
+  /** Restrict dragged movement inside viewport.  */
   readonly isViewportRestricted: boolean;
 
   /**
-   * If the dragged is moving opposite to the center X/Y.
+   * If the dragged is moving opposite to the center X/Y point(0.0).
    * Far from Y, is moving down.
    * Far from X, is moving right.
    */
   readonly isMovingAwayFrom: AxesCoordinatesBoolInterface;
+
   readonly isDraggedOutPosition: AxesCoordinatesBoolInterface;
   readonly isDraggedOutContainer: AxesCoordinatesBoolInterface;
+
   dragAt(x: number, y: number): void;
+
   /**
    * Check if the dragged out self position or parent container and set the
    * necessary flags.
@@ -70,6 +83,8 @@ export interface DraggableAxesInterface
    * is out self threshold.
    */
   isLeavingFromTail(): boolean;
+
+  /** Has moved without settling inside new position. */
   isNotSettled(): boolean;
 }
 

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -13,7 +13,7 @@ import type {
   ThresholdCoordinate,
 } from "../Plugins/Threshold";
 
-export interface SiblingsThresholdMatrix {
+export interface SiblingsThreshold {
   [sk: string]: ThresholdCoordinate;
 }
 
@@ -32,23 +32,16 @@ export interface Restrictions {
   };
 }
 
-export interface DraggableDnDInterface
+export interface DraggableAxesInterface
   extends AbstractDraggableInterface<CoreInstanceInterface> {
-  readonly operationID: string;
   readonly threshold: ThresholdInterface;
-  readonly layoutThresholds: SiblingsThresholdMatrix;
+  readonly layoutThresholds: SiblingsThreshold;
   readonly innerOffset: AxesCoordinatesInterface;
   readonly offsetPlaceholder: AxesCoordinatesInterface;
   readonly indexPlaceholder: number;
-  setOfTransformedIds?: Set<string>;
-  siblingsContainer: CoreInstanceInterface | null;
-  scroll: ScrollOptWithThreshold;
-  readonly occupiedOffset: AxesCoordinatesInterface;
-  readonly occupiedTranslate: AxesCoordinatesInterface;
 
   /** Previous X and Y are used to calculate mouse directions. */
   readonly mousePoints: AxesCoordinatesInterface;
-  readonly numberOfElementsTransformed: number;
   readonly isViewportRestricted: boolean;
 
   /**
@@ -59,11 +52,7 @@ export interface DraggableDnDInterface
   readonly isMovingAwayFrom: AxesCoordinatesBoolInterface;
   readonly isDraggedOutPosition: AxesCoordinatesBoolInterface;
   readonly isDraggedOutContainer: AxesCoordinatesBoolInterface;
-  readonly isDraggedPositionFixed: boolean;
-  setDraggedTempIndex(i: number): void;
   dragAt(x: number, y: number): void;
-  updateNumOfElementsTransformed(effectedElemDirection: number): void;
-  setDraggedMouseMovement(x: number, y: number): void;
   /**
    * Check if the dragged out self position or parent container and set the
    * necessary flags.
@@ -82,5 +71,18 @@ export interface DraggableDnDInterface
    */
   isLeavingFromTail(): boolean;
   isNotSettled(): boolean;
+}
+
+export interface DraggableInteractiveInterface extends DraggableAxesInterface {
+  readonly operationID: string;
+  setOfTransformedIds?: Set<string>;
+  siblingsContainer: CoreInstanceInterface | null;
+  scroll: ScrollOptWithThreshold;
+  readonly occupiedOffset: AxesCoordinatesInterface;
+  readonly occupiedTranslate: AxesCoordinatesInterface;
+  readonly numberOfElementsTransformed: number;
+  readonly isDraggedPositionFixed: boolean;
+  setDraggedTempIndex(i: number): void;
+  updateNumOfElementsTransformed(effectedElemDirection: number): void;
   endDragging(isFallback: boolean): void;
 }

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -45,30 +45,39 @@ export interface DraggableDnDInterface
   scroll: ScrollOptWithThreshold;
   readonly occupiedOffset: AxesCoordinatesInterface;
   readonly occupiedTranslate: AxesCoordinatesInterface;
+
+  /** Previous X and Y are used to calculate mouse directions. */
   readonly mousePoints: AxesCoordinatesInterface;
   readonly numberOfElementsTransformed: number;
   readonly isViewportRestricted: boolean;
-  readonly isMovingDown: boolean;
-  readonly isMovingLeft: boolean;
+
+  /**
+   * If the dragged is moving opposite to the center X/Y.
+   * Far from Y, is moving down.
+   * Far from X, is moving right.
+   */
+  readonly isMovingAwayFrom: AxesCoordinatesBoolInterface;
   readonly isDraggedOutPosition: AxesCoordinatesBoolInterface;
   readonly isDraggedOutContainer: AxesCoordinatesBoolInterface;
   readonly isDraggedPositionFixed: boolean;
   setDraggedTempIndex(i: number): void;
   dragAt(x: number, y: number): void;
   updateNumOfElementsTransformed(effectedElemDirection: number): void;
-  setDraggedMovementDirection(coordinate: number, axes: Axes): void;
+  setDraggedMouseMovement(x: number, y: number): void;
   /**
    * Check if the dragged out self position or parent container and set the
    * necessary flags.
    */
   isOutThreshold(siblingsK?: string): boolean;
 
-  /** Checks if dragged index is first the mouse going up. Valid only if dragged
+  /**
+   * Checks if dragged index is first the mouse going up. Valid only if dragged
    * is out self threshold.
    */
   isLeavingFromHead(): boolean;
 
-  /** Checks if dragged index is last the mouse going down. Valid only if dragged
+  /**
+   * Checks if dragged index is last the mouse going down. Valid only if dragged
    * is out self threshold.
    */
   isLeavingFromTail(): boolean;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -62,10 +62,16 @@ export interface DraggableDnDInterface
    * necessary flags.
    */
   isOutThreshold(siblingsK?: string): boolean;
-  /** Checks if dragged is the first child and going up. */
-  isLeavingFromTop(): boolean;
-  /** Checks if dragged is the last child and going down. */
-  isLeavingFromBottom(): boolean;
+
+  /** Checks if dragged index is first the mouse going up. Valid only if dragged
+   * is out self threshold.
+   */
+  isLeavingFromHead(): boolean;
+
+  /** Checks if dragged index is last the mouse going down. Valid only if dragged
+   * is out self threshold.
+   */
+  isLeavingFromTail(): boolean;
   isNotSettled(): boolean;
   endDragging(isFallback: boolean): void;
 }

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -52,7 +52,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   private siblingsEmptyElmIndex: AxesCoordinatesInterface;
 
-  protected isOutActiveSiblingsContainer: boolean;
+  /** Isolated form the threshold and predict is-out based on the controllers */
+  protected isDraggedOutContainerEarlyDetection: boolean;
 
   constructor(draggable: DraggableInteractiveInterface) {
     this.draggable = draggable;
@@ -80,7 +81,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       y: 1,
     };
 
-    this.isOutActiveSiblingsContainer = false;
+    this.isDraggedOutContainerEarlyDetection = false;
   }
 
   protected setEffectedElemDirection(isIncrease: boolean, axes: Axes) {
@@ -216,7 +217,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     this.draggable.updateNumOfElementsTransformed(this.effectedElemDirection.x);
 
     // TODO: always true for the first element
-    if (!this.isOutActiveSiblingsContainer) {
+    if (!this.isDraggedOutContainerEarlyDetection) {
       /**
        * By updating the dragged translate, we guarantee that dragged
        * transformation will not triggered until dragged is over threshold

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -9,7 +9,7 @@ import type {
 } from "@dflex/utils";
 
 import type { InteractivityEvent } from "../types";
-import type { DraggableDnDInterface } from "../Draggable";
+import type { DraggableInteractiveInterface } from "../Draggable";
 
 import store from "../DnDStore";
 
@@ -40,7 +40,7 @@ function emitInteractiveEvent(
  * accordingly.
  */
 class DistanceCalculator implements DistanceCalculatorInterface {
-  protected draggable: DraggableDnDInterface;
+  protected draggable: DraggableInteractiveInterface;
 
   protected effectedElemDirection: EffectedElemDirection;
 
@@ -54,7 +54,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
   protected isOutActiveSiblingsContainer: boolean;
 
-  constructor(draggable: DraggableDnDInterface) {
+  constructor(draggable: DraggableInteractiveInterface) {
     this.draggable = draggable;
 
     /**

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -138,7 +138,7 @@ class Droppable extends DistanceCalculator {
     this.isOnDragOutThresholdEvtEmitted = false;
     this.animatedDraggedInsertionFrame = null;
 
-    this.isOutActiveSiblingsContainer = false;
+    this.isDraggedOutContainerEarlyDetection = false;
 
     this.axes = store.siblingsAlignment[SK] === "Horizontal" ? "x" : "y";
   }
@@ -443,11 +443,11 @@ class Droppable extends DistanceCalculator {
   }
 
   private setDraggedPositionFlagInSiblingsContainer(isOut: boolean) {
-    if (isOut === this.isOutActiveSiblingsContainer) {
+    if (isOut === this.isDraggedOutContainerEarlyDetection) {
       return;
     }
 
-    this.isOutActiveSiblingsContainer = isOut;
+    this.isDraggedOutContainerEarlyDetection = isOut;
   }
 
   /**
@@ -748,7 +748,7 @@ class Droppable extends DistanceCalculator {
 
       this.scrollManager(x, y);
 
-      if (!this.isOutActiveSiblingsContainer) {
+      if (!this.isDraggedOutContainerEarlyDetection) {
         this.draggable.draggedElm.setDataset("draggedOutPosition", true);
 
         this.draggedOutPosition();
@@ -779,7 +779,7 @@ class Droppable extends DistanceCalculator {
 
       this.emitDraggedEvent("onDragOutContainer");
 
-      this.isOutActiveSiblingsContainer = true;
+      this.isDraggedOutContainerEarlyDetection = true;
 
       this.detectNearestContainer();
 
@@ -793,7 +793,7 @@ class Droppable extends DistanceCalculator {
     /**
      * When dragged is out parent and returning to it.
      */
-    if (this.isOutActiveSiblingsContainer) {
+    if (this.isDraggedOutContainerEarlyDetection) {
       isOutSiblingsContainer = this.draggable.isOutThreshold(SK);
 
       if (isOutSiblingsContainer) {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -219,7 +219,7 @@ class Droppable extends DistanceCalculator {
         const element = store.registry[id];
 
         const isQualified = !element.isPositionedUnder(
-          this.draggable.offsetPlaceholder.y
+          this.draggable.positionPlaceholder.y
         );
 
         if (isQualified) {
@@ -270,7 +270,7 @@ class Droppable extends DistanceCalculator {
         const element = store.registry[id];
 
         const isQualified = element.isPositionedUnder(
-          this.draggable.offsetPlaceholder.y
+          this.draggable.positionPlaceholder.y
         );
 
         if (isQualified) {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -380,7 +380,7 @@ class Droppable extends DistanceCalculator {
   }
 
   private draggedOutPosition() {
-    if (this.draggable.isLeavingFromTop()) {
+    if (this.draggable.isLeavingFromHead()) {
       /**
        * If leaving and parent locked, do nothing.
        */
@@ -396,7 +396,7 @@ class Droppable extends DistanceCalculator {
       return;
     }
 
-    if (this.draggable.isLeavingFromBottom()) {
+    if (this.draggable.isLeavingFromTail()) {
       this.setDraggedPositionFlagInSiblingsContainer(true);
 
       return;

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -430,8 +430,8 @@ class Droppable extends DistanceCalculator {
     // inside the list, effected should be related to mouse movement
     this.setEffectedElemDirection(
       this.axes === "y"
-        ? this.draggable.isMovingDown
-        : this.draggable.isMovingLeft,
+        ? this.draggable.isMovingAwayFrom.y
+        : this.draggable.isMovingAwayFrom.x,
       this.axes
     );
 
@@ -636,7 +636,7 @@ class Droppable extends DistanceCalculator {
           store.siblingsScrollElement[SK];
 
         if (
-          this.draggable.isMovingDown &&
+          this.draggable.isMovingAwayFrom.y &&
           y >= threshold!.main.top.min &&
           this.scrollTop + scrollRect.height < scrollHeight
         ) {
@@ -739,7 +739,7 @@ class Droppable extends DistanceCalculator {
 
     const { SK } = store.registry[this.draggable.draggedElm.id].keys;
 
-    this.draggable.setDraggedMovementDirection(y, this.axes);
+    this.draggable.setDraggedMouseMovement(x, y);
 
     if (this.draggable.isOutThreshold()) {
       this.emitDraggedEvent("onDragOutThreshold");

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -4,7 +4,7 @@ import type { DraggedEvent, SiblingsEvent } from "../types";
 
 import store from "../DnDStore";
 
-import type { DraggableDnDInterface } from "../Draggable";
+import type { DraggableInteractiveInterface } from "../Draggable";
 import DistanceCalculator from "./DistanceCalculator";
 
 function emitSiblingsEvent(
@@ -92,7 +92,7 @@ class Droppable extends DistanceCalculator {
 
   protected axes: Axes;
 
-  constructor(draggable: DraggableDnDInterface) {
+  constructor(draggable: DraggableInteractiveInterface) {
     super(draggable);
 
     this.leftAtIndex = -1;
@@ -380,6 +380,10 @@ class Droppable extends DistanceCalculator {
   }
 
   private draggedOutPosition() {
+    console.log(
+      "file: Droppable.ts ~ line 384 ~ this.draggable.isLeavingFromHead()",
+      this.draggable.isLeavingFromHead()
+    );
     if (this.draggable.isLeavingFromHead()) {
       /**
        * If leaving and parent locked, do nothing.
@@ -738,8 +742,6 @@ class Droppable extends DistanceCalculator {
     let isOutSiblingsContainer = false;
 
     const { SK } = store.registry[this.draggable.draggedElm.id].keys;
-
-    this.draggable.setDraggedMouseMovement(x, y);
 
     if (this.draggable.isOutThreshold()) {
       this.emitDraggedEvent("onDragOutThreshold");

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -134,7 +134,7 @@ class EndDroppable extends Droppable {
     } = this.draggable.draggedElm;
 
     if (
-      this.isOutActiveSiblingsContainer ||
+      this.isDraggedOutContainerEarlyDetection ||
       this.draggable.isMovingAwayFrom.y
     ) {
       this.loopAscWithAnimationFrame(from, lst);

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -133,7 +133,10 @@ class EndDroppable extends Droppable {
       order: { self: from },
     } = this.draggable.draggedElm;
 
-    if (this.isOutActiveSiblingsContainer || this.draggable.isMovingDown) {
+    if (
+      this.isOutActiveSiblingsContainer ||
+      this.draggable.isMovingAwayFrom.y
+    ) {
       this.loopAscWithAnimationFrame(from, lst);
     } else {
       /**

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -4,12 +4,12 @@ import type { ELmBranch } from "@dflex/dom-gen";
 import store from "../DnDStore";
 import Droppable, { isIDEligible } from "./Droppable";
 
-import type { DraggableDnDInterface } from "../Draggable";
+import type { DraggableInteractiveInterface } from "../Draggable";
 
 class EndDroppable extends Droppable {
   private spliceAt: number;
 
-  constructor(draggable: DraggableDnDInterface) {
+  constructor(draggable: DraggableInteractiveInterface) {
     super(draggable);
     this.spliceAt = -1;
   }

--- a/packages/utils/src/AxesCoordinatesBool.ts
+++ b/packages/utils/src/AxesCoordinatesBool.ts
@@ -13,7 +13,7 @@ class AxesCoordinatesBool
     return !this.x && !this.y;
   }
 
-  setAllFalse() {
+  setFalsy() {
     this.x = false;
     this.y = false;
   }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -30,5 +30,5 @@ export interface AxesCoordinatesBoolInterface
   /** True if both axes are false. */
   isAllFalsy(): boolean;
   /** Set both axes to false. */
-  setAllFalse(): void;
+  setFalsy(): void;
 }


### PR DESCRIPTION
- [x] Add `DraggableInteractive` instead of `Draggable`/`DraggableDnD` with new interface exclude all motion flags/methods.
- [x] Add new `DraggableAxes` for all drag-related movement that is affected by both axes.
- [x] Enhance internal documentation for both classes.  