### PR TITLE
Update grid for `Core` and `Dragged`

### DIFF
--- a/packages/core-instance/src/AbstractInstance.ts
+++ b/packages/core-instance/src/AbstractInstance.ts
@@ -99,7 +99,7 @@ class AbstractInstance implements AbstractInterface {
   }
 
   setDataset(key: AllowedDataset, value: number | boolean) {
-    if (key === "index") {
+    if (key === "index" || key === "gridX" || key === "gridY") {
       this.ref!.dataset[key] = `${value}`;
 
       return;

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -40,7 +40,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
 
   animatedFrame: number | null;
 
-  #translateHistory?: IPoint<TransitionHistory>;
+  #translateHistory?: IPoint<TransitionHistory[]>;
 
   constructor(eleWithPointer: CoreInput, opts: AbstractOpts) {
     const { order, keys, depth, scrollX, scrollY, ...element } = eleWithPointer;
@@ -210,9 +210,9 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
     isForceTransform = false
   ) {
     if (operationID) {
-      const elmAxesHistory = {
+      const elmAxesHistory: TransitionHistory = {
         ID: operationID,
-        pre: this.translate[axes],
+        translate: this.translate[axes],
       };
 
       if (!this.#translateHistory) {
@@ -303,9 +303,9 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
 
     if (!lastMovement) return;
 
-    const { pre } = lastMovement;
+    const { translate: preTranslate } = lastMovement;
 
-    const elmSpace = pre - this.translate[axes];
+    const elmSpace = preTranslate - this.translate[axes];
 
     const increment = elmSpace > 0 ? 1 : -1;
 

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -82,6 +82,10 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
 
     this.currentPosition = new PointNum(this.offset.left, this.offset.top);
 
+    /**
+     * Initializing grid comes later when the siblings boundaries are
+     * initialized and the element is visible.
+     */
     this.grid = new PointNum(0, 0);
 
     this.hasToTransform = false;
@@ -149,6 +153,8 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
 
     this.order.self = newIndex;
 
+    this.setDataset("index", newIndex);
+
     return { oldIndex, newIndex };
   }
 
@@ -194,8 +200,6 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
     }
 
     branchIDsOrder[newIndex] = this.id;
-
-    this.setDataset("index", newIndex);
 
     return oldIndex;
   }
@@ -273,6 +277,21 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
       effectedElemDirection[axes] * numberOfPassedElm
     );
 
+    this.grid[axes] += effectedElemDirection[axes] * numberOfPassedElm;
+
+    if (process.env.NODE_ENV !== "production") {
+      if (this.grid[axes] !== newIndex + 1) {
+        throw new Error(
+          `Grid:  is ${this.grid[axes]} while the new index is ${newIndex}`
+        );
+      }
+
+      this.setDataset(
+        `grid${axes.toUpperCase() as "X" | "Y"}`,
+        this.grid[axes]
+      );
+    }
+
     const newStatusSiblingsHasEmptyElm = this.assignNewPosition(
       iDsInOrder,
       newIndex,
@@ -314,7 +333,20 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
 
     const { newIndex } = this.#updateOrderIndexing(increment);
 
-    this.setDataset("index", newIndex);
+    this.grid[axes] += increment;
+
+    if (process.env.NODE_ENV !== "production") {
+      if (this.grid[axes] !== newIndex + 1) {
+        throw new Error(
+          `Grid:  is ${this.grid[axes]} while the new index is ${newIndex}`
+        );
+      }
+
+      this.setDataset(
+        `grid${axes.toUpperCase() as "X" | "Y"}`,
+        this.grid[axes]
+      );
+    }
 
     this.rollBack(operationID, isForceTransform, axes);
   }

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -16,6 +16,8 @@ export type AbstractInput = {
 };
 
 export type AllowedDataset =
+  | "gridX"
+  | "gridY"
   | "index"
   | "draggedOutPosition"
   | "draggedOutContainer";

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -78,8 +78,8 @@ export interface CoreInput extends AbstractInput {
 
 export type TransitionHistory = {
   ID: string;
-  pre: number;
-}[];
+  translate: number;
+};
 
 export interface CoreInstanceInterface extends AbstractInterface {
   /** Initial read-only element offset */

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -29,11 +29,11 @@ export type AttributesIndicators =
   | AllowedAttributes;
 
 export interface AbstractInterface {
-  isInitialized: boolean;
+  readonly isInitialized: boolean;
   isPaused: boolean;
-  ref: HTMLElement | null;
-  id: string;
-  translate: IPointNum;
+  readonly ref: HTMLElement | null;
+  readonly id: string;
+  readonly translate: IPointNum;
   attach(ref: HTMLElement | null): void;
   detach(): void;
   initTranslate(): void;

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -71,7 +71,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
 
     this.tracker = new Tracker();
 
-    this.initELmIndicator();
+    this.#initELmIndicator();
 
     this.isInitialized = false;
     this.isDOM = false;
@@ -103,13 +103,13 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
     this.events[event.type](event);
   }
 
-  private init() {
+  #init() {
     window.addEventListener("load", this.onLoadListeners);
 
     window.onbeforeunload = this.dispose();
   }
 
-  private initELmIndicator() {
+  #initELmIndicator() {
     this.elmIndicator = {
       currentKy: "",
       prevKy: "",
@@ -117,7 +117,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
     };
   }
 
-  private getBranchHeadAndTail(key: string) {
+  #getBranchHeadAndTail(key: string) {
     const branch = this.DOMGen.branches[key];
 
     let hasSiblings = false;
@@ -152,7 +152,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
       this.registry[elmID].resume(scroll.scrollX, scroll.scrollY);
     }
 
-    this.assignSiblingsBoundariesAndAlignment(
+    this.#assignSiblingsBoundariesAndAlignment(
       elmID,
       this.registry[elmID].keys.SK,
       this.registry[elmID].offset!
@@ -189,7 +189,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
           // But, there's a possibility that the rest of the branch elements
           // are hidden.
           // Eg: 1, 2: hidden 3, 4, 5, 6, 7:visible 8, 9, 10: hidden.
-          this.initELmIndicator();
+          this.#initELmIndicator();
         }
       }
     }
@@ -213,7 +213,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
       return;
     }
 
-    this.initELmIndicator();
+    this.#initELmIndicator();
 
     let prevIndex = 0;
 
@@ -291,7 +291,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
 
   initSiblingsScrollAndVisibilityIfNecessary(key: string) {
     const { hasSiblings, firstElemID, lastElemID } =
-      this.getBranchHeadAndTail(key);
+      this.#getBranchHeadAndTail(key);
 
     if (!this.registry[firstElemID].isInitialized) {
       this.registry[firstElemID].resume(0, 0);
@@ -367,7 +367,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
     });
   }
 
-  private assignSiblingsBoundariesAndAlignment(
+  #assignSiblingsBoundariesAndAlignment(
     id: string,
     SK: string,
     rect: RectDimensions
@@ -406,9 +406,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
       this.siblingsGrid[SK].x += 1;
     }
 
-    this.registry[id].grid = {
-      ...this.siblingsGrid[SK],
-    };
+    this.registry[id].grid.clone(this.siblingsGrid[SK]);
 
     if (left < $.left) {
       $.left = left;
@@ -461,7 +459,7 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
     }
 
     if (!this.isInitialized) {
-      this.init();
+      this.#init();
       this.isInitialized = true;
     }
 

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -150,13 +150,15 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
   ) {
     if (this.registry[elmID].isPaused) {
       this.registry[elmID].resume(scroll.scrollX, scroll.scrollY);
-    }
 
-    this.#assignSiblingsBoundariesAndAlignment(
-      elmID,
-      this.registry[elmID].keys.SK,
-      this.registry[elmID].offset!
-    );
+      if (this.registry[elmID].grid.x === 0) {
+        this.#assignSiblingsBoundariesAndAlignment(
+          elmID,
+          this.registry[elmID].keys.SK,
+          this.registry[elmID].offset!
+        );
+      }
+    }
 
     let isVisible = true;
     let isVisibleY = true;
@@ -389,6 +391,11 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
 
       this.registry[id].grid.clone(this.siblingsGrid[SK]);
 
+      if (process.env.NODE_ENV !== "production") {
+        this.registry[id].setDataset(`gridX`, this.registry[id].grid.x);
+        this.registry[id].setDataset(`gridY`, this.registry[id].grid.y);
+      }
+
       return;
     }
 
@@ -427,6 +434,11 @@ class DnDStoreImp extends Store implements DnDStoreInterface {
     }
 
     this.siblingsAlignment[SK] = isHorizontal ? "Horizontal" : "Vertical";
+
+    if (process.env.NODE_ENV !== "production") {
+      this.registry[id].setDataset(`gridX`, this.registry[id].grid.x);
+      this.registry[id].setDataset(`gridY`, this.registry[id].grid.y);
+    }
   }
 
   /**

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -22,6 +22,8 @@ class DraggableAxes
 
   positionPlaceholder: IPointNum;
 
+  gridPlaceholder: IPointNum;
+
   threshold: ThresholdInterface;
 
   isViewportRestricted: boolean;
@@ -51,9 +53,10 @@ class DraggableAxes
 
     this.isLayoutStateUpdated = false;
 
-    const { order } = element;
+    const { order, grid } = element;
 
     this.indexPlaceholder = order.self;
+    this.gridPlaceholder = new PointNum(grid.x, grid.y);
 
     const { SK } = store.registry[id].keys;
 

--- a/packages/dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dnd/src/Draggable/DraggableInteractive.ts
@@ -183,6 +183,8 @@ class DraggableInteractive
 
     this.draggedElm.currentPosition.clone(this.occupiedOffset);
     this.draggedElm.translate.clone(this.occupiedTranslate);
+    this.draggedElm.grid.clone(this.gridPlaceholder);
+    this.draggedElm.setDataset("gridY", this.draggedElm.grid.y);
 
     this.draggedElm.transformElm();
 

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -41,6 +41,9 @@ export interface DraggableAxesInterface
   /** Temporary index for dragged  */
   readonly indexPlaceholder: number;
 
+  /** grid placeholder for dragged grid position. */
+  readonly gridPlaceholder: IPointNum;
+
   /** Previous X and Y are used to calculate mouse directions. */
   readonly mousePoints: IPointNum;
 

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -245,11 +245,13 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
     emitInteractiveEvent("onDragOver", element);
 
-    const { currentPosition } = element;
+    const { currentPosition, grid } = element;
 
     this.updateOccupiedOffset(currentPosition.y, currentPosition.x);
 
     this.updateOccupiedTranslate(enforceDraggedDirection);
+
+    this.draggable.gridPlaceholder.clone(grid);
 
     /**
      * Start transforming process


### PR DESCRIPTION
- [x] Refactor transition history type.
- [x] Allow adding grid positions to the dataset.
- [x] add a read-only prefix to the abstract core interface.
- [x] Add `gridPlaceholder` for Dragged and update it for Core.