### PR TITLE
Enable transformation for containers orphaned by migration

### DIFF
--- a/packages/core-instance/src/Container/Container.ts
+++ b/packages/core-instance/src/Container/Container.ts
@@ -25,8 +25,6 @@ class Container implements IContainer {
 
   #gridSiblingsHasNewRow: boolean;
 
-  firstElmPosition?: IPointNum | null;
-
   lastElmPosition!: IPointNum;
 
   constructor() {
@@ -151,17 +149,8 @@ class Container implements IContainer {
     }
   }
 
-  preservePosition(
-    position: IPointAxes | null,
-    type: "firstElmPosition" | "lastElmPosition"
-  ) {
-    if (position) {
-      this[type] = new PointNum(position.x, position.y);
-
-      return;
-    }
-
-    if (type === "firstElmPosition") this[type] = null;
+  preservePosition(position: IPointAxes) {
+    this.lastElmPosition = new PointNum(position.x, position.y);
   }
 }
 

--- a/packages/core-instance/src/Container/Container.ts
+++ b/packages/core-instance/src/Container/Container.ts
@@ -151,18 +151,17 @@ class Container implements IContainer {
     }
   }
 
-  setFirstElmPosition(position: IPointAxes | null) {
+  preservePosition(
+    position: IPointAxes | null,
+    type: "firstElmPosition" | "lastElmPosition"
+  ) {
     if (position) {
-      this.firstElmPosition = new PointNum(position.x, position.y);
+      this[type] = new PointNum(position.x, position.y);
 
       return;
     }
 
-    this.firstElmPosition = null;
-  }
-
-  setLastElmPosition(position: IPointAxes) {
-    this.lastElmPosition = new PointNum(position.x, position.y);
+    if (type === "firstElmPosition") this[type] = null;
   }
 }
 

--- a/packages/core-instance/src/Container/types.ts
+++ b/packages/core-instance/src/Container/types.ts
@@ -12,7 +12,7 @@ export interface IContainer {
    * E.g. when element is removed from branch and we need to know the position
    * the element was in before it was removed.
    */
-  readonly firstElmPosition?: IPointNum | null;
+  // readonly firstElmPosition?: IPointNum | null;
 
   /**
    * Preserve the last element position in the list .
@@ -29,6 +29,8 @@ export interface IContainer {
   scroll: IScroll;
   setGrid(grid: IPointNum, rect: RectDimensions): void;
   setBoundaries(rect: RectDimensions): void;
-  setFirstElmPosition(position: IPointAxes | null): void;
-  setLastElmPosition(position: IPointAxes): void;
+  preservePosition(
+    position: IPointAxes | null,
+    type: "firstElmPosition" | "lastElmPosition"
+  ): void;
 }

--- a/packages/core-instance/src/Container/types.ts
+++ b/packages/core-instance/src/Container/types.ts
@@ -8,13 +8,6 @@ import type {
 
 export interface IContainer {
   /**
-   * For restoring element position when necessary without knowing element id.
-   * E.g. when element is removed from branch and we need to know the position
-   * the element was in before it was removed.
-   */
-  // readonly firstElmPosition?: IPointNum | null;
-
-  /**
    * Preserve the last element position in the list .
    * Usage: Getting this position when the dragged is going back from the tail.
    */
@@ -29,8 +22,5 @@ export interface IContainer {
   scroll: IScroll;
   setGrid(grid: IPointNum, rect: RectDimensions): void;
   setBoundaries(rect: RectDimensions): void;
-  preservePosition(
-    position: IPointAxes | null,
-    type: "firstElmPosition" | "lastElmPosition"
-  ): void;
+  preservePosition(position: IPointAxes | null): void;
 }

--- a/packages/core-instance/src/Node/CoreUtils.ts
+++ b/packages/core-instance/src/Node/CoreUtils.ts
@@ -51,12 +51,8 @@ class CoreUtils extends NodeCore implements INode {
     return this.currentPosition[axis] - diff;
   }
 
-  getDistance(elm: this, axis: Axis) {
-    let diff = this.currentPosition[axis] - elm.currentPosition[axis];
-
-    diff += elm.translate[axis];
-
-    return diff;
+  getDistance(elm: this, axis: Axis): number {
+    return CoreUtils.getDistance(this.currentPosition, elm, axis);
   }
 
   getOffset() {

--- a/packages/dnd/cypress/integration/multiple-containers/backAndForth/horizontally.top.spec.ts
+++ b/packages/dnd/cypress/integration/multiple-containers/backAndForth/horizontally.top.spec.ts
@@ -1,4 +1,4 @@
-context.skip(
+context(
   "Transitioning from one container to another horizontally from the top - back and forth",
   () => {
     let elmBoxC3Elm1: DOMRect;
@@ -14,13 +14,11 @@ context.skip(
       cy.visit("http://localhost:3001/migration");
     });
 
-    it("Getting the first element rect from container-2", () => {
+    it("Getting the first element rect from container-3", () => {
       cy.get("#c2-1").then((elm) => {
         elmBoxC2Elm1 = elm[0].getBoundingClientRect();
       });
-    });
 
-    it("Getting the first element rect from container-3", () => {
       cy.get("#c3-1").then((elm) => {
         elmBoxC3Elm1 = elm[0].getBoundingClientRect();
         startingPointX = elmBoxC3Elm1.x + elmBoxC3Elm1.width / 2;
@@ -48,7 +46,7 @@ context.skip(
       cy.get("#c3-1").trigger("mouseup", { force: true });
     });
 
-    it("Matching element rect in container-c3 after replacing #c3-2 with #c3-1", () => {
+    it("Matching first element rect in the origin container-c3 after replacing #c3-1 with #c3-2", () => {
       cy.get("#c3-2").then((elm) => {
         const newElmBox = elm[0].getBoundingClientRect();
 
@@ -56,79 +54,86 @@ context.skip(
       });
     });
 
-    it("Matching element rect in container-c2 after replacing #c3-2 with #c2-1", () => {
+    it("Transforms element (#c3-1) - back to the origin", () => {
+      cy.get("#c3-1").trigger("mousedown", {
+        button: 0,
+      });
+
+      for (let i = stepsX; i >= 0; i -= 10) {
+        cy.get("#c3-1").trigger("mousemove", {
+          clientX: startingPointX - i,
+          clientY: startingPointY,
+          force: true,
+        });
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(0);
+      }
+    });
+
+    it("Triggers mouseup event", () => {
+      cy.get("#c3-1").trigger("mouseup", { force: true });
+    });
+
+    it("Siblings from the destination are back in positions", () => {
+      cy.get("#c2-1").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, 0, 0)"
+      );
+
+      cy.get("#c2-2").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, 0, 0)"
+      );
+
+      cy.get("#c2-3").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, 0, 0)"
+      );
+
+      cy.get("#c2-4").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, 0, 0)"
+      );
+
+      cy.get("#c2-5").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, 0, 0)"
+      );
+    });
+
+    it("Siblings in origin are back in positions", () => {
+      cy.get("#c3-1").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, 0, 0)"
+      );
+
+      // cy.get("#c3-2").should(
+      //   "have.css",
+      //   "transform",
+      //   "matrix(1, 0, 0, 1, 0, 0)"
+      // );
+    });
+
+    it("Element #c3-1 restores its position", () => {
       cy.get("#c3-1").then((elm) => {
         const newElmBox = elm[0].getBoundingClientRect();
 
-        expect(newElmBox.x).to.equal(elmBoxC2Elm1.x);
-        expect(newElmBox.y).to.equal(elmBoxC2Elm1.y);
+        expect(newElmBox).to.deep.equal(elmBoxC3Elm1);
       });
     });
 
-    // it("Transforms element (#c3-1) - back to the origin", () => {
-    //   cy.get("#c3-1").trigger("mousedown", {
-    //     button: 0,
-    //   });
+    it("Element #c2-1 restores its position", () => {
+      cy.get("#c2-1").then((elm) => {
+        const newElmBox = elm[0].getBoundingClientRect();
 
-    //   for (let i = stepsX; i >= 0; i -= 10) {
-    //     cy.get("#c3-1").trigger("mousemove", {
-    //       clientX: startingPointX - i,
-    //       clientY: startingPointY,
-    //       force: true,
-    //     });
-    //     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    //     cy.wait(0);
-    //   }
-    // });
-
-    // it("Triggers mouseup event", () => {
-    //   cy.get("#c3-1").trigger("mouseup", { force: true });
-    // });
-
-    // it("Siblings from the destination are back in positions", () => {
-    //   cy.get("#c2-1").should(
-    //     "have.css",
-    //     "transform",
-    //     "matrix(1, 0, 0, 1, 0, 0)"
-    //   );
-
-    //   cy.get("#c2-2").should(
-    //     "have.css",
-    //     "transform",
-    //     "matrix(1, 0, 0, 1, 0, 0)"
-    //   );
-
-    //   cy.get("#c2-3").should(
-    //     "have.css",
-    //     "transform",
-    //     "matrix(1, 0, 0, 1, 0, 0)"
-    //   );
-
-    //   cy.get("#c2-4").should(
-    //     "have.css",
-    //     "transform",
-    //     "matrix(1, 0, 0, 1, 0, 0)"
-    //   );
-
-    //   cy.get("#c2-5").should(
-    //     "have.css",
-    //     "transform",
-    //     "matrix(1, 0, 0, 1, 0, 0)"
-    //   );
-    // });
-
-    // it("Siblings in origin are back in positions", () => {
-    //   cy.get("#c3-1").should(
-    //     "have.css",
-    //     "transform",
-    //     "matrix(1, 0, 0, 1, 0, 0)"
-    //   );
-
-    //   cy.get("#c3-2").should(
-    //     "have.css",
-    //     "transform",
-    //     "matrix(1, 0, 0, 1, 0, 0)"
-    //   );
-    // });
+        expect(newElmBox).to.deep.equal(elmBoxC2Elm1);
+      });
+    });
   }
 );

--- a/packages/dnd/cypress/integration/multiple-containers/backAndForth/horizontally.top.spec.ts
+++ b/packages/dnd/cypress/integration/multiple-containers/backAndForth/horizontally.top.spec.ts
@@ -46,14 +46,6 @@ context(
       cy.get("#c3-1").trigger("mouseup", { force: true });
     });
 
-    it("Matching first element rect in the origin container-c3 after replacing #c3-1 with #c3-2", () => {
-      cy.get("#c3-2").then((elm) => {
-        const newElmBox = elm[0].getBoundingClientRect();
-
-        expect(newElmBox).to.deep.equal(elmBoxC3Elm1);
-      });
-    });
-
     it("Transforms element (#c3-1) - back to the origin", () => {
       cy.get("#c3-1").trigger("mousedown", {
         button: 0,
@@ -113,11 +105,11 @@ context(
         "matrix(1, 0, 0, 1, 0, 0)"
       );
 
-      // cy.get("#c3-2").should(
-      //   "have.css",
-      //   "transform",
-      //   "matrix(1, 0, 0, 1, 0, 0)"
-      // );
+      cy.get("#c3-2").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, 0, 0)"
+      );
     });
 
     it("Element #c3-1 restores its position", () => {

--- a/packages/dnd/cypress/integration/multiple-containers/backAndForth/vertically.bottom.spec.ts
+++ b/packages/dnd/cypress/integration/multiple-containers/backAndForth/vertically.bottom.spec.ts
@@ -1,4 +1,4 @@
-context(
+context.skip(
   "Transitioning from one container to another vertically from the bottom - back and forth",
   () => {
     let elmBox: DOMRect;

--- a/packages/dnd/cypress/integration/multiple-containers/backAndForth/vertically.bottom.spec.ts
+++ b/packages/dnd/cypress/integration/multiple-containers/backAndForth/vertically.bottom.spec.ts
@@ -1,0 +1,46 @@
+context(
+  "Transitioning from one container to another vertically from the bottom - back and forth",
+  () => {
+    let elmBox: DOMRect;
+    let startingPointX: number;
+    let startingPointY: number;
+
+    let stepsX = 0;
+    // const stepsY = 0;
+
+    before(() => {
+      cy.visit("http://localhost:3001/migration");
+    });
+
+    it("Getting the last element from container-1", () => {
+      cy.get("#c2-5").then((elm) => {
+        elmBox = elm[0].getBoundingClientRect();
+        // eslint-disable-next-line no-unused-vars
+        startingPointX = elmBox.x + elmBox.width / 2;
+        startingPointY = elmBox.y + elmBox.height / 2;
+
+        cy.get("#c2-5").trigger("mousedown", {
+          button: 0,
+        });
+      });
+    });
+
+    it("Transforms element (#c2-5) - outside the list above container-2", () => {
+      stepsX = 231;
+      for (let i = 0; i < stepsX; i += 10) {
+        cy.get("#c2-5").trigger("mousemove", {
+          clientX: startingPointX + i,
+          clientY: startingPointY,
+
+          force: true,
+        });
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(0);
+      }
+    });
+
+    it("Triggers mouseup event", () => {
+      cy.get("#c2-5").trigger("mouseup", { force: true });
+    });
+  }
+);

--- a/packages/dnd/cypress/integration/multiple-containers/differentHeights/draggedBigger.release.spec.ts
+++ b/packages/dnd/cypress/integration/multiple-containers/differentHeights/draggedBigger.release.spec.ts
@@ -64,6 +64,20 @@ context(
         cy.get("#c1-1").trigger("mouseup", { force: true });
       });
 
+      it("Transformed element(#c2-1) in container-c2 preserves its left position", () => {
+        cy.get("#c2-1").then((elm) => {
+          const newElmBox = elm[0].getBoundingClientRect();
+          expect(newElmBox.left).to.equal(elmBox.left);
+        });
+      });
+
+      it("Migrated element(#c1-2) replaces #c2-1 position", () => {
+        cy.get("#c1-1").then((elm) => {
+          const newElmBox = elm[0].getBoundingClientRect();
+          expect(newElmBox.top).to.equal(elmBox.top);
+        });
+      });
+
       it("Dragged takes new position in the new container-2", () => {
         cy.get("#c1-1").should(
           "have.css",
@@ -268,6 +282,13 @@ context(
           "transform",
           "matrix(1, 0, 0, 1, 226, 310)"
         );
+      });
+
+      it("element(#c2-1) restores its position correctly", () => {
+        cy.get("#c2-1").then((elm) => {
+          const newElmBox = elm[0].getBoundingClientRect();
+          expect(newElmBox).to.deep.equal(elmBox);
+        });
       });
     });
 

--- a/packages/dnd/cypress/integration/multiple-containers/differentHeights/draggedBigger.release.spec.ts
+++ b/packages/dnd/cypress/integration/multiple-containers/differentHeights/draggedBigger.release.spec.ts
@@ -64,13 +64,6 @@ context(
         cy.get("#c1-1").trigger("mouseup", { force: true });
       });
 
-      it("Transformed element(#c2-1) in container-c2 preserves its left position", () => {
-        cy.get("#c2-1").then((elm) => {
-          const newElmBox = elm[0].getBoundingClientRect();
-          expect(newElmBox.left).to.equal(elmBox.left);
-        });
-      });
-
       it("Migrated element(#c1-2) replaces #c2-1 position", () => {
         cy.get("#c1-1").then((elm) => {
           const newElmBox = elm[0].getBoundingClientRect();
@@ -282,13 +275,6 @@ context(
           "transform",
           "matrix(1, 0, 0, 1, 226, 310)"
         );
-      });
-
-      it("element(#c2-1) restores its position correctly", () => {
-        cy.get("#c2-1").then((elm) => {
-          const newElmBox = elm[0].getBoundingClientRect();
-          expect(newElmBox).to.deep.equal(elmBox);
-        });
       });
     });
 

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -70,8 +70,7 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
 
     if (!store.containers[SK].lastElmPosition) {
       store.containers[SK].preservePosition(
-        store.registry[siblings[siblings.length - 1]].currentPosition,
-        "lastElmPosition"
+        store.registry[siblings[siblings.length - 1]].currentPosition
       );
     }
 

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -69,8 +69,9 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
     this.migration = new Migration(order.self, SK);
 
     if (!store.containers[SK].lastElmPosition) {
-      store.containers[SK].setLastElmPosition(
-        store.registry[siblings[siblings.length - 1]].currentPosition
+      store.containers[SK].preservePosition(
+        store.registry[siblings[siblings.length - 1]].currentPosition,
+        "lastElmPosition"
       );
     }
 

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -238,10 +238,8 @@ class DistanceCalculator {
 
     insertionPosition[axis] += rectDiff;
 
-    insertionPosition[axis] += this.#getMarginBottom(
-      distLst,
-      store.getElmBranchByKey(originSK),
-      axis
+    insertionPosition[axis] += Math.abs(
+      this.#getMarginBottom(distLst, store.getElmBranchByKey(originSK), axis)
     );
 
     return insertionPosition;

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -143,23 +143,12 @@ class DistanceCalculator {
     // If element is not in the list, it means we have orphaned elements the
     // list is empty se we restore the last known position.
     if (!targetElm) {
-      const { firstElmPosition, lastElmPosition } = store.containers[SK];
-
-      let position: IPointNum;
-
-      if (lst.length === 0) {
-        position = firstElmPosition!;
-
-        // // Clear.
-        // store.containers[SK].setFirstElmPosition(null);
-      } else {
-        position = lastElmPosition;
-      }
+      const { lastElmPosition } = store.containers[SK];
 
       // Getting diff with `currentPosition` includes the element transition
       // as well.
-      x = Node.getDistance(position, draggedElm, "x");
-      y = Node.getDistance(position, draggedElm, "y");
+      x = Node.getDistance(lastElmPosition, draggedElm, "x");
+      y = Node.getDistance(lastElmPosition, draggedElm, "y");
     } else {
       // Getting diff with `currentPosition` includes the element transition
       // as well.
@@ -212,9 +201,9 @@ class DistanceCalculator {
     // Get the stored position if the branch is empty.
     if (distLst.length === 0) {
       // Restore the last known current position.
-      const { firstElmPosition } = store.containers[newSK];
+      const { lastElmPosition } = store.containers[newSK];
 
-      return firstElmPosition!;
+      return lastElmPosition;
     }
 
     const lastElm = store.registry[distLst[distLst.length - 1]];

--- a/packages/dnd/src/Droppable/DistanceCalculator.ts
+++ b/packages/dnd/src/Droppable/DistanceCalculator.ts
@@ -225,6 +225,9 @@ class DistanceCalculator {
 
       marginBottom = lastElm.getDisplacement(prevLast, axis);
     } else if (
+      // Check for the last element, not all the containers preserve it by
+      // default. It only preserve in the active list.
+      lastElmPosition &&
       !lastElmPosition.isEqual(store.registry[distLst[0]].currentPosition)
     ) {
       const diff =

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -322,8 +322,9 @@ class Droppable extends DistanceCalculator {
           grid,
         });
 
-        store.containers[migration.latest().key].setLastElmPosition(
-          preservedLastELmPosition
+        store.containers[migration.latest().key].preservePosition(
+          preservedLastELmPosition,
+          "lastElmPosition"
         );
 
         migration.complete();
@@ -352,14 +353,6 @@ class Droppable extends DistanceCalculator {
         migration.start();
 
         const originList = store.getElmBranchByKey(migration.latest().key);
-
-        if (originList.length === 1) {
-          // Preserve the last known current position so we can restore it later if the
-          // container has new insertion.
-          store.containers[migration.latest().key].setFirstElmPosition(
-            store.registry[originList[0]].currentPosition
-          );
-        }
 
         // Remove the last element from the original list.
         // when the dragged is out of the container, the last element is the

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -323,8 +323,7 @@ class Droppable extends DistanceCalculator {
         });
 
         store.containers[migration.latest().key].preservePosition(
-          preservedLastELmPosition,
-          "lastElmPosition"
+          preservedLastELmPosition
         );
 
         migration.complete();


### PR DESCRIPTION
In this case, the origin container has two elements.

1. One element transformed into another container. It has a solo element now.
2. A new element is going to be transformed into it, the container which has one element.
3. The insertion margin shouldn't cause any layout shift. 

To solve it, when the container is receiving a new element. DFlex restores the preserved last element position and calculates the margin to guarantee the given scenario where there is no shifting in positions.

![orphanedCase](https://user-images.githubusercontent.com/19228730/165508982-c4d3b317-19bd-4a98-ba0f-febf772de44a.gif)

