### PR TITLE
Use direction and axis with each transformation instead global instances

### DIFF
--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -4,7 +4,7 @@ import { Point, PointNum } from "@dflex/utils";
 
 import type {
   RectDimensions,
-  EffectedElemDirection,
+  Direction,
   Axis,
   IPoint,
   IPointNum,
@@ -249,7 +249,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
   /**
    *
    * @param iDsInOrder -
-   * @param effectedElemDirection - (+1/-1)
+   * @param direction - (+1/-1)
    * @param elmSpace - space between dragged and the immediate next element.
    * @param operationID - A unique ID used to store translate history
    * @param numberOfPassedElm - the number of passed elements.
@@ -257,7 +257,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
    */
   setPosition(
     iDsInOrder: string[],
-    effectedElemDirection: EffectedElemDirection,
+    direction: Direction,
     elmSpace: PointNum,
     operationID: string,
     siblingsEmptyElmIndex: PointNum,
@@ -269,15 +269,15 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
      * effectedElemDirection decides the direction of the element, negative or positive.
      * If the element is dragged to the left, the effectedElemDirection is -1.
      */
-    elmSpace[axis] *= effectedElemDirection[axis];
+    elmSpace[axis] *= direction;
 
     this.#seTranslate(elmSpace[axis], axis, operationID);
 
     const { oldIndex, newIndex } = this.#updateOrderIndexing(
-      effectedElemDirection[axis] * numberOfPassedElm
+      direction * numberOfPassedElm
     );
 
-    this.grid[axis] += effectedElemDirection[axis] * numberOfPassedElm;
+    this.grid[axis] += direction * numberOfPassedElm;
 
     if (process.env.NODE_ENV !== "production") {
       // if (this.grid[axis] !== newIndex + 1) {

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -1,9 +1,4 @@
-import type {
-  RectDimensions,
-  Axis,
-  EffectedElemDirection,
-  IPointNum,
-} from "@dflex/utils";
+import type { RectDimensions, Axis, IPointNum, Direction } from "@dflex/utils";
 
 export interface AbstractOpts {
   isInitialized: boolean;
@@ -109,7 +104,7 @@ export interface CoreInstanceInterface extends AbstractInterface {
   changeVisibility(isVisible: boolean): void;
   setPosition(
     iDsInOrder: string[],
-    effectedElemDirection: EffectedElemDirection,
+    direction: Direction,
     elmSpace: IPointNum,
     operationID: string,
     siblingsEmptyElmIndex: IPointNum,

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -79,10 +79,6 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     this.isParentLocked = false;
   }
 
-  protected setEffectedElemDirection(isIncrease: boolean, axis: Axis) {
-    this.effectedElemDirection[axis] = isIncrease ? -1 : 1;
-  }
-
   /**
    *
    * @param position - Hight if the working axes is Y. Otherwise, it's width.

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -262,7 +262,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
      */
     this.siblingsEmptyElmIndex[axis] = element.setPosition(
       store.getElmSiblingsListById(this.draggable.draggedElm.id)!,
-      this.effectedElemDirection[axis],
+      elmDirection,
       this.elmTransition,
       this.draggable.operationID,
       this.siblingsEmptyElmIndex,

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -187,16 +187,24 @@ class DistanceCalculator implements DistanceCalculatorInterface {
    *
    * @param id -
    */
-  protected updateElement(id: string, isIncrease: boolean, axis: Axis) {
+  protected updateElement(id: string, isIncrease: boolean, initAxis: Axis) {
     const element = store.registry[id];
 
-    // const { SK } = store.registry[id].keys;
-    // const siblingsGrid = store.siblingsGridContainer[SK];
+    const { SK } = store.registry[id].keys;
 
-    // const isContainerHasCol =
-    //   this.draggable.gridPlaceholder.x + 1 <= siblingsGrid.x;
+    const siblingsGrid = store.siblingsGridContainer[SK];
 
-    // const axis = isContainerHasCol ? "x" : "y";
+    const isContainerHasCol =
+      this.draggable.gridPlaceholder.x + 1 <= siblingsGrid.x;
+
+    const axis = isContainerHasCol ? "x" : "y";
+
+    if (initAxis !== axis) {
+      throw new Error(
+        `Axis is not the same as initAxis is ${initAxis} and axis is ${axis}`
+      );
+    }
+
     const elmDirection = isIncrease ? -1 : 1;
 
     this.calculateDistance(element, axis);

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -255,7 +255,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
      */
     this.siblingsEmptyElmIndex[axis] = element.setPosition(
       store.getElmSiblingsListById(this.draggable.draggedElm.id)!,
-      this.effectedElemDirection,
+      this.effectedElemDirection[axis],
       this.elmTransition,
       this.draggable.operationID,
       this.siblingsEmptyElmIndex,

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,7 +1,7 @@
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 
 import { Direction, PointNum } from "@dflex/utils";
-import type { IPointNum, EffectedElemDirection, Axis } from "@dflex/utils";
+import type { IPointNum, Axis } from "@dflex/utils";
 
 import type { InteractivityEvent } from "../types";
 import type { DraggableInteractiveInterface } from "../Draggable";
@@ -37,8 +37,6 @@ function emitInteractiveEvent(
 class DistanceCalculator implements DistanceCalculatorInterface {
   protected draggable: DraggableInteractiveInterface;
 
-  protected effectedElemDirection: EffectedElemDirection;
-
   private elmTransition: IPointNum;
 
   private draggedOffset: IPointNum;
@@ -66,15 +64,6 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     this.draggedAccumulatedTransition = new PointNum(0, 0);
 
     this.siblingsEmptyElmIndex = new PointNum(-1, -1);
-
-    /**
-     * Elements effected by dragged direction.
-     * Negative for up and right.
-     */
-    this.effectedElemDirection = {
-      x: 1,
-      y: 1,
-    };
 
     this.isParentLocked = false;
   }

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -187,7 +187,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
    *
    * @param id -
    */
-  protected updateElement(id: string, axis: Axis) {
+  protected updateElement(id: string, isIncrease: boolean, axis: Axis) {
     const element = store.registry[id];
 
     // const { SK } = store.registry[id].keys;
@@ -197,13 +197,11 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     //   this.draggable.gridPlaceholder.x + 1 <= siblingsGrid.x;
 
     // const axis = isContainerHasCol ? "x" : "y";
-    // const elmDirection = isIncrease ? -1 : 1;
+    const elmDirection = isIncrease ? -1 : 1;
 
     this.calculateDistance(element, axis);
 
-    this.draggable.updateNumOfElementsTransformed(
-      this.effectedElemDirection[axis]
-    );
+    this.draggable.updateNumOfElementsTransformed(elmDirection);
 
     // TODO: always true for the first element
     if (!this.isParentLocked) {
@@ -241,7 +239,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       currentPosition.y + this.draggedOffset.y
     );
 
-    const draggedDirection = -1 * this.effectedElemDirection[axis];
+    const draggedDirection = -1 * elmDirection;
 
     this.draggable.occupiedTranslate.increase(
       draggedDirection * this.draggedAccumulatedTransition.x,

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -187,7 +187,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
    *
    * @param id -
    */
-  protected updateElement(id: string, isIncrease: boolean, initAxis: Axis) {
+  protected updateElement(id: string, isIncrease: boolean) {
     const element = store.registry[id];
 
     const { SK } = store.registry[id].keys;
@@ -198,12 +198,6 @@ class DistanceCalculator implements DistanceCalculatorInterface {
       this.draggable.gridPlaceholder.x + 1 <= siblingsGrid.x;
 
     const axis = isContainerHasCol ? "x" : "y";
-
-    if (initAxis !== axis) {
-      throw new Error(
-        `Axis is not the same as initAxis is ${initAxis} and axis is ${axis}`
-      );
-    }
 
     const elmDirection = isIncrease ? -1 : 1;
 

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,6 +1,6 @@
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 
-import { PointNum } from "@dflex/utils";
+import { Direction, PointNum } from "@dflex/utils";
 import type { IPointNum, EffectedElemDirection, Axis } from "@dflex/utils";
 
 import type { InteractivityEvent } from "../types";
@@ -93,7 +93,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
   private setDistanceIndicators(
     position: Difference,
     space: Difference,
-    axis: Axis
+    axis: Axis,
+    direction: Direction
   ) {
     const positionDifference = Math.abs(position.dragged - position.element);
 
@@ -107,7 +108,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     if (space.dragged < space.element) {
       // console.log("elmHight is bigger");
 
-      if (this.effectedElemDirection[axis] === -1) {
+      if (direction === -1) {
         // console.log("elm going up");
 
         this.draggedAccumulatedTransition[axis] += offsetDiff;
@@ -123,7 +124,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
     // console.log("elmHight is smaller");
 
-    if (this.effectedElemDirection[axis] === -1) {
+    if (direction === -1) {
       // console.log("elm going up");
 
       this.draggedAccumulatedTransition[axis] -= offsetDiff;
@@ -135,7 +136,11 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     }
   }
 
-  private calculateDistance(element: CoreInstanceInterface, axis: Axis) {
+  private calculateDistance(
+    element: CoreInstanceInterface,
+    axis: Axis,
+    direction: Direction
+  ) {
     const {
       currentPosition: elmPosition,
       offset: { height: elmHight, width: elmWidth },
@@ -162,7 +167,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
           dragged: draggedHight,
           element: elmHight,
         },
-        "y"
+        "y",
+        direction
       );
 
       return;
@@ -177,7 +183,8 @@ class DistanceCalculator implements DistanceCalculatorInterface {
         dragged: draggedWidth,
         element: elmWidth,
       },
-      "x"
+      "x",
+      direction
     );
   }
 
@@ -199,9 +206,9 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
     const axis = isContainerHasCol ? "x" : "y";
 
-    const elmDirection = isIncrease ? -1 : 1;
+    const elmDirection: Direction = isIncrease ? -1 : 1;
 
-    this.calculateDistance(element, axis);
+    this.calculateDistance(element, axis, elmDirection);
 
     this.draggable.updateNumOfElementsTransformed(elmDirection);
 

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -299,7 +299,7 @@ class Droppable extends DistanceCalculator {
     ) {
       this.draggable.setDraggedTempIndex(elmIndex);
 
-      this.updateElement(id, isIncrease, this.axes);
+      this.updateElement(id, isIncrease);
     }
   }
 
@@ -337,7 +337,7 @@ class Droppable extends DistanceCalculator {
           this.draggable.scroll.enable
         )
       ) {
-        this.updateElement(id, true, this.axes);
+        this.updateElement(id, true);
       }
     }
   }
@@ -367,7 +367,7 @@ class Droppable extends DistanceCalculator {
           this.draggable.scroll.enable
         )
       ) {
-        this.updateElement(id, false, this.axes);
+        this.updateElement(id, false);
       }
     }
   }

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -285,8 +285,7 @@ class Droppable extends DistanceCalculator {
     const siblings = store.getElmSiblingsListById(this.draggable.draggedElm.id);
 
     const elmIndex =
-      this.draggable.indexPlaceholder +
-      -1 * this.effectedElemDirection[this.axes];
+      this.draggable.indexPlaceholder + -1 * (isIncrease ? -1 : 1);
 
     const id = siblings![elmIndex];
 

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -281,7 +281,7 @@ class Droppable extends DistanceCalculator {
     return droppableIndex;
   }
 
-  private switchElement() {
+  private switchElement(isIncrease: boolean) {
     const siblings = store.getElmSiblingsListById(this.draggable.draggedElm.id);
 
     const elmIndex =
@@ -299,7 +299,7 @@ class Droppable extends DistanceCalculator {
     ) {
       this.draggable.setDraggedTempIndex(elmIndex);
 
-      this.updateElement(id, this.axes);
+      this.updateElement(id, isIncrease, this.axes);
     }
   }
 
@@ -337,7 +337,7 @@ class Droppable extends DistanceCalculator {
           this.draggable.scroll.enable
         )
       ) {
-        this.updateElement(id, this.axes);
+        this.updateElement(id, true, this.axes);
       }
     }
   }
@@ -367,7 +367,7 @@ class Droppable extends DistanceCalculator {
           this.draggable.scroll.enable
         )
       ) {
-        this.updateElement(id, this.axes);
+        this.updateElement(id, false, this.axes);
       }
     }
   }
@@ -415,7 +415,7 @@ class Droppable extends DistanceCalculator {
       // Inside the container.
       this.setEffectedElemDirection(isOut[id].isLeftFromBottom, this.axes);
 
-      this.switchElement();
+      this.switchElement(isOut[id].isLeftFromBottom);
 
       return;
     }
@@ -438,7 +438,7 @@ class Droppable extends DistanceCalculator {
 
     this.setEffectedElemDirection(isOut[id].isLeftFromRight, this.axes);
 
-    this.switchElement();
+    this.switchElement(isOut[id].isLeftFromRight);
   }
 
   private lockParent(isOut: boolean) {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -392,9 +392,6 @@ class Droppable extends DistanceCalculator {
 
       // Leaving from top.
       if (newRow === 0) {
-        // move element up
-        this.setEffectedElemDirection(true, this.axes);
-
         // lock the parent
         this.lockParent(true);
 
@@ -411,9 +408,6 @@ class Droppable extends DistanceCalculator {
         return;
       }
 
-      // Inside the container.
-      this.setEffectedElemDirection(isOut[id].isLeftFromBottom, this.axes);
-
       this.switchElement(isOut[id].isLeftFromBottom);
 
       return;
@@ -424,9 +418,6 @@ class Droppable extends DistanceCalculator {
       : gridPlaceholder.x - 1;
 
     if (newCol <= 0 || newCol > siblingsGrid.x) {
-      // move element up
-      this.setEffectedElemDirection(true, this.axes);
-
       // lock the parent
       this.lockParent(true);
 
@@ -434,8 +425,6 @@ class Droppable extends DistanceCalculator {
 
       return;
     }
-
-    this.setEffectedElemDirection(isOut[id].isLeftFromRight, this.axes);
 
     this.switchElement(isOut[id].isLeftFromRight);
   }
@@ -476,22 +465,8 @@ class Droppable extends DistanceCalculator {
 
     this.lockParent(false);
 
-    /**
-     * Moving element down by setting is up to false
-     */
-    this.setEffectedElemDirection(false, this.axes);
-
     if (hasToMoveSiblingsDown) {
       this.moveDown(to);
-
-      /**
-       * Now, resitting direction by figuring out if dragged settled up/dwn.
-       */
-      const isElmUp = this.leftAtIndex > this.draggable.indexPlaceholder;
-
-      this.setEffectedElemDirection(isElmUp, this.axes);
-    } else {
-      this.setEffectedElemDirection(true, this.axes);
     }
 
     /**


### PR DESCRIPTION
- [x] Core updater receives one axis/direction instead of both matching the entire approach of one axis per transformation. 
- [x] Remove `setEffectedElemDirection` and `effectedElemDirection`  using the direction resulted in the update-element depending on the increase/decreas parameter. 