### PR TITLE
Add threshold indicators to each active layout

### DIFF
--- a/packages/dnd/cypress/integration/restrictions/container-diff/horizontal.spec.ts
+++ b/packages/dnd/cypress/integration/restrictions/container-diff/horizontal.spec.ts
@@ -448,7 +448,7 @@ context(
           button: 0,
         });
 
-        for (let i = 0; i <= 600; i += 10) {
+        for (let i = 0; i <= 610; i += 10) {
           cy.get("#item-rest-container-left-right").trigger("mousemove", {
             clientY: startingPointY + i,
             force: true,
@@ -462,7 +462,7 @@ context(
         cy.get("#item-rest-container-left-right").should(
           "have.css",
           "transform",
-          "matrix(1, 0, 0, 1, 0, 426.219)"
+          "matrix(1, 0, 0, 1, 0, 436.219)"
         );
       });
 

--- a/packages/dnd/cypress/integration/restrictions/container-diff/horizontal.spec.ts
+++ b/packages/dnd/cypress/integration/restrictions/container-diff/horizontal.spec.ts
@@ -29,7 +29,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -49,7 +49,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -108,7 +108,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -167,7 +167,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -242,7 +242,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -262,7 +262,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -321,7 +321,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -396,7 +396,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -425,7 +425,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -454,7 +454,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 

--- a/packages/dnd/cypress/integration/restrictions/container-diff/vertical.spec.ts
+++ b/packages/dnd/cypress/integration/restrictions/container-diff/vertical.spec.ts
@@ -29,7 +29,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -70,7 +70,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -111,7 +111,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -140,7 +140,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -223,7 +223,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -293,7 +293,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 
@@ -322,7 +322,7 @@ context(
             force: true,
           });
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          // cy.wait(0);
+          cy.wait(0);
         }
       });
 

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -1,7 +1,12 @@
 import { AbstractDraggable } from "@dflex/draggable";
 import type { Coordinates } from "@dflex/draggable";
 
-import { Threshold, AxesCoordinates, AxesCoordinatesBool } from "@dflex/utils";
+import {
+  Threshold,
+  AxesCoordinates,
+  AxesCoordinatesBool,
+  AxesFourCoordinatesBool,
+} from "@dflex/utils";
 import type {
   ThresholdInterface,
   ThresholdCoordinate,
@@ -59,13 +64,15 @@ class DraggableAxes
 
   private initX: number;
 
-  isLeftFromTop: boolean;
+  // isLeftFromTop: boolean;
 
-  isLeftFromBottom: boolean;
+  // isLeftFromBottom: boolean;
 
-  isLeftFromLeft: boolean;
+  // isLeftFromLeft: boolean;
 
-  isLeftFromRight: boolean;
+  // isLeftFromRight: boolean;
+
+  isOut: AxesFourCoordinatesBool;
 
   constructor(id: string, initCoordinates: Coordinates, opts: FinalDndOpts) {
     const { element } = store.getElmTreeById(id);
@@ -126,10 +133,12 @@ class DraggableAxes
     this.isDraggedOutContainer = new AxesCoordinatesBool(false, false);
     this.isMovingAwayFrom = new AxesCoordinatesBool(false, false);
 
-    this.isLeftFromTop = false;
-    this.isLeftFromBottom = false;
-    this.isLeftFromLeft = false;
-    this.isLeftFromRight = false;
+    // this.isLeftFromTop = false;
+    // this.isLeftFromBottom = false;
+    // this.isLeftFromLeft = false;
+    // this.isLeftFromRight = false;
+
+    this.isOut = new AxesFourCoordinatesBool();
 
     const { x, y } = initCoordinates;
 
@@ -321,10 +330,15 @@ class DraggableAxes
 
     const { left } = $;
 
-    this.isLeftFromLeft = x < left.max;
-    this.isLeftFromRight = x > left.min;
+    this.isOut.setOutX({
+      left: x < left.max,
+      right: x > left.min,
+    });
 
-    return this.isLeftFromLeft || this.isLeftFromRight;
+    // this.isLeftFromLeft = x < left.max;
+    // this.isLeftFromRight = x > left.min;
+
+    return this.isOut.isOutX();
   }
 
   private isOutThresholdV($: ThresholdCoordinate) {
@@ -332,10 +346,15 @@ class DraggableAxes
 
     const { y } = this.positionPlaceholder;
 
-    this.isLeftFromTop = y < top.max;
-    this.isLeftFromBottom = y > top.min;
+    this.isOut.setOutY({
+      up: y < top.max,
+      down: y > top.min,
+    });
 
-    return this.isLeftFromTop || this.isLeftFromBottom;
+    // this.isLeftFromTop = y < top.max;
+    // this.isLeftFromBottom = y > top.min;
+
+    return this.isOut.isOutY();
   }
 
   isOutThreshold(SK?: string) {
@@ -369,7 +388,7 @@ class DraggableAxes
 
   isLeavingFromHead() {
     return (
-      this.isLeftFromTop && this.indexPlaceholder <= 0 // first our outside.
+      this.isOut.isLeftFromTop && this.indexPlaceholder <= 0 // first our outside.
     );
   }
 
@@ -377,7 +396,7 @@ class DraggableAxes
     const lastElm =
       (store.getElmSiblingsListById(this.draggedElm.id) as string[]).length - 1;
 
-    return this.isLeftFromBottom && this.indexPlaceholder === lastElm;
+    return this.isOut.isLeftFromBottom && this.indexPlaceholder === lastElm;
   }
 
   isNotSettled() {

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -3,7 +3,6 @@ import type {
   AxesCoordinatesBoolInterface,
   ThresholdInterface,
   ThresholdCoordinate,
-  AxesFourCoordinatesBool,
 } from "@dflex/utils";
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 import type { AbstractDraggableInterface } from "@dflex/draggable";
@@ -33,9 +32,6 @@ export interface DraggableAxesInterface
   extends AbstractDraggableInterface<CoreInstanceInterface> {
   /** Dragged threshold  */
   readonly threshold: ThresholdInterface;
-
-  /** Dragged parent containers threshold  */
-  readonly layoutThresholds: SiblingsThreshold;
 
   readonly innerOffset: AxesCoordinatesInterface;
 
@@ -83,15 +79,6 @@ export interface DraggableAxesInterface
 
   /** Has moved without settling inside new position. */
   isNotSettled(): boolean;
-
-  // isLeftFromTop: boolean;
-
-  // isLeftFromBottom: boolean;
-
-  // isLeftFromLeft: boolean;
-
-  // isLeftFromRight: boolean;
-  isOut: AxesFourCoordinatesBool;
 }
 
 export interface DraggableInteractiveInterface extends DraggableAxesInterface {

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -3,6 +3,7 @@ import type {
   AxesCoordinatesBoolInterface,
   ThresholdInterface,
   ThresholdCoordinate,
+  AxesFourCoordinatesBool,
 } from "@dflex/utils";
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 import type { AbstractDraggableInterface } from "@dflex/draggable";
@@ -83,13 +84,14 @@ export interface DraggableAxesInterface
   /** Has moved without settling inside new position. */
   isNotSettled(): boolean;
 
-  isLeftFromTop: boolean;
+  // isLeftFromTop: boolean;
 
-  isLeftFromBottom: boolean;
+  // isLeftFromBottom: boolean;
 
-  isLeftFromLeft: boolean;
+  // isLeftFromLeft: boolean;
 
-  isLeftFromRight: boolean;
+  // isLeftFromRight: boolean;
+  isOut: AxesFourCoordinatesBool;
 }
 
 export interface DraggableInteractiveInterface extends DraggableAxesInterface {

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -235,7 +235,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
         currentPosition: { x, y },
       } = element;
 
-      this.draggable.threshold.setMainThreshold(
+      this.draggable.threshold.setThreshold(
+        this.draggable.draggedElm.id,
         {
           width,
           height,

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -228,7 +228,8 @@ class Droppable extends DistanceCalculator {
           /**
            * Update threshold from here since there's no calling to updateElement.
            */
-          this.draggable.threshold.setMainThreshold(
+          this.draggable.threshold.setThreshold(
+            this.draggable.draggedElm.id,
             {
               width: this.draggable.draggedElm.offset.width,
               height: this.draggable.draggedElm.offset.height,
@@ -381,6 +382,10 @@ class Droppable extends DistanceCalculator {
 
   private draggedOutPosition() {
     if (this.draggable.isLeavingFromHead()) {
+      console.log(
+        "file: Droppable.ts ~ line 385 ~ this.draggable.isLeavingFromHead()",
+        this.draggable.isLeavingFromHead()
+      );
       /**
        * If leaving and parent locked, do nothing.
        */
@@ -397,6 +402,10 @@ class Droppable extends DistanceCalculator {
     }
 
     if (this.draggable.isLeavingFromTail()) {
+      console.log(
+        "file: Droppable.ts ~ line 405 ~ this.draggable.isLeavingFromTail",
+        this.draggable.isLeavingFromTail
+      );
       this.setDraggedPositionFlagInSiblingsContainer(true);
 
       return;
@@ -410,6 +419,10 @@ class Droppable extends DistanceCalculator {
      * Going out from the list: Right/left.
      */
     if (this.draggable.isDraggedOutPosition.x) {
+      console.log(
+        "file: Droppable.ts ~ line 422 ~ this.draggable.isDraggedOutPosition.x",
+        this.draggable.isDraggedOutPosition.x
+      );
       // Is is out parent?
 
       // move element up
@@ -427,10 +440,13 @@ class Droppable extends DistanceCalculator {
      * Normal state, switch.
      */
 
-    const isLeftUp =
-      this.draggable.isOut.isLeftFromBottom ||
-      (!this.draggable.isOut.isLeftFromTop &&
-        !this.draggable.isOut.isLeftFromBottom);
+    const isLeftUp: boolean =
+      this.draggable.threshold.isOut[this.draggable.draggedElm.id]
+        .isLeftFromBottom ||
+      (!this.draggable.threshold.isOut[this.draggable.draggedElm.id]
+        .isLeftFromTop &&
+        !this.draggable.threshold.isOut[this.draggable.draggedElm.id]
+          .isLeftFromBottom);
 
     // inside the list, effected should be related to mouse movement
     this.setEffectedElemDirection(
@@ -637,20 +653,16 @@ class Droppable extends DistanceCalculator {
       if (store.siblingsScrollElement[SK].hasOverflowY) {
         const { scrollRect, scrollHeight, threshold } =
           store.siblingsScrollElement[SK];
-
         if (
           this.draggable.isMovingAwayFrom.y &&
-          y >= threshold!.main.top.min &&
+          y >= threshold!.thresholds[SK].top.min &&
           this.scrollTop + scrollRect.height < scrollHeight
         ) {
           this.scrollElement(x, y, 1, "scrollElementOnY");
-
           return;
         }
-
-        if (y <= threshold!.main.top.max && this.scrollTop > 0) {
+        if (y <= threshold!.thresholds[SK].top.max && this.scrollTop > 0) {
           this.scrollElement(x, y, -1, "scrollElementOnY");
-
           return;
         }
       }
@@ -658,17 +670,14 @@ class Droppable extends DistanceCalculator {
       if (store.siblingsScrollElement[SK].hasOverflowX) {
         const { scrollRect, scrollHeight, threshold } =
           store.siblingsScrollElement[SK];
-
         if (
-          x >= threshold!.main.left.max &&
+          x >= threshold!.thresholds[SK].left.max &&
           this.scrollLeft + scrollRect.width < scrollHeight
         ) {
           this.scrollElement(x, y, 1, "scrollElementOnX");
-
           return;
         }
-
-        if (x <= threshold!.main.left.min && this.scrollLeft > 0) {
+        if (x <= threshold!.thresholds[SK].left.min && this.scrollLeft > 0) {
           this.scrollElement(x, y, -1, "scrollElementOnX");
         }
       }
@@ -718,14 +727,6 @@ class Droppable extends DistanceCalculator {
     });
   }
 
-  /**
-   * Invokes draggable method responsible of transform.
-   * Monitors dragged translate and called related methods. Which controls the
-   * active and droppable method.
-   *
-   * @param x- mouse X coordinate
-   * @param y- mouse Y coordinate
-   */
   dragAt(x: number, y: number) {
     if (this.regularDragging) {
       this.draggable.dragAt(

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -428,8 +428,9 @@ class Droppable extends DistanceCalculator {
      */
 
     const isLeftUp =
-      this.draggable.isLeftFromBottom ||
-      (!this.draggable.isLeftFromTop && !this.draggable.isLeftFromBottom);
+      this.draggable.isOut.isLeftFromBottom ||
+      (!this.draggable.isOut.isLeftFromTop &&
+        !this.draggable.isOut.isLeftFromBottom);
 
     // inside the list, effected should be related to mouse movement
     this.setEffectedElemDirection(

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -382,10 +382,6 @@ class Droppable extends DistanceCalculator {
 
   private draggedOutPosition() {
     if (this.draggable.isLeavingFromHead()) {
-      console.log(
-        "file: Droppable.ts ~ line 385 ~ this.draggable.isLeavingFromHead()",
-        this.draggable.isLeavingFromHead()
-      );
       /**
        * If leaving and parent locked, do nothing.
        */
@@ -402,10 +398,6 @@ class Droppable extends DistanceCalculator {
     }
 
     if (this.draggable.isLeavingFromTail()) {
-      console.log(
-        "file: Droppable.ts ~ line 405 ~ this.draggable.isLeavingFromTail",
-        this.draggable.isLeavingFromTail
-      );
       this.setDraggedPositionFlagInSiblingsContainer(true);
 
       return;
@@ -419,10 +411,6 @@ class Droppable extends DistanceCalculator {
      * Going out from the list: Right/left.
      */
     if (this.draggable.isDraggedOutPosition.x) {
-      console.log(
-        "file: Droppable.ts ~ line 422 ~ this.draggable.isDraggedOutPosition.x",
-        this.draggable.isDraggedOutPosition.x
-      );
       // Is is out parent?
 
       // move element up

--- a/packages/dnd/src/Plugins/Scroll/Scroll.ts
+++ b/packages/dnd/src/Plugins/Scroll/Scroll.ts
@@ -259,9 +259,9 @@ Please provide scroll container by ref/id when registering the element or turn o
   }
 
   setThresholdMatrix(threshold: ThresholdPercentages) {
-    this.threshold = new Threshold(threshold, this.scrollRect, {
-      isContainer: true,
-    });
+    this.threshold = new Threshold(threshold);
+
+    this.threshold.setThreshold(this.siblingKey, this.scrollRect, true, true);
   }
 
   private setScrollCoordinates() {

--- a/packages/dnd/src/Plugins/Scroll/types.ts
+++ b/packages/dnd/src/Plugins/Scroll/types.ts
@@ -1,4 +1,8 @@
-import type { ThresholdInterface, Rect } from "@dflex/utils";
+import type {
+  ThresholdInterface,
+  Rect,
+  ThresholdPercentages,
+} from "@dflex/utils";
 
 export interface ScrollInput {
   element: HTMLElement;
@@ -26,6 +30,6 @@ export interface ScrollInterface {
   getMaximumScrollContainerTop(): number;
   isElementVisibleViewportX(currentLeft: number): boolean;
   isElementVisibleViewportY(currentTop: number): boolean;
-  setThresholdMatrix(threshold: ThresholdInterface["percentages"]): void;
+  setThresholdMatrix(threshold: ThresholdPercentages): void;
   destroy(): void;
 }

--- a/packages/dnd/src/types.ts
+++ b/packages/dnd/src/types.ts
@@ -1,4 +1,4 @@
-import type { ThresholdInterface } from "@dflex/utils";
+import type { ThresholdPercentages } from "@dflex/utils";
 import type { Restrictions } from "./Draggable";
 
 interface DnDEvent {
@@ -83,11 +83,11 @@ export interface ScrollOptWithoutThreshold {
 
 export interface ScrollOptWithPartialThreshold
   extends ScrollOptWithoutThreshold {
-  threshold: Partial<ThresholdInterface["percentages"]>;
+  threshold: Partial<ThresholdPercentages>;
 }
 
 export interface ScrollOptWithThreshold extends ScrollOptWithoutThreshold {
-  threshold: ThresholdInterface["percentages"];
+  threshold: ThresholdPercentages;
 }
 
 export interface RestrictionsStatus {
@@ -96,7 +96,7 @@ export interface RestrictionsStatus {
 }
 
 export interface FinalDndOpts {
-  threshold: ThresholdInterface["percentages"];
+  threshold: ThresholdPercentages;
   restrictions: Restrictions;
   restrictionsStatus: RestrictionsStatus;
   scroll: ScrollOptWithThreshold;
@@ -104,7 +104,7 @@ export interface FinalDndOpts {
 }
 
 export interface DndOpts {
-  threshold?: Partial<ThresholdInterface["percentages"]>;
+  threshold?: Partial<ThresholdPercentages>;
   restrictions?: {
     self?: Partial<Restrictions["self"]>;
     container?: Partial<Restrictions["container"]>;

--- a/packages/utils/src/AxesCoordinates/AxesFourCoordinatesBool.ts
+++ b/packages/utils/src/AxesCoordinates/AxesFourCoordinatesBool.ts
@@ -15,6 +15,14 @@ class AxesFourCoordinatesBool {
     this.isLeftFromRight = false;
   }
 
+  reset() {
+    this.isLeftFromTop = false;
+    this.isLeftFromBottom = false;
+
+    this.isLeftFromLeft = false;
+    this.isLeftFromRight = false;
+  }
+
   isOutY() {
     return this.isLeftFromTop || this.isLeftFromBottom;
   }

--- a/packages/utils/src/AxesCoordinates/AxesFourCoordinatesBool.ts
+++ b/packages/utils/src/AxesCoordinates/AxesFourCoordinatesBool.ts
@@ -1,0 +1,47 @@
+class AxesFourCoordinatesBool {
+  isLeftFromTop: boolean;
+
+  isLeftFromBottom: boolean;
+
+  isLeftFromLeft: boolean;
+
+  isLeftFromRight: boolean;
+
+  constructor() {
+    this.isLeftFromTop = false;
+    this.isLeftFromBottom = false;
+
+    this.isLeftFromLeft = false;
+    this.isLeftFromRight = false;
+  }
+
+  isOutY() {
+    return this.isLeftFromTop || this.isLeftFromBottom;
+  }
+
+  setOutY({ up, down }: { up: boolean; down: boolean }) {
+    this.isLeftFromTop = up;
+    this.isLeftFromBottom = down;
+  }
+
+  setOutYFalsy() {
+    this.isLeftFromTop = false;
+    this.isLeftFromBottom = false;
+  }
+
+  isOutX() {
+    return this.isLeftFromLeft || this.isLeftFromRight;
+  }
+
+  setOutX({ left, right }: { left: boolean; right: boolean }) {
+    this.isLeftFromLeft = left;
+    this.isLeftFromRight = right;
+  }
+
+  setOutXFalsy() {
+    this.isLeftFromLeft = false;
+    this.isLeftFromRight = false;
+  }
+}
+
+export default AxesFourCoordinatesBool;

--- a/packages/utils/src/AxesCoordinates/index.ts
+++ b/packages/utils/src/AxesCoordinates/index.ts
@@ -1,5 +1,6 @@
 export { default as AxesCoordinates } from "./AxesCoordinates";
 export { default as AxesCoordinatesBool } from "./AxesCoordinatesBool";
+export { default as AxesFourCoordinatesBool } from "./AxesFourCoordinatesBool";
 
 export type {
   AxesCoordinatesInterface,

--- a/packages/utils/src/Threshold/types.ts
+++ b/packages/utils/src/Threshold/types.ts
@@ -1,3 +1,4 @@
+import { AxesFourCoordinatesBool } from "../AxesCoordinates";
 import type { Rect } from "../types";
 
 export interface ThresholdPercentages {
@@ -18,9 +19,23 @@ export interface ThresholdCoordinate {
   left: ThresholdPointInterface;
 }
 
+export interface ThresholdsStore {
+  [key: string]: ThresholdCoordinate;
+}
+
+export interface LayoutPositionStatus {
+  [key: string]: AxesFourCoordinatesBool;
+}
+
 export interface ThresholdInterface {
-  percentages: ThresholdPercentages;
-  main: ThresholdCoordinate;
-  getThreshold(rect: Rect, isContainer: boolean): ThresholdCoordinate;
-  setMainThreshold(rect: Rect, isContainer: boolean): void;
+  thresholds: ThresholdsStore;
+  isOut: LayoutPositionStatus;
+  setThreshold(
+    key: string,
+    rect: Rect,
+    isContainer: boolean,
+    isUpdatePixels?: boolean
+  ): void;
+  isOutThresholdH(key: string, x: number): boolean;
+  isOutThresholdV(key: string, y: number): boolean;
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,8 @@
-export { AxesCoordinates, AxesCoordinatesBool } from "./AxesCoordinates";
+export {
+  AxesCoordinates,
+  AxesCoordinatesBool,
+  AxesFourCoordinatesBool,
+} from "./AxesCoordinates";
 export type {
   AxesCoordinatesInterface,
   AxesCoordinatesBoolInterface,

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -14,3 +14,8 @@ export interface EffectedElemDirection {
 }
 
 export type Axes = "x" | "y";
+
+export interface Coordinates {
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
- [x] Add a new class `AxesFourCoordinatesBool` for dealing with layout position in four directions.
- [x] Add the new direction instance to the threshold. Include all the position indicators in the threshold that has a store for threshold(`thresholds`)/indicators(`isOut`). 
- [x] Enable position flags for dragged and the parent layout instead of depending on one set of flags for position detection. 