### PR TITLE
Store axes in translate history for each movement

### DIFF
--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -216,7 +216,8 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
     if (operationID) {
       const elmAxesHistory: TransitionHistory = {
         ID: operationID,
-        translate: this.translate[axis],
+        axis,
+        translate: { x: this.translate.x, y: this.translate.y },
       };
 
       if (!this.#translateHistory) {
@@ -324,7 +325,9 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
 
     const { translate: preTranslate } = lastMovement;
 
-    const elmSpace = preTranslate - this.translate[axis];
+    console.log(preTranslate);
+
+    const elmSpace = preTranslate[axis] - this.translate[axis];
 
     const increment = elmSpace > 0 ? 1 : -1;
 

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -8,6 +8,7 @@ import type {
   Axis,
   IPoint,
   IPointNum,
+  IPointAxes,
 } from "@dflex/utils";
 
 import AbstractInstance from "./AbstractInstance";
@@ -91,8 +92,8 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
     this.hasToTransform = false;
   }
 
-  #updateCurrentIndicators(leftSpace: number, topSpace: number) {
-    this.translate.increase(leftSpace, topSpace);
+  #updateCurrentIndicators(space: IPointAxes) {
+    this.translate.increase(space.x, space.y);
 
     const { left, top } = this.offset!;
 
@@ -208,7 +209,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
    *  Set a new translate position and store the old one.
    */
   #seTranslate(
-    elmSpace: number,
+    elmSpace: IPointAxes,
     axis: Axis,
     operationID?: string,
     isForceTransform = false
@@ -230,11 +231,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
       }
     }
 
-    if (axis === "x") {
-      this.#updateCurrentIndicators(elmSpace, 0);
-    } else {
-      this.#updateCurrentIndicators(0, elmSpace);
-    }
+    this.#updateCurrentIndicators(elmSpace);
 
     if (!isForceTransform && !this.isVisible) {
       this.hasToTransform = true;
@@ -272,7 +269,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
      */
     elmSpace[axis] *= direction;
 
-    this.#seTranslate(elmSpace[axis], axis, operationID);
+    this.#seTranslate(elmSpace, axis, operationID);
 
     const { oldIndex, newIndex } = this.#updateOrderIndexing(
       direction * numberOfPassedElm
@@ -325,14 +322,21 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
 
     const { translate: preTranslate } = lastMovement;
 
-    console.log(preTranslate);
+    const elmSpaceX = preTranslate.x - this.translate.x;
+    const elmSpaceY = preTranslate.y - this.translate.y;
 
-    const elmSpace = preTranslate[axis] - this.translate[axis];
-
-    const increment = elmSpace > 0 ? 1 : -1;
+    const increment = elmSpaceX > 0 || elmSpaceY > 0 ? 1 : -1;
 
     // Don't update UI if it's zero and wasn't transformed.
-    this.#seTranslate(elmSpace, axis, undefined, isForceTransform);
+    this.#seTranslate(
+      {
+        x: elmSpaceX,
+        y: elmSpaceY,
+      },
+      axis,
+      undefined,
+      isForceTransform
+    );
 
     this.#updateOrderIndexing(increment);
 

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -92,7 +92,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
   }
 
   #updateCurrentIndicators(space: IPointAxes) {
-    this.translate.increase(space.x, space.y);
+    this.translate.increase(space);
 
     const { left, top } = this.offset!;
 

--- a/packages/core-instance/src/CoreInstance.ts
+++ b/packages/core-instance/src/CoreInstance.ts
@@ -1,12 +1,11 @@
 /* eslint-disable no-param-reassign */
 
-import { Point, PointNum } from "@dflex/utils";
+import { PointNum } from "@dflex/utils";
 
 import type {
   RectDimensions,
   Direction,
   Axis,
-  IPoint,
   IPointNum,
   IPointAxes,
 } from "@dflex/utils";
@@ -41,7 +40,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
 
   animatedFrame: number | null;
 
-  #translateHistory?: IPoint<TransitionHistory[]>;
+  #translateHistory?: TransitionHistory[];
 
   constructor(eleWithPointer: CoreInput, opts: AbstractOpts) {
     const { order, keys, depth, scrollX, scrollY, ...element } = eleWithPointer;
@@ -221,13 +220,10 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
         translate: { x: this.translate.x, y: this.translate.y },
       };
 
-      if (!this.#translateHistory) {
-        this.#translateHistory =
-          axis === "x"
-            ? new Point([elmAxesHistory], [])
-            : new Point([], [elmAxesHistory]);
+      if (!Array.isArray(this.#translateHistory)) {
+        this.#translateHistory = [elmAxesHistory];
       } else {
-        this.#translateHistory[axis].push(elmAxesHistory);
+        this.#translateHistory.push(elmAxesHistory);
       }
     }
 
@@ -305,22 +301,22 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
    *
    * @param operationID
    * @param isForceTransform
-   * @param axis
    */
-  rollBack(operationID: string, isForceTransform: boolean, axis: Axis) {
+  rollBack(operationID: string, isForceTransform: boolean) {
     if (
-      this.#translateHistory![axis].length === 0 ||
-      this.#translateHistory![axis][this.#translateHistory![axis].length - 1]
-        .ID !== operationID
+      !Array.isArray(this.#translateHistory) ||
+      this.#translateHistory.length === 0 ||
+      this.#translateHistory[this.#translateHistory.length - 1].ID !==
+        operationID
     ) {
       return;
     }
 
-    const lastMovement = this.#translateHistory![axis].pop();
+    const lastMovement = this.#translateHistory.pop();
 
     if (!lastMovement) return;
 
-    const { translate: preTranslate } = lastMovement;
+    const { translate: preTranslate, axis } = lastMovement;
 
     const elmSpaceX = preTranslate.x - this.translate.x;
     const elmSpaceY = preTranslate.y - this.translate.y;
@@ -355,7 +351,7 @@ class CoreInstance extends AbstractInstance implements CoreInstanceInterface {
       );
     }
 
-    this.rollBack(operationID, isForceTransform, axis);
+    this.rollBack(operationID, isForceTransform);
   }
 }
 

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -1,4 +1,10 @@
-import type { RectDimensions, Axis, IPointNum, Direction } from "@dflex/utils";
+import type {
+  RectDimensions,
+  Axis,
+  IPointNum,
+  IPointAxes,
+  Direction,
+} from "@dflex/utils";
 
 export interface AbstractOpts {
   isInitialized: boolean;
@@ -75,7 +81,8 @@ export interface CoreInput extends AbstractInput {
 
 export type TransitionHistory = {
   ID: string;
-  translate: number;
+  axis: Axis;
+  translate: IPointAxes;
 };
 
 export interface CoreInstanceInterface extends AbstractInterface {

--- a/packages/core-instance/src/types.ts
+++ b/packages/core-instance/src/types.ts
@@ -126,5 +126,5 @@ export interface CoreInstanceInterface extends AbstractInterface {
     oldIndex?: number,
     siblingsHasEmptyElm?: number
   ): number;
-  rollBack(operationID: string, isForceTransform: boolean, axis: Axis): void;
+  rollBack(operationID: string, isForceTransform: boolean): void;
 }

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -236,8 +236,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
     const draggedDirection = -1 * elmDirection;
 
     this.draggable.occupiedTranslate.increase(
-      draggedDirection * this.draggedAccumulatedTransition.x,
-      draggedDirection * this.draggedAccumulatedTransition.y
+      this.draggedAccumulatedTransition.getMultiplied(draggedDirection)
     );
 
     this.draggable.gridPlaceholder.clone(grid);

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -52,7 +52,7 @@ class EndDroppable extends Droppable {
        * Note: rolling back won't affect order array. It only deals with element
        * itself and totally ignore any instance related to store.
        */
-      element.rollBack(this.draggable.operationID, listVisibility, this.axes);
+      element.rollBack(this.draggable.operationID, listVisibility);
 
       // This will decrease the number by 1.
       this.draggable.updateNumOfElementsTransformed(1);

--- a/packages/utils/src/Point/PointNum.ts
+++ b/packages/utils/src/Point/PointNum.ts
@@ -1,14 +1,24 @@
 import Point from "./Point";
+import type { IPointAxes } from "./types";
 
 class PointNum extends Point<number> {
-  increase(x: number, y: number) {
-    this.x += x;
-    this.y += y;
+  increase(point: IPointAxes) {
+    this.x += point.x;
+    this.y += point.y;
   }
 
-  decrease(x: number, y: number) {
-    this.x -= x;
-    this.y -= y;
+  decrease(point: IPointAxes) {
+    this.x -= point.x;
+    this.y -= point.y;
+  }
+
+  multiplyAll(val: number) {
+    this.x *= val;
+    this.y *= val;
+  }
+
+  getMultiplied(val: number) {
+    return { x: this.x * val, y: this.y * val };
   }
 }
 

--- a/packages/utils/src/Point/index.ts
+++ b/packages/utils/src/Point/index.ts
@@ -2,4 +2,4 @@ export { default as Point } from "./Point";
 export { default as PointNum } from "./PointNum";
 export { default as PointBool } from "./PointBool";
 
-export type { IPoint, IPointNum, IPointBool } from "./types";
+export type { IPointAxes, IPoint, IPointNum, IPointBool } from "./types";

--- a/packages/utils/src/Point/types.ts
+++ b/packages/utils/src/Point/types.ts
@@ -13,8 +13,12 @@ export interface IPointAxes<T = number> {
 }
 
 export interface IPointNum extends IPoint<number> {
-  increase(x: number, y: number): void;
-  decrease(x: number, y: number): void;
+  increase(point: IPointAxes): void;
+  decrease(point: IPointAxes): void;
+  multiplyAll(val: number): void;
+
+  /** Multiply the value with instance and return the result without mutation. */
+  getMultiplied(val: number): IPointAxes;
 }
 
 export interface IPointBool extends IPoint<boolean> {

--- a/packages/utils/src/Point/types.ts
+++ b/packages/utils/src/Point/types.ts
@@ -6,6 +6,12 @@ export interface IPoint<T = number> {
   isEqual(target: IPoint<T>): boolean;
 }
 
+/** X/Y object without the class instance. */
+export interface IPointAxes<T = number> {
+  x: T;
+  y: T;
+}
+
 export interface IPointNum extends IPoint<number> {
   increase(x: number, y: number): void;
   decrease(x: number, y: number): void;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,5 @@
 export { Point, PointNum, PointBool } from "./Point";
-export type { IPoint, IPointNum, IPointBool } from "./Point";
+export type { IPointAxes, IPoint, IPointNum, IPointBool } from "./Point";
 
 export { Threshold } from "./Threshold";
 export type {
@@ -11,7 +11,7 @@ export type {
 export type {
   RectDimensions,
   RectBoundaries,
+  Axes,
   Axis,
   Direction,
-  EffectedElemDirection,
 } from "./types";

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -14,15 +14,8 @@ export interface RectBoundaries {
 
 export type Direction = 1 | -1;
 
-/** How the element movement effects the siblings direction */
-export interface EffectedElemDirection {
-  x: Direction;
-  y: Direction;
-}
-
+/** Single Axis. */
 export type Axis = "x" | "y";
 
-export interface Coordinates {
-  x: number;
-  y: number;
-}
+/** Bi-directional Axis. */
+export type Axes = Axis | "z";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "target": "ESNext",
-    "module": "CommonJS",
+    "module": "ES2022",
     "sourceMap": false,
     "lib": ["dom", "ESNext"],
     "moduleResolution": "Node",


### PR DESCRIPTION
- [x] Store both axes for undoing history.
- [x] Update both axes at once with x/y instance.
- [x] Remove axis parameter from the Undo mehod in the core.
- [x] Utilize Point  instance.
- [x] Use bi-directional axis for undoing position.