### PR TITLE
Manage containers migration

### DIFF
--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -24,7 +24,7 @@ class DraggableAxes
 
   gridPlaceholder: IPointNum;
 
-  SKplaceholder: string | null;
+  siblingsKeyPlaceholder: string;
 
   threshold: ThresholdInterface;
 
@@ -59,7 +59,7 @@ class DraggableAxes
 
     this.indexPlaceholder = order.self;
     this.gridPlaceholder = new PointNum(grid.x, grid.y);
-    this.SKplaceholder = SK;
+    this.siblingsKeyPlaceholder = SK;
 
     this.isViewportRestricted = true;
 
@@ -117,7 +117,7 @@ class DraggableAxes
 
     this.restrictionsStatus = opts.restrictionsStatus;
 
-    const siblings = store.getElmBranchByKey(this.SKplaceholder);
+    const siblings = store.getElmBranchByKey(this.siblingsKeyPlaceholder);
 
     this.axesFilterNeeded =
       siblings !== null &&
@@ -283,7 +283,8 @@ class DraggableAxes
 
   #isLeavingFromTail() {
     const lastElm =
-      (store.getElmBranchByKey(this.SKplaceholder!) as string[]).length - 1;
+      (store.getElmBranchByKey(this.siblingsKeyPlaceholder) as string[])
+        .length - 1;
 
     return (
       this.threshold.isOut[this.draggedElm.id].isLeftFromBottom &&
@@ -295,8 +296,7 @@ class DraggableAxes
     return (
       !this.#isLeavingFromTail() &&
       (this.isOutThreshold() ||
-        this.SKplaceholder === null ||
-        this.isOutThreshold(this.SKplaceholder))
+        this.isOutThreshold(this.siblingsKeyPlaceholder))
     );
   }
 }

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -1,8 +1,13 @@
 import { AbstractDraggable } from "@dflex/draggable";
 import type { Coordinates } from "@dflex/draggable";
 
-import { Threshold, PointNum, PointBool } from "@dflex/utils";
-import type { ThresholdInterface, IPointNum, IPointBool } from "@dflex/utils";
+import { Threshold, PointNum, PointBool, Migration } from "@dflex/utils";
+import type {
+  ThresholdInterface,
+  IPointNum,
+  IPointBool,
+  IMigration,
+} from "@dflex/utils";
 
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 
@@ -16,13 +21,15 @@ class DraggableAxes
   extends AbstractDraggable<CoreInstanceInterface>
   implements DraggableAxesInterface
 {
-  indexPlaceholder: number;
+  // indexPlaceholder: number;
 
   positionPlaceholder: IPointNum;
 
   gridPlaceholder: IPointNum;
 
-  siblingsKeyPlaceholder: string;
+  // siblingsKeyPlaceholder: string;
+
+  migration: IMigration;
 
   threshold: ThresholdInterface;
 
@@ -51,15 +58,15 @@ class DraggableAxes
 
     this.#isLayoutStateUpdated = false;
 
-    const { order, grid } = element;
-
     const {
+      order,
+      grid,
       keys: { SK },
-    } = store.registry[id];
+    } = element;
 
-    this.indexPlaceholder = order.self;
     this.gridPlaceholder = new PointNum(grid.x, grid.y);
-    this.siblingsKeyPlaceholder = SK;
+
+    this.migration = new Migration(order.self, SK);
 
     this.isViewportRestricted = true;
 
@@ -117,7 +124,7 @@ class DraggableAxes
 
     this.#restrictionsStatus = opts.restrictionsStatus;
 
-    const siblings = store.getElmBranchByKey(this.siblingsKeyPlaceholder);
+    const siblings = store.getElmBranchByKey(this.migration.latest().key);
 
     this.#axesFilterNeeded =
       siblings !== null &&
@@ -283,12 +290,12 @@ class DraggableAxes
 
   #isLeavingFromTail() {
     const lastElm =
-      (store.getElmBranchByKey(this.siblingsKeyPlaceholder) as string[])
+      (store.getElmBranchByKey(this.migration.latest().key) as string[])
         .length - 1;
 
     return (
       this.threshold.isOut[this.draggedElm.id].isLeftFromBottom &&
-      this.indexPlaceholder === lastElm
+      this.migration.latest().index === lastElm
     );
   }
 
@@ -296,7 +303,7 @@ class DraggableAxes
     return (
       !this.#isLeavingFromTail() &&
       (this.isOutThreshold() ||
-        this.isOutThreshold(this.siblingsKeyPlaceholder))
+        this.isOutThreshold(this.migration.latest().key))
     );
   }
 }

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -16,8 +16,6 @@ class DraggableAxes
   extends AbstractDraggable<CoreInstanceInterface>
   implements DraggableAxesInterface
 {
-  private isLayoutStateUpdated: boolean;
-
   indexPlaceholder: number;
 
   positionPlaceholder: IPointNum;
@@ -30,17 +28,19 @@ class DraggableAxes
 
   isViewportRestricted: boolean;
 
-  readonly innerOffset: IPointNum;
-
   isMovingAwayFrom: IPointBool;
 
-  private readonly axesFilterNeeded: boolean;
+  readonly innerOffset: IPointNum;
 
-  private readonly restrictions: Restrictions;
+  #isLayoutStateUpdated: boolean;
 
-  private readonly restrictionsStatus: RestrictionsStatus;
+  readonly #axesFilterNeeded: boolean;
 
-  private readonly marginX: number;
+  readonly #restrictions: Restrictions;
+
+  readonly #restrictionsStatus: RestrictionsStatus;
+
+  readonly #marginX: number;
 
   readonly #initCoordinates: IPointNum;
 
@@ -49,7 +49,7 @@ class DraggableAxes
 
     super(element, initCoordinates);
 
-    this.isLayoutStateUpdated = false;
+    this.#isLayoutStateUpdated = false;
 
     const { order, grid } = element;
 
@@ -106,20 +106,20 @@ class DraggableAxes
     // get element margin
     const rm = Math.round(parseFloat(style.marginRight));
     const lm = Math.round(parseFloat(style.marginLeft));
-    this.marginX = rm + lm;
+    this.#marginX = rm + lm;
 
     this.positionPlaceholder = new PointNum(
       currentPosition.x,
       currentPosition.y
     );
 
-    this.restrictions = opts.restrictions;
+    this.#restrictions = opts.restrictions;
 
-    this.restrictionsStatus = opts.restrictionsStatus;
+    this.#restrictionsStatus = opts.restrictionsStatus;
 
     const siblings = store.getElmBranchByKey(this.siblingsKeyPlaceholder);
 
-    this.axesFilterNeeded =
+    this.#axesFilterNeeded =
       siblings !== null &&
       (opts.restrictionsStatus.isContainerRestricted ||
         opts.restrictionsStatus.isSelfRestricted);
@@ -168,12 +168,12 @@ class DraggableAxes
         : this.#initCoordinates.x;
     }
 
-    if (!allowRight && currentRight + this.marginX >= rightThreshold) {
+    if (!allowRight && currentRight + this.#marginX >= rightThreshold) {
       return restrictToThreshold
         ? rightThreshold +
             this.innerOffset.x -
             this.draggedElm.offset.width -
-            this.marginX
+            this.#marginX
         : this.#initCoordinates.x;
     }
 
@@ -181,8 +181,8 @@ class DraggableAxes
   }
 
   dragAt(x: number, y: number) {
-    if (!this.isLayoutStateUpdated) {
-      this.isLayoutStateUpdated = true;
+    if (!this.#isLayoutStateUpdated) {
+      this.#isLayoutStateUpdated = true;
       store.onStateChange("dragging");
     }
 
@@ -191,7 +191,7 @@ class DraggableAxes
 
     const { SK } = store.registry[this.draggedElm.id].keys;
 
-    if (this.axesFilterNeeded) {
+    if (this.#axesFilterNeeded) {
       const {
         top,
         bottom,
@@ -199,38 +199,38 @@ class DraggableAxes
         right: minRight,
       } = store.siblingsBoundaries[SK];
 
-      if (this.restrictionsStatus.isContainerRestricted) {
+      if (this.#restrictionsStatus.isContainerRestricted) {
         filteredX = this.axesXFilter(
           x,
           maxLeft,
           minRight,
-          this.restrictions.container.allowLeavingFromLeft,
-          this.restrictions.container.allowLeavingFromRight,
+          this.#restrictions.container.allowLeavingFromLeft,
+          this.#restrictions.container.allowLeavingFromRight,
           false
         );
         filteredY = this.axesYFilter(
           y,
           top,
           bottom,
-          this.restrictions.container.allowLeavingFromTop,
-          this.restrictions.container.allowLeavingFromBottom,
+          this.#restrictions.container.allowLeavingFromTop,
+          this.#restrictions.container.allowLeavingFromBottom,
           true
         );
-      } else if (this.restrictionsStatus.isSelfRestricted) {
+      } else if (this.#restrictionsStatus.isSelfRestricted) {
         filteredX = this.axesXFilter(
           x,
           maxLeft,
           minRight,
-          this.restrictions.self.allowLeavingFromLeft,
-          this.restrictions.self.allowLeavingFromRight,
+          this.#restrictions.self.allowLeavingFromLeft,
+          this.#restrictions.self.allowLeavingFromRight,
           false
         );
         filteredY = this.axesYFilter(
           y,
           this.draggedElm.currentPosition.y,
           this.draggedElm.currentPosition.y + this.draggedElm.offset.height,
-          this.restrictions.self.allowLeavingFromTop,
-          this.restrictions.self.allowLeavingFromBottom,
+          this.#restrictions.self.allowLeavingFromTop,
+          this.#restrictions.self.allowLeavingFromBottom,
           false
         );
       }

--- a/packages/dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dnd/src/Draggable/DraggableInteractive.ts
@@ -47,7 +47,7 @@ class DraggableInteractive
 
     const { hasOverflowX, hasOverflowY } = store.siblingsScrollElement[SK];
 
-    const siblings = store.getElmBranchByKey(this.siblingsKeyPlaceholder);
+    const siblings = store.getElmBranchByKey(this.migration.latest().key);
 
     this.isDraggedPositionFixed = false;
 
@@ -128,7 +128,7 @@ class DraggableInteractive
   }
 
   setDraggedTempIndex(i: number) {
-    this.indexPlaceholder = i;
+    this.migration.setIndex(i);
     this.draggedElm.setDataset("index", i);
   }
 
@@ -137,7 +137,7 @@ class DraggableInteractive
   }
 
   setDraggedTransformPosition(isFallback: boolean) {
-    const siblings = store.getElmBranchByKey(this.siblingsKeyPlaceholder);
+    const siblings = store.getElmBranchByKey(this.migration.latest().key);
 
     /**
      * In this case, the use clicked without making any move.
@@ -189,10 +189,13 @@ class DraggableInteractive
     this.draggedElm.transformElm();
 
     if (Array.isArray(siblings)) {
-      this.draggedElm.assignNewPosition(siblings, this.indexPlaceholder);
+      this.draggedElm.assignNewPosition(
+        siblings,
+        this.migration.latest().index
+      );
     }
 
-    this.draggedElm.order.self = this.indexPlaceholder;
+    this.draggedElm.order.self = this.migration.latest().index;
   }
 
   endDragging(isFallback: boolean) {

--- a/packages/dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dnd/src/Draggable/DraggableInteractive.ts
@@ -128,7 +128,10 @@ class DraggableInteractive
   }
 
   setDraggedTempIndex(i: number) {
-    this.migration.setIndex(i);
+    if (!Number.isNaN(i)) {
+      this.migration.setIndex(i);
+    }
+
     this.draggedElm.setDataset("index", i);
   }
 
@@ -184,6 +187,8 @@ class DraggableInteractive
     this.draggedElm.currentPosition.clone(this.occupiedOffset);
     this.draggedElm.translate.clone(this.occupiedTranslate);
     this.draggedElm.grid.clone(this.gridPlaceholder);
+
+    // TODO: Fix this please, why it's just Y.
     this.draggedElm.setDataset("gridY", this.draggedElm.grid.y);
 
     this.draggedElm.transformElm();

--- a/packages/dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dnd/src/Draggable/DraggableInteractive.ts
@@ -47,7 +47,7 @@ class DraggableInteractive
 
     const { hasOverflowX, hasOverflowY } = store.siblingsScrollElement[SK];
 
-    const siblings = store.getElmBranchByKey(this.SKplaceholder!);
+    const siblings = store.getElmBranchByKey(this.siblingsKeyPlaceholder);
 
     this.isDraggedPositionFixed = false;
 
@@ -137,7 +137,7 @@ class DraggableInteractive
   }
 
   setDraggedTransformPosition(isFallback: boolean) {
-    const siblings = store.getElmBranchByKey(this.SKplaceholder!);
+    const siblings = store.getElmBranchByKey(this.siblingsKeyPlaceholder);
 
     /**
      * In this case, the use clicked without making any move.
@@ -205,7 +205,8 @@ class DraggableInteractive
 
     this.threshold.destroy();
 
-    [
+    // TODO: add type to this.
+    const properties = [
       "threshold",
       "gridPlaceholder",
       "isMovingAwayFrom",
@@ -213,9 +214,11 @@ class DraggableInteractive
       "occupiedOffset",
       "occupiedTranslate",
       "#initCoordinates",
-    ].forEach((instance) => {
+    ];
+
+    properties.forEach((property) => {
       // @ts-expect-error
-      this[instance] = null;
+      this[property] = null;
     });
   }
 }

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -3,6 +3,7 @@ import type {
   IPointBool,
   ThresholdInterface,
   ThresholdCoordinate,
+  IMigration,
 } from "@dflex/utils";
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 import type { AbstractDraggableInterface } from "@dflex/draggable";
@@ -38,11 +39,7 @@ export interface DraggableAxesInterface
   /** Dragged position for both X and Y.  */
   readonly positionPlaceholder: IPointNum;
 
-  /** Temporary index for dragged  */
-  readonly indexPlaceholder: number;
-
-  /** Siblings key holder. Also, it's always defined until introducing actions. */
-  readonly siblingsKeyPlaceholder: string;
+  readonly migration: IMigration;
 
   /** grid placeholder for dragged grid position. */
   readonly gridPlaceholder: IPointNum;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -41,8 +41,8 @@ export interface DraggableAxesInterface
   /** Temporary index for dragged  */
   readonly indexPlaceholder: number;
 
-  /** Siblings key holder. */
-  SKplaceholder: string | null;
+  /** Siblings key holder. Also, it's always defined until introducing actions. */
+  readonly siblingsKeyPlaceholder: string;
 
   /** grid placeholder for dragged grid position. */
   readonly gridPlaceholder: IPointNum;

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -259,7 +259,9 @@ class DistanceCalculator implements DistanceCalculatorInterface {
      * Start transforming process
      */
     this.siblingsEmptyElmIndex[axis] = element.setPosition(
-      store.getElmBranchByKey(this.draggable.SKplaceholder!) as string[],
+      store.getElmBranchByKey(
+        this.draggable.siblingsKeyPlaceholder
+      ) as string[],
       elmDirection,
       this.elmTransition,
       this.draggable.operationID,

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -260,7 +260,7 @@ class DistanceCalculator implements DistanceCalculatorInterface {
      */
     this.siblingsEmptyElmIndex[axis] = element.setPosition(
       store.getElmBranchByKey(
-        this.draggable.siblingsKeyPlaceholder
+        this.draggable.migration.latest().key
       ) as string[],
       elmDirection,
       this.elmTransition,

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -84,9 +84,6 @@ class Droppable extends DistanceCalculator {
    * transformation. */
   #animatedDraggedInsertionFrame: number | null;
 
-  /** True when the element left the old container and found new one. */
-  #hasMigrated: boolean;
-
   static INDEX_OUT_CONTAINER = NaN;
 
   constructor(draggable: DraggableInteractiveInterface) {
@@ -134,7 +131,6 @@ class Droppable extends DistanceCalculator {
     this.#animatedDraggedInsertionFrame = null;
 
     this.isParentLocked = false;
-    this.#hasMigrated = false;
   }
 
   #draggedEventGenerator(type: DraggedEvent["type"]): DraggedEvent {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -97,7 +97,7 @@ class Droppable extends DistanceCalculator {
     this.#scrollAnimatedFrame = null;
 
     const { scrollX, scrollY } =
-      store.siblingsScrollElement[this.draggable.siblingsKeyPlaceholder];
+      store.siblingsScrollElement[this.draggable.migration.latest().key];
 
     this.#initialScroll = new PointNum(scrollX, scrollY);
 
@@ -171,14 +171,14 @@ class Droppable extends DistanceCalculator {
    * Gets the temporary index of dragged before it occupies new position.
    */
   getDraggedTempIndex() {
-    return this.draggable.indexPlaceholder;
+    return this.draggable.migration.latest().index;
   }
 
   #detectDroppableIndex() {
     let droppableIndex = null;
 
     const siblings = store.getElmBranchByKey(
-      this.draggable.siblingsKeyPlaceholder
+      this.draggable.migration.latest().key
     );
 
     for (let i = 0; i < siblings!.length; i += 1) {
@@ -208,9 +208,34 @@ class Droppable extends DistanceCalculator {
     return droppableIndex;
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  #migrateContainerIndicators() {
+    // const { oldSiblingsKey, oldIndex, newSiblingsKey } =
+    //   this.migrationPlaceholder;
+    // const originalSiblingList = store.getElmBranchByKey(
+    //   oldSiblingsKey
+    // ) as string[];
+    // Delete the element from old sibling list.
+    // originalSiblingList.splice(oldIndex, 1);
+    // const newSiblingList = store.getElmBranchByKey(
+    //   this.draggable.SKplaceholder!
+    // ) as string[];
+    // // insert element to new sibling list
+    // newSiblingList.splice(
+    //   this.draggable.draggedElm.order.self,
+    //   0,
+    //   this.draggable.draggedElm.id
+    // );
+    // console.log(
+    //   "file: Droppable.ts ~ line 660 ~ newSiblingList",
+    //   newSiblingList
+    // );
+    // this.draggable.SKplaceholder = newSK;
+  }
+
   #detectNearestElm() {
     const siblings =
-      store.DOMGen.branches[this.draggable.siblingsKeyPlaceholder];
+      store.DOMGen.branches[this.draggable.migration.latest().key];
 
     /**
      * If tempIndex is zero, the dragged is coming from the top. So, move them
@@ -255,37 +280,11 @@ class Droppable extends DistanceCalculator {
       if (!isOut) {
         newSK = SK;
 
-        this.#hasMigrated = true;
-
         break;
       }
     }
 
     return newSK;
-
-    // const oldSiblingList = store.getElmBranchByKey(
-    //   this.draggable.SKplaceholder!
-    // ) as string[];
-
-    // // Delete the element from old sibling list.
-    // oldSiblingList!.splice(oldSiblingList.length - 1, 1);
-
-    // const newSiblingList = store.getElmBranchByKey(
-    //   this.draggable.SKplaceholder!
-    // ) as string[];
-
-    // // insert element to new sibling list
-    // newSiblingList.splice(
-    //   this.draggable.draggedElm.order.self,
-    //   0,
-    //   this.draggable.draggedElm.id
-    // );
-    // console.log(
-    //   "file: Droppable.ts ~ line 660 ~ newSiblingList",
-    //   newSiblingList
-    // );
-
-    // this.draggable.SKplaceholder = newSK;
   }
 
   #updateLastElmOffset() {
@@ -293,7 +292,7 @@ class Droppable extends DistanceCalculator {
     let currentLeft = 0;
 
     const siblings = store.getElmBranchByKey(
-      this.draggable.siblingsKeyPlaceholder
+      this.draggable.migration.latest().key
     );
 
     if (siblings) {
@@ -316,7 +315,7 @@ class Droppable extends DistanceCalculator {
 
   #checkIfDraggedIsLastElm() {
     const siblings = store.getElmBranchByKey(
-      this.draggable.siblingsKeyPlaceholder
+      this.draggable.migration.latest().key
     );
 
     let isLast = false;
@@ -367,11 +366,11 @@ class Droppable extends DistanceCalculator {
 
   #switchElement(isIncrease: boolean) {
     const siblings = store.getElmBranchByKey(
-      this.draggable.siblingsKeyPlaceholder
+      this.draggable.migration.latest().key
     );
 
     const elmIndex =
-      this.draggable.indexPlaceholder + -1 * (isIncrease ? -1 : 1);
+      this.draggable.migration.latest().index + -1 * (isIncrease ? -1 : 1);
 
     const id = siblings![elmIndex];
 
@@ -393,10 +392,10 @@ class Droppable extends DistanceCalculator {
    */
   #fillHeadUp() {
     const siblings = store.getElmBranchByKey(
-      this.draggable.siblingsKeyPlaceholder
+      this.draggable.migration.latest().key
     ) as string[];
 
-    const from = this.draggable.indexPlaceholder + 1;
+    const from = this.draggable.migration.latest().index + 1;
 
     // this.leftAtIndex = this.draggable.indexPlaceholder;
 
@@ -433,7 +432,7 @@ class Droppable extends DistanceCalculator {
    */
   #moveDown(to: number) {
     const siblings = store.getElmBranchByKey(
-      this.draggable.siblingsKeyPlaceholder
+      this.draggable.migration.latest().key
     ) as string[];
 
     emitSiblingsEvent("onMoveDownSiblings", {
@@ -688,10 +687,10 @@ class Droppable extends DistanceCalculator {
       );
     }
 
-    if (!this.draggable.siblingsKeyPlaceholder) return;
+    if (!this.draggable.migration.latest().key) return;
 
     const siblings =
-      store.DOMGen.branches[this.draggable.siblingsKeyPlaceholder];
+      store.DOMGen.branches[this.draggable.migration.latest().key];
 
     if (siblings === null) return;
 
@@ -712,9 +711,9 @@ class Droppable extends DistanceCalculator {
 
       this.draggable.draggedElm.rmDateset("draggedOutPosition");
 
-      isOutSiblingsContainer =
-        !this.draggable.siblingsKeyPlaceholder ||
-        this.draggable.isOutThreshold(this.draggable.siblingsKeyPlaceholder);
+      isOutSiblingsContainer = this.draggable.isOutThreshold(
+        this.draggable.migration.latest().key
+      );
 
       // when it's out, and on of theses is true then it's happening.
       if (!isOutSiblingsContainer) {
@@ -750,9 +749,9 @@ class Droppable extends DistanceCalculator {
      * When dragged is out parent and returning to it.
      */
     if (this.isParentLocked) {
-      isOutSiblingsContainer =
-        this.draggable.siblingsKeyPlaceholder === null ||
-        this.draggable.isOutThreshold(this.draggable.siblingsKeyPlaceholder);
+      isOutSiblingsContainer = this.draggable.isOutThreshold(
+        this.draggable.migration.latest().key
+      );
 
       if (isOutSiblingsContainer) {
         return;

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -204,31 +204,6 @@ class Droppable extends DistanceCalculator {
     return droppableIndex;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  #migrateContainerIndicators() {
-    // const { oldSiblingsKey, oldIndex, newSiblingsKey } =
-    //   this.migrationPlaceholder;
-    // const originalSiblingList = store.getElmBranchByKey(
-    //   oldSiblingsKey
-    // ) as string[];
-    // Delete the element from old sibling list.
-    // originalSiblingList.splice(oldIndex, 1);
-    // const newSiblingList = store.getElmBranchByKey(
-    //   this.draggable.SKplaceholder!
-    // ) as string[];
-    // // insert element to new sibling list
-    // newSiblingList.splice(
-    //   this.draggable.draggedElm.order.self,
-    //   0,
-    //   this.draggable.draggedElm.id
-    // );
-    // console.log(
-    //   "file: Droppable.ts ~ line 660 ~ newSiblingList",
-    //   newSiblingList
-    // );
-    // this.draggable.SKplaceholder = newSK;
-  }
-
   #detectNearestElm() {
     const siblings =
       store.DOMGen.branches[this.draggable.migration.latest().key];

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -87,6 +87,8 @@ class Droppable extends DistanceCalculator {
   /** True when the element left the old container and found new one. */
   #hasMigrated: boolean;
 
+  static INDEX_OUT_CONTAINER = NaN;
+
   constructor(draggable: DraggableInteractiveInterface) {
     super(draggable);
 
@@ -214,28 +216,21 @@ class Droppable extends DistanceCalculator {
      * If tempIndex is zero, the dragged is coming from the top. So, move them
      * down all: to=0
      */
-    let to: number | null = 0;
     let hasToMoveSiblingsDown = true;
 
-    /**
-     * Otherwise, detect where it coming from and update tempIndex
-     * accordingly.
-     */
-    if (this.draggable.indexPlaceholder !== 0) {
-      to = this.#detectDroppableIndex();
+    let to = this.#detectDroppableIndex();
 
-      if (typeof to !== "number") {
-        // check if it's the last element
+    if (typeof to !== "number") {
+      // check if it's the last element
 
-        if (!this.#checkIfDraggedIsLastElm()) return;
+      if (!this.#checkIfDraggedIsLastElm()) return;
 
-        to = siblings!.length - 1;
+      to = siblings!.length - 1;
 
-        hasToMoveSiblingsDown = false;
-      }
-
-      this.draggable.setDraggedTempIndex(to);
+      hasToMoveSiblingsDown = false;
     }
+
+    this.draggable.setDraggedTempIndex(to);
 
     this.lockParent(false);
 
@@ -411,7 +406,7 @@ class Droppable extends DistanceCalculator {
       to: siblings.length,
     });
 
-    this.draggable.setDraggedTempIndex(-1);
+    this.draggable.setDraggedTempIndex(Droppable.INDEX_OUT_CONTAINER);
 
     for (let i = from; i < siblings.length; i += 1) {
       /**
@@ -520,6 +515,7 @@ class Droppable extends DistanceCalculator {
     this.isParentLocked = isOut;
   }
 
+  // TODO: Merge scrollElementOnY/scrollElementOnx with one method scrollElement.
   private scrollElementOnY(x: number, y: number, direction: 1 | -1) {
     let nextScrollTop = this.#scrollAxes.y;
 

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -276,11 +276,25 @@ class Droppable extends DistanceCalculator {
       if (!isOut) {
         newSK = SK;
 
+        const originalSiblingList = store.getElmBranchByKey(
+          this.draggable.migration.latest().key
+        ) as string[];
+
+        const newSiblingList = store.getElmBranchByKey(newSK) as string[];
+
+        // Remove the last element from the original list.
+        // when the dragged is out of the container, the last element is the
+        // placeholder as all the elements are stacked.
+        originalSiblingList.pop();
+
+        // Insert the element to the new list.
+        newSiblingList.push("");
+
+        this.draggable.migration.add(NaN, newSK);
+
         break;
       }
     }
-
-    return newSK;
   }
 
   #updateLastElmOffset() {

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -163,7 +163,7 @@ class EndDroppable extends Droppable {
 
   endDragging() {
     const siblings = store.getElmBranchByKey(
-      this.draggable.siblingsKeyPlaceholder
+      this.draggable.migration.latest().key
     );
 
     let isFallback = false;

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -162,7 +162,9 @@ class EndDroppable extends Droppable {
   }
 
   endDragging() {
-    const siblings = store.getElmBranchByKey(this.draggable.SKplaceholder!);
+    const siblings = store.getElmBranchByKey(
+      this.draggable.siblingsKeyPlaceholder
+    );
 
     let isFallback = false;
 

--- a/packages/utils/src/Migration/Migration.ts
+++ b/packages/utils/src/Migration/Migration.ts
@@ -1,0 +1,36 @@
+/* eslint-disable max-classes-per-file */
+
+import type { IAbstract, IMigration } from "./types";
+
+class AbstractMigration implements IAbstract {
+  index: number;
+
+  key: string;
+
+  constructor(index: number, key: string) {
+    this.index = index;
+    this.key = key;
+  }
+}
+
+class Migration implements IMigration {
+  migrations: Array<IAbstract>;
+
+  constructor(index: number, key: string) {
+    this.migrations = [new AbstractMigration(index, key)];
+  }
+
+  latest() {
+    return this.migrations[this.migrations.length - 1];
+  }
+
+  setIndex(index: number) {
+    this.latest().index = index;
+  }
+
+  setKey(k: string) {
+    this.latest().key = k;
+  }
+}
+
+export default Migration;

--- a/packages/utils/src/Migration/Migration.ts
+++ b/packages/utils/src/Migration/Migration.ts
@@ -14,22 +14,22 @@ class AbstractMigration implements IAbstract {
 }
 
 class Migration implements IMigration {
-  migrations: Array<IAbstract>;
+  #migrations: Array<IAbstract>;
 
   constructor(index: number, key: string) {
-    this.migrations = [new AbstractMigration(index, key)];
+    this.#migrations = [new AbstractMigration(index, key)];
   }
 
   latest() {
-    return this.migrations[this.migrations.length - 1];
+    return this.#migrations[this.#migrations.length - 1];
   }
 
   setIndex(index: number) {
     this.latest().index = index;
   }
 
-  setKey(k: string) {
-    this.latest().key = k;
+  add(index: number, key: string) {
+    this.#migrations.push(new AbstractMigration(index, key));
   }
 }
 

--- a/packages/utils/src/Migration/index.ts
+++ b/packages/utils/src/Migration/index.ts
@@ -1,0 +1,3 @@
+export { default as Migration } from "./Migration";
+
+export type { IAbstract, IMigration } from "./types";

--- a/packages/utils/src/Migration/types.ts
+++ b/packages/utils/src/Migration/types.ts
@@ -10,8 +10,8 @@ export interface IMigration {
 
   /**
    * We only update indexes considering migration definition when it happens
-   * outside container not moving inside it. So just index not key. If we have
-   * new key then we use add.
+   * outside container but not moving inside it.
+   * So we update an index but we add key.
    */
   setIndex(index: number): void;
 

--- a/packages/utils/src/Migration/types.ts
+++ b/packages/utils/src/Migration/types.ts
@@ -5,8 +5,16 @@ export interface IAbstract {
 }
 
 export interface IMigration {
-  migrations: Array<IAbstract>;
+  /** Get the latest migrations instance */
   latest(): IAbstract;
+
+  /**
+   * We only update indexes considering migration definition when it happens
+   * outside container not moving inside it. So just index not key. If we have
+   * new key then we use add.
+   */
   setIndex(index: number): void;
-  setKey(k: string): void;
+
+  /** When migration from one container to another. */
+  add(index: number, key: string): void;
 }

--- a/packages/utils/src/Migration/types.ts
+++ b/packages/utils/src/Migration/types.ts
@@ -1,0 +1,12 @@
+export interface IAbstract {
+  index: number;
+
+  key: string;
+}
+
+export interface IMigration {
+  migrations: Array<IAbstract>;
+  latest(): IAbstract;
+  setIndex(index: number): void;
+  setKey(k: string): void;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -11,6 +11,9 @@ export type {
 export { Tracker } from "./Tracker";
 export type { ITracker } from "./Tracker";
 
+export { Migration } from "./Migration";
+export type { IAbstract, IMigration } from "./Migration";
+
 export type {
   RectDimensions,
   RectBoundaries,


### PR DESCRIPTION
Replace placeholders with a new `Migration` class to deal with migrating from one container to another.
```ts
interface IAbstract {
  index: number;
  key: string;
}

interface IMigration {
  /** Get the latest migrations instance */
  latest(): IAbstract;

  /**
   * We only update indexes considering migration definition when it happens
   * outside container but not moving inside it.
   * So we update an index but we add a key.
   */
  setIndex(index: number): void;

  /** When migration from one container to another. */
  add(index: number, key: string): void;
}
```