### PR TITLE
Create depth threshold for element(s) transformation between containers

### DIFF
--- a/packages/core-instance/src/Container/Container.ts
+++ b/packages/core-instance/src/Container/Container.ts
@@ -1,4 +1,4 @@
-import { PointNum } from "@dflex/utils";
+import { PointNum, dirtyAssignBiggestRect } from "@dflex/utils";
 
 import type {
   IScroll,
@@ -109,13 +109,15 @@ class Container implements IContainer {
     const right = left + width;
     const bottom = top + height;
 
+    const elmRectBoundaries = {
+      top,
+      left,
+      right,
+      bottom,
+    };
+
     if (!this.boundaries) {
-      this.boundaries = {
-        top,
-        left,
-        right,
-        bottom,
-      };
+      this.boundaries = elmRectBoundaries;
 
       return;
     }
@@ -132,21 +134,7 @@ class Container implements IContainer {
       this.#gridContainer.x += 1;
     }
 
-    if (left < $.left) {
-      $.left = left;
-    }
-
-    if (top < $.top) {
-      $.top = top;
-    }
-
-    if (right > $.right) {
-      $.right = right;
-    }
-
-    if (bottom > $.bottom) {
-      $.bottom = bottom;
-    }
+    dirtyAssignBiggestRect($, elmRectBoundaries);
   }
 
   preservePosition(position: IPointAxes) {

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -284,19 +284,6 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
     return isLoose ? isV || isH : isV && isH;
   }
 
-  isInThreshold(SK: string) {
-    const {
-      offset: { height, width },
-    } = this.draggedElm;
-
-    const { x, y } = this.positionPlaceholder;
-
-    return (
-      !this.threshold.isOutThresholdV(SK, y, y + height) ||
-      !this.threshold.isOutThresholdH(SK, x, x + width)
-    );
-  }
-
   #isLeavingFromTail() {
     const lastElm =
       (store.getElmBranchByKey(this.migration.latest().key) as string[])

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -268,7 +268,7 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
     );
   }
 
-  isOutThreshold(SK?: string) {
+  isOutThreshold(SK?: string, isLoose = true) {
     const {
       id,
       offset: { height, width },
@@ -278,9 +278,22 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
 
     const key = SK || id;
 
+    const isV = this.threshold.isOutThresholdV(key, y, y + height);
+    const isH = this.threshold.isOutThresholdH(key, x, x + width);
+
+    return isLoose ? isV || isH : isV && isH;
+  }
+
+  isInThreshold(SK: string) {
+    const {
+      offset: { height, width },
+    } = this.draggedElm;
+
+    const { x, y } = this.positionPlaceholder;
+
     return (
-      this.threshold.isOutThresholdV(key, y, y + height) ||
-      this.threshold.isOutThresholdH(key, x, x + width)
+      !this.threshold.isOutThresholdV(SK, y, y + height) ||
+      !this.threshold.isOutThresholdH(SK, x, x + width)
     );
   }
 

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -96,7 +96,7 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
         }
       }
 
-      this.threshold.setContainerThreshold(key, boundaries);
+      this.threshold.setContainerThreshold(key, depth, boundaries);
     });
 
     this.isMovingAwayFrom = new PointBool(false, false);

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -281,7 +281,7 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
     const isV = this.threshold.isOutThresholdV(key, y, y + height);
     const isH = this.threshold.isOutThresholdH(key, x, x + width);
 
-    return isLoose ? isV || isH : isV && isH;
+    return isLoose ? isV || isH : (isV && !isH) || (isH && !isV);
   }
 
   #isLeavingFromTail() {

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -59,7 +59,8 @@ export interface IDraggableAxes extends IAbstractDraggable<INode> {
    * Check if the dragged out self position or parent container and set the
    * necessary flags.
    */
-  isOutThreshold(siblingsK?: string): boolean;
+  isOutThreshold(SK: string, isLoose: boolean): boolean;
+  isOutThreshold(SK?: never, isLoose?: never): boolean;
 
   /** Has moved without settling inside new position. */
   isNotSettled(): boolean;

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -334,9 +334,11 @@ class Droppable extends DistanceCalculator {
   #detectNearestContainer() {
     const { migration, draggedElm } = this.draggable;
 
+    const { depth } = draggedElm;
+
     let newSK;
 
-    const dp = store.getBranchesByDepth(draggedElm.depth);
+    const dp = store.getBranchesByDepth(depth);
 
     for (let i = 0; i < dp.length; i += 1) {
       newSK = dp[i];

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -343,9 +343,10 @@ class Droppable extends DistanceCalculator {
     for (let i = 0; i < dp.length; i += 1) {
       newSK = dp[i];
 
-      const isOut = this.draggable.isOutThreshold(newSK, false);
-
-      if (newSK !== migration.latest().key && !isOut) {
+      if (
+        newSK !== migration.latest().key &&
+        !this.draggable.isOutThreshold(newSK, false)
+      ) {
         migration.start();
 
         const originList = store.getElmBranchByKey(migration.latest().key);

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -343,7 +343,7 @@ class Droppable extends DistanceCalculator {
     for (let i = 0; i < dp.length; i += 1) {
       newSK = dp[i];
 
-      const isOut = this.draggable.isOutThreshold(newSK);
+      const isOut = this.draggable.isOutThreshold(newSK, false);
 
       if (!isOut) {
         // Coming back to the same container.
@@ -724,7 +724,8 @@ class Droppable extends DistanceCalculator {
       this.draggable.draggedElm.rmDateset("draggedOutPosition");
 
       isOutSiblingsContainer = this.draggable.isOutThreshold(
-        this.draggable.migration.latest().key
+        this.draggable.migration.latest().key,
+        true
       );
 
       // when it's out, and on of theses is true then it's happening.
@@ -772,7 +773,8 @@ class Droppable extends DistanceCalculator {
      */
     if (this.isParentLocked) {
       isOutSiblingsContainer = this.draggable.isOutThreshold(
-        this.draggable.migration.latest().key
+        this.draggable.migration.latest().key,
+        true
       );
 
       if (isOutSiblingsContainer) {

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -345,12 +345,7 @@ class Droppable extends DistanceCalculator {
 
       const isOut = this.draggable.isOutThreshold(newSK, false);
 
-      if (!isOut) {
-        // Coming back to the same container.
-        if (newSK === migration.latest().key) {
-          return;
-        }
-
+      if (newSK !== migration.latest().key && !isOut) {
         migration.start();
 
         const originList = store.getElmBranchByKey(migration.latest().key);

--- a/packages/utils/src/Threshold/Threshold.ts
+++ b/packages/utils/src/Threshold/Threshold.ts
@@ -10,6 +10,7 @@ import type {
   ThresholdsStore,
   LayoutPositionStatus,
 } from "./types";
+import { dirtyAssignBiggestRect } from "../collections";
 
 class Threshold implements ThresholdInterface {
   thresholds: ThresholdsStore;
@@ -95,9 +96,28 @@ class Threshold implements ThresholdInterface {
     this.#initIndicators(key);
   }
 
-  setContainerThreshold(key: string, rect: RectBoundaries) {
+  #addDepthThreshold(key: string, depth: number) {
+    const dp = `${depth}`;
+
+    if (!this.thresholds[dp]) {
+      this.thresholds[dp] = {
+        ...this.thresholds[key],
+      };
+
+      this.#initIndicators(dp);
+    }
+
+    const $ = this.thresholds[depth];
+
+    dirtyAssignBiggestRect($, this.thresholds[key]);
+  }
+
+  setContainerThreshold(key: string, depth: number, rect: RectBoundaries) {
     this.thresholds[key] = this.#getThreshold(rect);
+
     this.#initIndicators(key);
+
+    this.#addDepthThreshold(key, depth);
   }
 
   isOutThresholdH(key: string, XLeft: number, XRight: number) {

--- a/packages/utils/src/Threshold/types.ts
+++ b/packages/utils/src/Threshold/types.ts
@@ -33,7 +33,7 @@ export interface ThresholdInterface {
   thresholds: ThresholdsStore;
   isOut: LayoutPositionStatus;
   setMainThreshold(id: string, rect: RectDimensions): void;
-  setContainerThreshold(key: string, rect: RectBoundaries): void;
+  setContainerThreshold(key: string, depth: number, rect: RectBoundaries): void;
   setScrollThreshold(key: string, rect: RectDimensions): void;
   isOutThresholdH(key: string, XLeft: number, XRight: number): boolean;
   isOutThresholdV(key: string, YTop: number, YBottom: number): boolean;

--- a/packages/utils/src/collections/assignBiggestRect.ts
+++ b/packages/utils/src/collections/assignBiggestRect.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-param-reassign */
+import { RectBoundaries } from "../types";
+
+function dirtyAssignBiggestRect($: RectBoundaries, elm: RectBoundaries) {
+  const { top, left, right, bottom } = elm;
+
+  if (left < $.left) {
+    $.left = left;
+  }
+
+  if (top < $.top) {
+    $.top = top;
+  }
+
+  if (right > $.right) {
+    $.right = right;
+  }
+
+  if (bottom > $.bottom) {
+    $.bottom = bottom;
+  }
+}
+
+export default dirtyAssignBiggestRect;

--- a/packages/utils/src/collections/assignBiggestRect.ts
+++ b/packages/utils/src/collections/assignBiggestRect.ts
@@ -1,6 +1,10 @@
 /* eslint-disable no-param-reassign */
 import { RectBoundaries } from "../types";
 
+/**
+ * Mutate the rect boundaries object to biggest rectangle if it is bigger than
+ * the current one.
+ */
 function dirtyAssignBiggestRect($: RectBoundaries, elm: RectBoundaries) {
   const { top, left, right, bottom } = elm;
 

--- a/packages/utils/src/collections/index.ts
+++ b/packages/utils/src/collections/index.ts
@@ -1,2 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as canUseDOM } from "./canUseDOM";
+export { default as dirtyAssignBiggestRect } from "./assignBiggestRect";

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -25,4 +25,4 @@ export type {
 export { Scroll } from "./Scroll";
 export type { IScroll } from "./Scroll";
 
-export { canUseDOM } from "./collections";
+export { canUseDOM, dirtyAssignBiggestRect } from "./collections";


### PR DESCRIPTION
One of the calculations DFlex has is defining a threshold for each layout (#418).  Threshold tells the transformers when dragged is in/out its position or the container strict boundaries.  This strict definition of threshold helps to improve user experience and the physical sense of elements' interactivity. It also plays role in detecting the active container when an element migrates from one to another. This definition prevents the transformation from a container having bigger height/width into another container having smaller boundaries. When leaving the position and entering a new one the transformer can't tell if the element is inside the less-boundaries container or not.  To tackle this issue each depth must have a unified transforming boundary.  So when the element is dragged at the same level horizontally or vertically it can be settled into the destination container and attached to the bottom which has the highest weight. 

This feature should allow `elm-5` to transform into the bottom of `container-3`:

![noSettled](https://user-images.githubusercontent.com/19228730/165713248-ceaa6858-7b03-4dd2-bd58-2beaf294b714.gif)
 