### PR TITLE
Add synthetic offset for element insertion 

### DIFF
--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -57,30 +57,39 @@ class DraggableAxes
     const {
       order,
       grid,
+      currentPosition,
       keys: { SK },
+      offset: { width, height },
+      depth,
     } = element;
 
     this.gridPlaceholder = new PointNum(grid.x, grid.y);
 
     const siblings = store.getElmBranchByKey(SK);
 
-    const firstElmId = siblings[siblings.length - 1];
+    const firstElmId = siblings[0];
+    const secondElmId = siblings[1];
     const lastElmId = siblings[siblings.length - 1];
 
     this.migration = new Migration(
       order.self,
       SK,
-      store.registry[firstElmId].currentPosition,
+      {
+        x: Math.abs(
+          store.registry[firstElmId].currentPosition.x -
+            store.registry[firstElmId].offset.width -
+            store.registry[secondElmId].currentPosition.x
+        ),
+        y: Math.abs(
+          store.registry[firstElmId].currentPosition.y +
+            store.registry[firstElmId].offset.height -
+            store.registry[secondElmId].currentPosition.y
+        ),
+      },
       store.registry[lastElmId].currentPosition
     );
 
     this.isViewportRestricted = true;
-
-    const {
-      offset: { width, height },
-      currentPosition,
-      depth,
-    } = this.draggedElm;
 
     this.threshold = new Threshold(opts.threshold);
 

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -75,16 +75,20 @@ class DraggableAxes
       order.self,
       SK,
       {
-        x: Math.abs(
-          store.registry[firstElmId].currentPosition.x -
-            store.registry[firstElmId].offset.width -
-            store.registry[secondElmId].currentPosition.x
-        ),
-        y: Math.abs(
-          store.registry[firstElmId].currentPosition.y +
-            store.registry[firstElmId].offset.height -
-            store.registry[secondElmId].currentPosition.y
-        ),
+        x: secondElmId
+          ? Math.abs(
+              store.registry[firstElmId].currentPosition.x -
+                store.registry[firstElmId].offset.width -
+                store.registry[secondElmId].currentPosition.x
+            )
+          : 0,
+        y: secondElmId
+          ? Math.abs(
+              store.registry[firstElmId].currentPosition.y +
+                store.registry[firstElmId].offset.height -
+                store.registry[secondElmId].currentPosition.y
+            )
+          : 0,
       },
       store.registry[lastElmId].currentPosition
     );

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -62,7 +62,17 @@ class DraggableAxes
 
     this.gridPlaceholder = new PointNum(grid.x, grid.y);
 
-    this.migration = new Migration(order.self, SK);
+    const siblings = store.getElmBranchByKey(SK);
+
+    const firstElmId = siblings[siblings.length - 1];
+    const lastElmId = siblings[siblings.length - 1];
+
+    this.migration = new Migration(
+      order.self,
+      SK,
+      store.registry[firstElmId].currentPosition,
+      store.registry[lastElmId].currentPosition
+    );
 
     this.isViewportRestricted = true;
 
@@ -119,8 +129,6 @@ class DraggableAxes
     this.#restrictions = opts.restrictions;
 
     this.#restrictionsStatus = opts.restrictionsStatus;
-
-    const siblings = store.getElmBranchByKey(this.migration.latest().key);
 
     this.#axesFilterNeeded =
       siblings !== null &&

--- a/packages/dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dnd/src/Draggable/DraggableInteractive.ts
@@ -139,22 +139,6 @@ class DraggableInteractive
     this.numberOfElementsTransformed += -1 * effectedElemDirection;
   }
 
-  assignSyntheticPosition(position: IPointNum) {
-    const { threshold, occupiedPosition, draggedElm } = this;
-
-    /**
-     * Update threshold from here since there's no calling to updateElement.
-     */
-    threshold.setMainThreshold(draggedElm.id, {
-      width: draggedElm.offset.width,
-      height: draggedElm.offset.height,
-      left: position.x,
-      top: position.y,
-    });
-
-    occupiedPosition.clone(position);
-  }
-
   setDraggedTransformPosition(isFallback: boolean) {
     const siblings = store.getElmBranchByKey(this.migration.latest().key);
 

--- a/packages/dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dnd/src/Draggable/DraggableInteractive.ts
@@ -25,7 +25,7 @@ class DraggableInteractive
 
   scroll: ScrollOptWithThreshold;
 
-  occupiedOffset: IPointNum;
+  occupiedPosition: IPointNum;
 
   occupiedTranslate: IPointNum;
 
@@ -104,7 +104,7 @@ class DraggableInteractive
 
     this.operationID = store.tracker.newTravel();
 
-    this.occupiedOffset = new PointNum(currentPosition.x, currentPosition.y);
+    this.occupiedPosition = new PointNum(currentPosition.x, currentPosition.y);
     this.occupiedTranslate = new PointNum(translate.x, translate.y);
 
     /**
@@ -181,7 +181,7 @@ class DraggableInteractive
       return;
     }
 
-    this.draggedElm.currentPosition.clone(this.occupiedOffset);
+    this.draggedElm.currentPosition.clone(this.occupiedPosition);
     this.draggedElm.translate.clone(this.occupiedTranslate);
     this.draggedElm.grid.clone(this.gridPlaceholder);
 

--- a/packages/dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dnd/src/Draggable/DraggableInteractive.ts
@@ -139,6 +139,22 @@ class DraggableInteractive
     this.numberOfElementsTransformed += -1 * effectedElemDirection;
   }
 
+  assignSyntheticPosition(position: IPointNum) {
+    const { threshold, occupiedPosition, draggedElm } = this;
+
+    /**
+     * Update threshold from here since there's no calling to updateElement.
+     */
+    threshold.setMainThreshold(draggedElm.id, {
+      width: draggedElm.offset.width,
+      height: draggedElm.offset.height,
+      left: position.x,
+      top: position.y,
+    });
+
+    occupiedPosition.clone(position);
+  }
+
   setDraggedTransformPosition(isFallback: boolean) {
     const siblings = store.getElmBranchByKey(this.migration.latest().key);
 

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -75,7 +75,6 @@ export interface DraggableInteractiveInterface extends DraggableAxesInterface {
   readonly occupiedTranslate: IPointNum;
   readonly numberOfElementsTransformed: number;
   readonly isDraggedPositionFixed: boolean;
-  assignSyntheticPosition(position: IPointNum): void;
   setDraggedTempIndex(i: number): void;
   updateNumOfElementsTransformed(effectedElemDirection: number): void;
   endDragging(isFallback: boolean): void;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -71,7 +71,7 @@ export interface DraggableInteractiveInterface extends DraggableAxesInterface {
   setOfTransformedIds?: Set<string>;
   siblingsContainer: CoreInstanceInterface | null;
   scroll: ScrollOptWithThreshold;
-  readonly occupiedOffset: IPointNum;
+  readonly occupiedPosition: IPointNum;
   readonly occupiedTranslate: IPointNum;
   readonly numberOfElementsTransformed: number;
   readonly isDraggedPositionFixed: boolean;

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -75,6 +75,7 @@ export interface DraggableInteractiveInterface extends DraggableAxesInterface {
   readonly occupiedTranslate: IPointNum;
   readonly numberOfElementsTransformed: number;
   readonly isDraggedPositionFixed: boolean;
+  assignSyntheticPosition(position: IPointNum): void;
   setDraggedTempIndex(i: number): void;
   updateNumOfElementsTransformed(effectedElemDirection: number): void;
   endDragging(isFallback: boolean): void;

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -1,6 +1,6 @@
 import type { CoreInstanceInterface } from "@dflex/core-instance";
 
-import { Direction, PointNum } from "@dflex/utils";
+import { Direction, PointNum, RectDimensions } from "@dflex/utils";
 import type { IPointNum, Axis } from "@dflex/utils";
 
 import type { InteractivityEvent } from "../types";
@@ -75,6 +75,38 @@ class DistanceCalculator implements DistanceCalculatorInterface {
    * @param axis - Axes(x or y).
    * @returns
    */
+  #setDistanceIndicators2(
+    element: CoreInstanceInterface,
+    axis: Axis,
+    direction: Direction
+  ) {
+    const {
+      occupiedOffset,
+      draggedElm: { offset: draggedRect },
+    } = this.draggable;
+
+    const { currentPosition: elmPosition, offset: elmOffset } = element;
+
+    const positionDiffX = Math.abs(elmPosition.x - occupiedOffset.x);
+    const positionDiffY = Math.abs(elmPosition.y - occupiedOffset.y);
+
+    this.#draggedTransition.setAxes(positionDiffX, positionDiffY);
+    this.#elmTransition.setAxes(positionDiffX, positionDiffY);
+
+    const widthDiff = Math.abs(elmOffset.width - draggedRect.width);
+    const heightDiff = Math.abs(elmOffset.height - draggedRect.height);
+
+    // Then dragged and element transition already set.
+    if (widthDiff === 0 && heightDiff === 0) return;
+  }
+
+  /**
+   *
+   * @param position - Hight if the working axes is Y. Otherwise, it's width.
+   * @param space - Hight if the working axes is Y. Otherwise, it's width.
+   * @param axis - Axes(x or y).
+   * @returns
+   */
   #setDistanceIndicators(
     position: Difference,
     space: Difference,
@@ -93,35 +125,44 @@ class DistanceCalculator implements DistanceCalculatorInterface {
 
     if (offsetDiff === 0) return;
 
-    if (space.dragged < space.element) {
-      // console.log("elmHight is bigger");
-
-      if (direction === -1) {
-        // console.log("elm going up");
-
-        this.#draggedTransition[axis] += offsetDiff;
-        this.#draggedOffset[axis] = offsetDiff;
-      } else {
-        // console.log("elm going down");
-
-        this.#elmTransition[axis] -= offsetDiff;
-      }
-
-      return;
-    }
-
-    // console.log("elmHight is smaller");
+    const equalizer = space.dragged < space.element ? 1 : -1;
 
     if (direction === -1) {
-      // console.log("elm going up");
-
-      this.#draggedTransition[axis] -= offsetDiff;
-      this.#draggedOffset[axis] = -offsetDiff;
+      this.#draggedTransition[axis] += equalizer * offsetDiff;
+      this.#draggedOffset[axis] = equalizer * offsetDiff;
     } else {
-      // console.log("elm going down");
-
-      this.#elmTransition[axis] += offsetDiff;
+      this.#elmTransition[axis] += -1 * equalizer * offsetDiff;
     }
+
+    // if (space.dragged < space.element) {
+    //   // console.log("elmHight is bigger");
+
+    //   if (direction === -1) {
+    //     // console.log("elm going up");
+
+    //     this.#draggedTransition[axis] += offsetDiff;
+    //     this.#draggedOffset[axis] = offsetDiff;
+    //   } else {
+    //     // console.log("elm going down");
+
+    //     this.#elmTransition[axis] -= offsetDiff;
+    //   }
+
+    //   return;
+    // }
+
+    // // console.log("elmHight is smaller");
+
+    // if (direction === -1) {
+    //   // console.log("elm going up");
+
+    //   this.#draggedTransition[axis] -= offsetDiff;
+    //   this.#draggedOffset[axis] = -offsetDiff;
+    // } else {
+    //   // console.log("elm going down");
+
+    //   this.#elmTransition[axis] += offsetDiff;
+    // }
   }
 
   private calculateDistance(

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -312,9 +312,20 @@ class Droppable extends DistanceCalculator {
         if (isQualified) {
           isLast = true;
 
-          const { assignSyntheticPosition, migration } = this.draggable;
+          const { threshold, draggedElm, migration, occupiedPosition } =
+            this.draggable;
 
-          assignSyntheticPosition(migration.lastElmPosition);
+          /**
+           * Update threshold from here since there's no calling to updateElement.
+           */
+          threshold.setMainThreshold(draggedElm.id, {
+            width: draggedElm.offset.width,
+            height: draggedElm.offset.height,
+            left: migration.lastElmPosition.x,
+            top: migration.lastElmPosition.y,
+          });
+
+          occupiedPosition.clone(migration.lastElmPosition);
 
           break;
         }

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -235,8 +235,7 @@ class Droppable extends DistanceCalculator {
   #detectNearestContainer() {
     const {
       migration,
-      // occupiedPosition: occupiedOffset,
-      draggedElm: { depth },
+      draggedElm: { depth, offset: draggedOffset },
     } = this.draggable;
 
     let newSK;
@@ -261,27 +260,20 @@ class Droppable extends DistanceCalculator {
         originalSiblingList.pop();
 
         // Getting the last element of the new list.
-        // const lastElm = newSiblingList[newSiblingList.length - 1];
+        const lastElm = newSiblingList[newSiblingList.length - 1];
 
-        // const { offset: lastElmOffset, currentPosition: elmPosition } =
-        // store.registry[lastElm];
-
-        // this.draggable.occupiedPosition.setAxes(
-        //   currentPosition.x + this.#draggedOffset.x,
-        //   currentPosition.y + this.#draggedOffset.y
-        // );
+        const { currentPosition: elmPosition } = store.registry[lastElm];
 
         // Update the offset accumulation. It has the old offset from the
         // one but now it has migrated to the new container.
-        // occupiedOffset.setAxes(
-        //   elmPosition.x + draggedOffset.width,
-        //   elmPosition.y + draggedOffset.height
-        // );
-
-        // this.draggable.occupiedPosition.setAxes(
-        //   currentPosition.x + this.#draggedOffset.x,
-        //   currentPosition.y + this.#draggedOffset.y
-        // );
+        this.draggable.occupiedPosition.setAxes(
+          elmPosition.x +
+            draggedOffset.width +
+            migration.firstElmSyntheticSpace.x,
+          elmPosition.y +
+            draggedOffset.height +
+            migration.firstElmSyntheticSpace.y
+        );
 
         // Insert the element to the new list. Empty string because when dragged
         // is out the branch sets its index as "".
@@ -320,20 +312,9 @@ class Droppable extends DistanceCalculator {
         if (isQualified) {
           isLast = true;
 
-          const { migration, threshold, occupiedPosition, draggedElm } =
-            this.draggable;
+          const { assignSyntheticPosition, migration } = this.draggable;
 
-          /**
-           * Update threshold from here since there's no calling to updateElement.
-           */
-          threshold.setMainThreshold(draggedElm.id, {
-            width: draggedElm.offset.width,
-            height: draggedElm.offset.height,
-            left: migration.lastElmPosition.x,
-            top: migration.lastElmPosition.y,
-          });
-
-          occupiedPosition.clone(migration.lastElmPosition);
+          assignSyntheticPosition(migration.lastElmPosition);
 
           break;
         }

--- a/packages/dnd/src/Droppable/EndDroppable.ts
+++ b/packages/dnd/src/Droppable/EndDroppable.ts
@@ -151,7 +151,7 @@ class EndDroppable extends Droppable {
     const id = lst[0];
 
     if (id.length === 0 || this.draggable.draggedElm.id === id) {
-      return Math.floor(top) === Math.floor(this.draggable.occupiedOffset.y);
+      return Math.floor(top) === Math.floor(this.draggable.occupiedPosition.y);
     }
 
     const element = store.registry[id];

--- a/packages/utils/src/Migration/Migration.ts
+++ b/packages/utils/src/Migration/Migration.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
-import { IPointNum, PointNum } from "../Point";
+import { IPointAxes, IPointNum, PointNum } from "../Point";
 import type { IAbstract, IMigration } from "./types";
 
 class AbstractMigration implements IAbstract {
@@ -21,18 +21,17 @@ class Migration implements IMigration {
 
   lastElmPosition: IPointNum;
 
-  firstElmPosition: IPointNum;
+  firstElmSyntheticSpace!: IPointAxes;
 
   constructor(
     index: number,
     key: string,
-    firstElmPosition: IPointNum,
+    firstElmPosition: IPointAxes,
     lastElmPosition: IPointNum
   ) {
     this.#migrations = [new AbstractMigration(index, key)];
 
     this.lastElmPosition = new PointNum(0, 0);
-    this.firstElmPosition = new PointNum(0, 0);
 
     this.complete(firstElmPosition, lastElmPosition);
   }
@@ -59,9 +58,9 @@ class Migration implements IMigration {
     return true;
   }
 
-  complete(firstElmPosition: IPointNum, lastElmPosition: IPointNum) {
+  complete(firstElmPosition: IPointAxes, lastElmPosition: IPointNum) {
     this.isMigrationCompleted = true;
-    this.firstElmPosition.clone(firstElmPosition);
+    this.firstElmSyntheticSpace = { ...firstElmPosition };
     this.lastElmPosition.clone(lastElmPosition);
   }
 }

--- a/packages/utils/src/Migration/Migration.ts
+++ b/packages/utils/src/Migration/Migration.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
+import { IPointNum, PointNum } from "../Point";
 import type { IAbstract, IMigration } from "./types";
 
 class AbstractMigration implements IAbstract {
@@ -16,11 +17,24 @@ class AbstractMigration implements IAbstract {
 class Migration implements IMigration {
   #migrations: Array<IAbstract>;
 
-  isMigrationCompleted: boolean;
+  isMigrationCompleted!: boolean;
 
-  constructor(index: number, key: string) {
+  lastElmPosition: IPointNum;
+
+  firstElmPosition: IPointNum;
+
+  constructor(
+    index: number,
+    key: string,
+    firstElmPosition: IPointNum,
+    lastElmPosition: IPointNum
+  ) {
     this.#migrations = [new AbstractMigration(index, key)];
-    this.isMigrationCompleted = true;
+
+    this.lastElmPosition = new PointNum(0, 0);
+    this.firstElmPosition = new PointNum(0, 0);
+
+    this.complete(firstElmPosition, lastElmPosition);
   }
 
   latest() {
@@ -43,6 +57,12 @@ class Migration implements IMigration {
     this.isMigrationCompleted = false;
 
     return true;
+  }
+
+  complete(firstElmPosition: IPointNum, lastElmPosition: IPointNum) {
+    this.isMigrationCompleted = true;
+    this.firstElmPosition.clone(firstElmPosition);
+    this.lastElmPosition.clone(lastElmPosition);
   }
 }
 

--- a/packages/utils/src/Migration/types.ts
+++ b/packages/utils/src/Migration/types.ts
@@ -1,3 +1,5 @@
+import { IPointNum } from "../Point";
+
 export interface IAbstract {
   index: number;
 
@@ -7,6 +9,9 @@ export interface IAbstract {
 export interface IMigration {
   /** False when migration transformation not completed yet. */
   isMigrationCompleted: boolean;
+
+  lastElmPosition: IPointNum;
+  firstElmPosition: IPointNum;
 
   /** Get the latest migrations instance */
   latest(): IAbstract;
@@ -23,4 +28,6 @@ export interface IMigration {
    * returning to the same container.
    */
   add(index: number, key: string): boolean;
+
+  complete(firstElmPosition: IPointNum, lastElmPosition: IPointNum): void;
 }

--- a/packages/utils/src/Migration/types.ts
+++ b/packages/utils/src/Migration/types.ts
@@ -1,4 +1,4 @@
-import { IPointNum } from "../Point";
+import { IPointAxes, IPointNum } from "../Point";
 
 export interface IAbstract {
   index: number;
@@ -10,8 +10,18 @@ export interface IMigration {
   /** False when migration transformation not completed yet. */
   isMigrationCompleted: boolean;
 
+  /**
+   * The space between first element in the list and the second element.
+   * Usage: This space equalizer used to create new element when migration is
+   * completed.
+   */
+  firstElmSyntheticSpace: IPointAxes;
+
+  /**
+   * Preserve the last element position in the list .
+   * Usage: Getting this position when the dragged is going back from the tail.
+   */
   lastElmPosition: IPointNum;
-  firstElmPosition: IPointNum;
 
   /** Get the latest migrations instance */
   latest(): IAbstract;
@@ -29,5 +39,6 @@ export interface IMigration {
    */
   add(index: number, key: string): boolean;
 
+  /** Get the migration done  */
   complete(firstElmPosition: IPointNum, lastElmPosition: IPointNum): void;
 }


### PR DESCRIPTION
- [x] Create a new synthetic offset for each container to deal with element migration. Taking into consideration multiple heights and widths. So, the insertion offset always matches the migrated element.
- [x] Element preservation offset now lives in the migration instance, supposedly grouping all related movement in one instance for maintaining purpose. 
- [x] Refactor `setDistanceIndicators` calculations in one equation instead of if/else.
- [x] Refactor draggable motion instance to clear naming meeting the interface requirements created in recent releases. 