### PR TITLE
Add a unified container dimensions for each layout belongs to the same depth

### DIFF
--- a/packages/core-instance/src/Container/Container.ts
+++ b/packages/core-instance/src/Container/Container.ts
@@ -1,6 +1,8 @@
+/* eslint-disable no-param-reassign */
 import { PointNum, dirtyAssignBiggestRect } from "@dflex/utils";
 
 import type {
+  Dimensions,
   IScroll,
   IPointNum,
   IPointAxes,
@@ -103,7 +105,7 @@ class Container implements IContainer {
     }
   }
 
-  setBoundaries(rect: RectDimensions) {
+  setBoundaries(rect: RectDimensions, unifiedContainerDimensions: Dimensions) {
     const { height, left, top, width } = rect;
 
     const right = left + width;
@@ -135,6 +137,19 @@ class Container implements IContainer {
     }
 
     dirtyAssignBiggestRect($, elmRectBoundaries);
+
+    const uni = unifiedContainerDimensions;
+
+    const $height = $.bottom - $.top;
+    const $width = $.right - $.left;
+
+    if (uni.height < $height) {
+      uni.height = $height;
+    }
+
+    if (uni.width < $width) {
+      uni.width = $height;
+    }
   }
 
   preservePosition(position: IPointAxes) {

--- a/packages/core-instance/src/Container/types.ts
+++ b/packages/core-instance/src/Container/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Dimensions,
   RectBoundaries,
   RectDimensions,
   IPointNum,
@@ -21,6 +22,9 @@ export interface IContainer {
   /** Container scroll instance.  */
   scroll: IScroll;
   setGrid(grid: IPointNum, rect: RectDimensions): void;
-  setBoundaries(rect: RectDimensions): void;
+  setBoundaries(
+    rect: RectDimensions,
+    unifiedContainerDimensions: Dimensions
+  ): void;
   preservePosition(position: IPointAxes | null): void;
 }

--- a/packages/dnd/src/DnDStore/types.ts
+++ b/packages/dnd/src/DnDStore/types.ts
@@ -1,4 +1,9 @@
-import type { RectDimensions, ITracker, IPointNum } from "@dflex/utils";
+import type {
+  Dimensions,
+  RectDimensions,
+  ITracker,
+  IPointNum,
+} from "@dflex/utils";
 import type { INode, IContainer } from "@dflex/core-instance";
 import type { RegisterInputMeta } from "@dflex/store";
 
@@ -53,7 +58,10 @@ interface Translate {
 }
 
 export interface IDnDStore {
-  readonly containers: { [siblingKey: string]: IContainer };
+  readonly containers: { [SK: string]: IContainer };
+  readonly unifiedContainerDimensions: {
+    [depth: number]: Dimensions;
+  };
   readonly tracker: ITracker;
   readonly layoutState: LayoutState;
   initSiblingContainer(SK: string, shouldValidate: boolean): void;
@@ -61,6 +69,7 @@ export interface IDnDStore {
   handleElmMigration(
     newSK: string,
     oldSK: string,
+    depth: number,
     append: {
       offset: RectDimensions;
       grid: IPointNum;

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -292,7 +292,6 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
 
     if (useInsertionThreshold) {
       key = combineKeys(depth, key);
-      console.log("file: DraggableAxes.ts ~ line 295 ~ key", key);
     }
 
     return (

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -1,6 +1,12 @@
 import { AbstractDraggable } from "@dflex/draggable";
 
-import { Threshold, PointNum, PointBool, Migration } from "@dflex/utils";
+import {
+  Threshold,
+  PointNum,
+  PointBool,
+  Migration,
+  combineKeys,
+} from "@dflex/utils";
 import type {
   ThresholdInterface,
   IPointNum,
@@ -96,7 +102,12 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
         }
       }
 
-      this.threshold.setContainerThreshold(key, depth, boundaries);
+      this.threshold.setContainerThreshold(
+        key,
+        depth,
+        boundaries,
+        store.unifiedContainerDimensions[depth]
+      );
     });
 
     this.isMovingAwayFrom = new PointBool(false, false);
@@ -268,15 +279,21 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
     );
   }
 
-  isOutThreshold(SK?: string) {
+  isOutThreshold(SK?: string, useInsertionThreshold?: boolean) {
     const {
       id,
+      depth,
       offset: { height, width },
     } = this.draggedElm;
 
     const { x, y } = this.positionPlaceholder;
 
-    const key = SK || id;
+    let key = SK || id;
+
+    if (useInsertionThreshold) {
+      key = combineKeys(depth, key);
+      console.log("file: DraggableAxes.ts ~ line 295 ~ key", key);
+    }
 
     return (
       this.threshold.isOutThresholdV(key, y, y + height) ||

--- a/packages/dnd/src/Draggable/types.ts
+++ b/packages/dnd/src/Draggable/types.ts
@@ -59,7 +59,8 @@ export interface IDraggableAxes extends IAbstractDraggable<INode> {
    * Check if the dragged out self position or parent container and set the
    * necessary flags.
    */
-  isOutThreshold(siblingsK?: string): boolean;
+  isOutThreshold(SK?: string): boolean;
+  isOutThreshold(SK: string, useInsertionThreshold: true): boolean;
 
   /** Has moved without settling inside new position. */
   isNotSettled(): boolean;

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -352,13 +352,8 @@ class Droppable extends DistanceCalculator {
     const { key: originSK } = migration.latest();
 
     for (let i = 0; i < dp.length; i += 1) {
-      newSK = dp[0];
+      newSK = dp[i];
 
-      console.log(
-        "file: Droppable.ts ~ line 354 ~ this.draggable.isOutThreshold",
-        !this.draggable.isOutThreshold(newSK, true),
-        newSK
-      );
       // Check if it is not the same list and if the dragged is inside new one.
       if (newSK !== originSK && !this.draggable.isOutThreshold(newSK, true)) {
         migration.start();

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -226,7 +226,9 @@ class Droppable extends DistanceCalculator {
       gridPlaceholder,
     } = this.draggable;
 
-    const siblings = store.getElmBranchByKey(migration.latest().key);
+    const { key: SK } = migration.latest();
+
+    const siblings = store.getElmBranchByKey(SK);
 
     /**
      * If tempIndex is zero, the dragged is coming from the top. So, move them
@@ -242,7 +244,7 @@ class Droppable extends DistanceCalculator {
     // Enforce attaching it from the bottom since it's already inside the container.
     if (typeof insertAt !== "number") {
       // Restore the last element position from the bottom.
-      const { lastElmPosition } = store.containers[migration.latest().key];
+      const { lastElmPosition } = store.containers[SK];
 
       this.updateDraggedThresholdPosition(lastElmPosition.x, lastElmPosition.y);
 
@@ -258,10 +260,7 @@ class Droppable extends DistanceCalculator {
     let draggedTransition: IPointAxes;
 
     if (migration.isTransitioning) {
-      draggedTransition = this.getInsertionOccupiedTranslate(
-        insertAt!,
-        migration.latest().key
-      );
+      draggedTransition = this.getInsertionOccupiedTranslate(insertAt!, SK);
     }
 
     // If it has solo empty id then there's no need to move down. Because it's
@@ -300,7 +299,7 @@ class Droppable extends DistanceCalculator {
 
           preservedLastELmPosition = occupiedPosition;
         } else {
-          const activeList = store.getElmBranchByKey(migration.latest().key);
+          const activeList = store.getElmBranchByKey(SK);
 
           const lastElm = Droppable.getTheLastValidElm(
             activeList,
@@ -317,19 +316,12 @@ class Droppable extends DistanceCalculator {
 
         occupiedTranslate.clone(draggedTransition);
 
-        store.handleElmMigration(
-          migration.latest().key,
-          migration.prev().key,
-          0,
-          {
-            offset,
-            grid,
-          }
-        );
+        store.handleElmMigration(SK, migration.prev().key, draggedElm.depth, {
+          offset,
+          grid,
+        });
 
-        store.containers[migration.latest().key].preservePosition(
-          preservedLastELmPosition
-        );
+        store.containers[SK].preservePosition(preservedLastELmPosition);
 
         migration.complete();
       });

--- a/packages/dnd/src/Droppable/Droppable.ts
+++ b/packages/dnd/src/Droppable/Droppable.ts
@@ -317,10 +317,15 @@ class Droppable extends DistanceCalculator {
 
         occupiedTranslate.clone(draggedTransition);
 
-        store.handleElmMigration(migration.latest().key, migration.prev().key, {
-          offset,
-          grid,
-        });
+        store.handleElmMigration(
+          migration.latest().key,
+          migration.prev().key,
+          0,
+          {
+            offset,
+            grid,
+          }
+        );
 
         store.containers[migration.latest().key].preservePosition(
           preservedLastELmPosition
@@ -347,10 +352,15 @@ class Droppable extends DistanceCalculator {
     const { key: originSK } = migration.latest();
 
     for (let i = 0; i < dp.length; i += 1) {
-      newSK = dp[i];
+      newSK = dp[0];
 
+      console.log(
+        "file: Droppable.ts ~ line 354 ~ this.draggable.isOutThreshold",
+        !this.draggable.isOutThreshold(newSK, true),
+        newSK
+      );
       // Check if it is not the same list and if the dragged is inside new one.
-      if (newSK !== originSK && !this.draggable.isOutThreshold(newSK)) {
+      if (newSK !== originSK && !this.draggable.isOutThreshold(newSK, true)) {
         migration.start();
 
         const originList = store.getElmBranchByKey(originSK);

--- a/packages/utils/src/Threshold/Threshold.ts
+++ b/packages/utils/src/Threshold/Threshold.ts
@@ -81,30 +81,34 @@ class Threshold implements ThresholdInterface {
     };
   }
 
+  /** Assign threshold property and create new instance for is out indicators */
+  #createThreshold(key: string, rect: RectBoundaries) {
+    this.thresholds[key] = this.#getThreshold(rect);
+    this.#initIndicators(key);
+  }
+
   setMainThreshold(key: string, rect: RectDimensions) {
     this.#setPixels(rect);
 
     const { top, left, height, width } = rect;
 
-    this.thresholds[key] = this.#getThreshold({
+    this.#createThreshold(key, {
       top,
       left,
       bottom: top + height,
       right: left + width,
     });
-
-    this.#initIndicators(key);
   }
 
   #addDepthThreshold(key: string, depth: number) {
     const dp = `${depth}`;
 
     if (!this.thresholds[dp]) {
-      this.thresholds[dp] = {
+      this.#createThreshold(dp, {
         ...this.thresholds[key],
-      };
+      });
 
-      this.#initIndicators(dp);
+      return;
     }
 
     const $ = this.thresholds[depth];
@@ -118,21 +122,20 @@ class Threshold implements ThresholdInterface {
     rect: RectBoundaries,
     unifiedContainerDimensions: Dimensions
   ) {
-    this.thresholds[key] = this.#getThreshold(rect);
-    this.#initIndicators(key);
+    this.#createThreshold(key, rect);
 
     queueMicrotask(() => {
       const { top, left } = rect;
       const { height, width } = unifiedContainerDimensions;
 
       const composedK = combineKeys(depth, key);
-      this.thresholds[composedK] = this.#getThreshold({
+
+      this.#createThreshold(composedK, {
         left,
         top,
         right: left + width,
         bottom: top + height,
       });
-      this.#initIndicators(composedK);
 
       this.#addDepthThreshold(key, depth);
     });

--- a/packages/utils/src/Threshold/types.ts
+++ b/packages/utils/src/Threshold/types.ts
@@ -1,4 +1,4 @@
-import type { RectBoundaries, RectDimensions } from "../types";
+import type { Dimensions, RectBoundaries, RectDimensions } from "../types";
 import FourDirectionsBool from "./FourDirectionsBool";
 
 export interface ThresholdPercentages {
@@ -33,7 +33,12 @@ export interface ThresholdInterface {
   thresholds: ThresholdsStore;
   isOut: LayoutPositionStatus;
   setMainThreshold(id: string, rect: RectDimensions): void;
-  setContainerThreshold(key: string, depth: number, rect: RectBoundaries): void;
+  setContainerThreshold(
+    key: string,
+    depth: number,
+    rect: RectBoundaries,
+    unifiedContainerDimensions: Dimensions
+  ): void;
   setScrollThreshold(key: string, rect: RectDimensions): void;
   isOutThresholdH(key: string, XLeft: number, XRight: number): boolean;
   isOutThresholdV(key: string, YTop: number, YBottom: number): boolean;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -15,6 +15,7 @@ export { Migration } from "./Migration";
 export type { IAbstract, IMigration } from "./Migration";
 
 export type {
+  Dimensions,
   RectDimensions,
   RectBoundaries,
   Axes,

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,8 +1,11 @@
-export interface RectDimensions {
-  top: number;
-  left: number;
+export interface Dimensions {
   height: number;
   width: number;
+}
+
+export interface RectDimensions extends Dimensions {
+  top: number;
+  left: number;
 }
 
 export interface RectBoundaries {


### PR DESCRIPTION
So when checking where the dragged is located different heights and widths won't be a problem given when dragged is transforming all of them has the same dimensions. Still, this needs to be improved to become more dynamic since heights and widths are constantly changing or supposed to be so.