### PR TITLE
Remove `branchesOrder` as it's unused in the store

### DIFF
--- a/packages/core-instance/src/Container/Container.ts
+++ b/packages/core-instance/src/Container/Container.ts
@@ -21,14 +21,19 @@ class Container implements IContainer {
 
   grid: IPointNum;
 
+  originLength: number;
+
   scroll!: IScroll;
 
   #gridSiblingsHasNewRow: boolean;
 
   lastElmPosition!: IPointNum;
 
+  static OUT_OF_RANGE = -1;
+
   constructor() {
     this.grid = new PointNum(1, 1);
+    this.originLength = Container.OUT_OF_RANGE;
     this.#boundariesByRow = {};
     this.#gridSiblingsHasNewRow = false;
   }

--- a/packages/core-instance/src/Container/types.ts
+++ b/packages/core-instance/src/Container/types.ts
@@ -20,6 +20,8 @@ export interface IContainer {
   /** Numbers of total columns and rows each container has.  */
   readonly grid: IPointNum;
 
+  originLength: number;
+
   /** Container scroll instance.  */
   scroll: IScroll;
   registerNewElm(

--- a/packages/dnd/cypress/integration/multiple-containers/continuity/multiple.intoTop.spec.ts
+++ b/packages/dnd/cypress/integration/multiple-containers/continuity/multiple.intoTop.spec.ts
@@ -12,108 +12,140 @@ context(
       cy.visit("http://localhost:3001/migration");
     });
 
-    context("Transform from to container-3 into (2)", () => {
-      it("Getting the first element from container-1", () => {
-        cy.get("#c3-1").then((elm) => {
-          elmBox = elm[0].getBoundingClientRect();
-          // eslint-disable-next-line no-unused-vars
-          startingPointX = elmBox.x + elmBox.width / 2;
-          startingPointY = elmBox.y + elmBox.height / 2;
+    it("Getting the first element from container-1", () => {
+      cy.get("#c3-1").then((elm) => {
+        elmBox = elm[0].getBoundingClientRect();
+        // eslint-disable-next-line no-unused-vars
+        startingPointX = elmBox.x + elmBox.width / 2;
+        startingPointY = elmBox.y + elmBox.height / 2;
 
-          cy.get("#c3-1").trigger("mousedown", {
-            button: 0,
-          });
+        cy.get("#c3-1").trigger("mousedown", {
+          button: 0,
         });
       });
+    });
 
-      it("Transforms element (#c3-1) - outside the list above container-3", () => {
-        stepsY = 90;
-        for (let i = 0; i < stepsY; i += 10) {
-          cy.get("#c3-1").trigger("mousemove", {
-            clientY: startingPointY - i,
-            force: true,
-          });
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(0);
-        }
+    it("Transforms element (#c3-1) - outside the list above container-3", () => {
+      stepsY = 90;
+      for (let i = 0; i < stepsY; i += 10) {
+        cy.get("#c3-1").trigger("mousemove", {
+          clientY: startingPointY - i,
+          force: true,
+        });
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(0);
+      }
 
-        stepsX = 470;
-        for (let i = 0; i < stepsX; i += 10) {
-          cy.get("#c3-1").trigger("mousemove", {
-            clientX: startingPointX - i,
-            force: true,
-          });
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(0);
-        }
-      });
+      stepsX = 470;
+      for (let i = 0; i < stepsX; i += 10) {
+        cy.get("#c3-1").trigger("mousemove", {
+          clientX: startingPointX - i,
+          force: true,
+        });
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(0);
+      }
+    });
 
-      it("Transforms element (#c3-1) - inside container-1", () => {
-        // stepsY = 110;
-        for (let i = stepsY; i >= 0; i -= 10) {
-          cy.get("#c3-1").trigger("mousemove", {
-            clientY: startingPointY - i,
-            force: true,
-          });
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(0);
-        }
-      });
+    it("Transforms element (#c3-1) - inside container-1", () => {
+      // stepsY = 110;
+      for (let i = stepsY; i >= 0; i -= 10) {
+        cy.get("#c3-1").trigger("mousemove", {
+          clientY: startingPointY - i,
+          force: true,
+        });
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(0);
+      }
+    });
 
-      it("Triggers mouseup event", () => {
-        cy.get("#c3-1").trigger("mouseup", { force: true });
-      });
+    it("Triggers mouseup event", () => {
+      cy.get("#c3-1").trigger("mouseup", { force: true });
+    });
 
-      it("Getting the first element from container-1", () => {
-        cy.get("#c3-2").then((elm) => {
-          elmBox = elm[0].getBoundingClientRect();
-          // eslint-disable-next-line no-unused-vars
-          startingPointX = elmBox.x + elmBox.width / 2;
-          startingPointY = elmBox.y + elmBox.height / 2;
+    it("Getting the first element from container-1", () => {
+      cy.get("#c3-2").then((elm) => {
+        elmBox = elm[0].getBoundingClientRect();
+        // eslint-disable-next-line no-unused-vars
+        startingPointX = elmBox.x + elmBox.width / 2;
+        startingPointY = elmBox.y + elmBox.height / 2;
 
-          cy.get("#c3-2").trigger("mousedown", {
-            button: 0,
-          });
+        cy.get("#c3-2").trigger("mousedown", {
+          button: 0,
         });
       });
+    });
 
-      it("Transforms element (#c3-2) - outside the list above container-3", () => {
-        stepsY = 90;
-        for (let i = 0; i < stepsY; i += 10) {
-          cy.get("#c3-2").trigger("mousemove", {
-            clientY: startingPointY - i,
-            force: true,
-          });
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(0);
-        }
+    it("Transforms element (#c3-2) - outside the list above container-3", () => {
+      stepsY = 90;
+      for (let i = 0; i < stepsY; i += 10) {
+        cy.get("#c3-2").trigger("mousemove", {
+          clientY: startingPointY - i,
+          force: true,
+        });
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(0);
+      }
 
-        stepsX = 470;
-        for (let i = 0; i < stepsX; i += 10) {
-          cy.get("#c3-2").trigger("mousemove", {
-            clientX: startingPointX - i,
-            force: true,
-          });
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(0);
-        }
-      });
+      stepsX = 470;
+      for (let i = 0; i < stepsX; i += 10) {
+        cy.get("#c3-2").trigger("mousemove", {
+          clientX: startingPointX - i,
+          force: true,
+        });
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(0);
+      }
+    });
 
-      it("Transforms element (#c3-2) - inside container-1", () => {
-        // stepsY = 110;
-        for (let i = stepsY; i >= 0; i -= 10) {
-          cy.get("#c3-2").trigger("mousemove", {
-            clientY: startingPointY - i,
-            force: true,
-          });
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(0);
-        }
-      });
+    it("Transforms element (#c3-2) - inside container-1", () => {
+      // stepsY = 110;
+      for (let i = stepsY; i >= 0; i -= 10) {
+        cy.get("#c3-2").trigger("mousemove", {
+          clientY: startingPointY - i,
+          force: true,
+        });
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(0);
+      }
+    });
 
-      it("Triggers mouseup event", () => {
-        cy.get("#c3-2").trigger("mouseup", { force: true });
-      });
+    it("Triggers mouseup event", () => {
+      cy.get("#c3-2").trigger("mouseup", { force: true });
+    });
+
+    it("Siblings in container 2 stay the same", () => {
+      cy.get("#c2-1").should("have.css", "transform", "none");
+
+      cy.get("#c2-2").should("have.css", "transform", "none");
+
+      cy.get("#c2-3").should("have.css", "transform", "none");
+
+      cy.get("#c2-4").should("have.css", "transform", "none");
+
+      cy.get("#c2-5").should("have.css", "transform", "none");
+    });
+
+    it("Siblings in destination have the correct position", () => {
+      cy.get("#c1-1").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, 0, 224)"
+      );
+    });
+
+    it("Dragged elements have the correct position", () => {
+      cy.get("#c3-1").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, -452, 112)"
+      );
+
+      cy.get("#c3-2").should(
+        "have.css",
+        "transform",
+        "matrix(1, 0, 0, 1, -452, -112)"
+      );
     });
   }
 );

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -404,7 +404,7 @@ class DnDStoreImp extends Store implements IDnDStore {
           position.clone(lastElmPosition);
           // Did we retorted the same element?
           isRestoredLastPosition =
-            originLength >= length &&
+            length <= originLength &&
             !lastElmPosition.isEqual(elm.currentPosition);
         } else {
           position.clone(elm.currentPosition);

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -364,7 +364,6 @@ class DnDStoreImp extends Store implements IDnDStore {
 
     // Restore the last known current position.
     const { lastElmPosition, originLength } = this.containers[SK];
-    console.log("file: DnDStoreImp.ts ~ line 367 ~ originLength", originLength);
 
     const position = new PointNum(0, 0);
     const isEmpty = Droppable.isEmpty(lst);

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -401,11 +401,16 @@ class DnDStoreImp extends Store implements IDnDStore {
         elm = this.registry[lst[at]];
 
         if (lastElmPosition) {
-          position.clone(lastElmPosition);
-          // Did we retorted the same element?
-          isRestoredLastPosition =
-            length <= originLength &&
-            !lastElmPosition.isEqual(elm.currentPosition);
+          if (length <= originLength) {
+            position.clone(lastElmPosition);
+            // Did we retorted the same element?
+            isRestoredLastPosition = !lastElmPosition.isEqual(
+              elm.currentPosition
+            );
+          } else {
+            isRestoredLastPosition = false;
+            position.clone(elm.currentPosition);
+          }
         } else {
           position.clone(elm.currentPosition);
         }

--- a/packages/dnd/src/DnDStore/DnDStoreImp.ts
+++ b/packages/dnd/src/DnDStore/DnDStoreImp.ts
@@ -363,7 +363,8 @@ class DnDStoreImp extends Store implements IDnDStore {
     const { length } = lst;
 
     // Restore the last known current position.
-    const { lastElmPosition } = this.containers[SK];
+    const { lastElmPosition, originLength } = this.containers[SK];
+    console.log("file: DnDStoreImp.ts ~ line 367 ~ originLength", originLength);
 
     const position = new PointNum(0, 0);
     const isEmpty = Droppable.isEmpty(lst);
@@ -403,9 +404,9 @@ class DnDStoreImp extends Store implements IDnDStore {
         if (lastElmPosition) {
           position.clone(lastElmPosition);
           // Did we retorted the same element?
-          isRestoredLastPosition = !lastElmPosition.isEqual(
-            elm.currentPosition
-          );
+          isRestoredLastPosition =
+            originLength >= length &&
+            !lastElmPosition.isEqual(elm.currentPosition);
         } else {
           position.clone(elm.currentPosition);
         }

--- a/packages/dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dnd/src/Draggable/DraggableAxes.ts
@@ -15,7 +15,7 @@ import type {
   IPointAxes,
 } from "@dflex/utils";
 
-import type { INode } from "@dflex/core-instance";
+import { Container, INode } from "@dflex/core-instance";
 
 import store from "../DnDStore";
 
@@ -110,6 +110,11 @@ class DraggableAxes extends AbstractDraggable<INode> implements IDraggableAxes {
         boundaries,
         store.unifiedContainerDimensions[depth]
       );
+
+      if (store.containers[key].originLength === Container.OUT_OF_RANGE) {
+        const { length } = store.getElmBranchByKey(key);
+        store.containers[key].originLength = length;
+      }
     });
 
     this.isMovingAwayFrom = new PointBool(false, false);

--- a/packages/dnd/test/dndStore.test.ts
+++ b/packages/dnd/test/dndStore.test.ts
@@ -38,6 +38,8 @@ describe("DnD Store", () => {
       y: 1000,
     };
 
+    const originLength = 4;
+
     let SK: string;
 
     describe("Normal branch without injection", () => {
@@ -106,6 +108,7 @@ describe("DnD Store", () => {
 
       it("Preserve the last element", () => {
         store.containers[SK].preservePosition(preservePosition);
+        store.containers[SK].originLength = originLength;
       });
 
       it("Restores the preserved position when calling for last element", () => {
@@ -204,7 +207,7 @@ describe("DnD Store", () => {
                   Object {
                     "isEmpty": false,
                     "isOrphan": false,
-                    "isRestoredLastPosition": true,
+                    "isRestoredLastPosition": false,
                   }
               `);
 

--- a/packages/dnd/test/dndStore.test.ts
+++ b/packages/dnd/test/dndStore.test.ts
@@ -197,7 +197,7 @@ describe("DnD Store", () => {
         `);
       });
 
-      it("Restores the preserved position when calling for last element", () => {
+      it("Restores the the last element when the branch is extended", () => {
         const { elm, prevElm, position, ...rest } = store.getInsertionELmMeta(
           4,
           SK
@@ -211,7 +211,10 @@ describe("DnD Store", () => {
                   }
               `);
 
-        expect(position.getInstance()).toStrictEqual(preservePosition);
+        expect(position.getInstance()).toStrictEqual({
+          x: elm4.ref.getBoundingClientRect().left,
+          y: elm4.ref.getBoundingClientRect().top,
+        });
 
         expect(elm.id).toBe(elm4.id);
         expect(prevElm.id).toBe(elm3.id);

--- a/packages/dom-gen/src/Generator.ts
+++ b/packages/dom-gen/src/Generator.ts
@@ -30,10 +30,6 @@ class Generator implements GeneratorInterface {
     [depth: number]: string[];
   };
 
-  branchesLength: {
-    [SK: string]: number;
-  };
-
   #prevDepth: number;
 
   #prevKey: string;
@@ -43,7 +39,6 @@ class Generator implements GeneratorInterface {
 
     this.branches = {};
     this.branchesByDepth = {};
-    this.branchesLength = {};
 
     this.#prevDepth = -99;
 
@@ -144,6 +139,7 @@ class Generator implements GeneratorInterface {
     const PK = combineKeys(depth + 1, this.#indicator[depth + 2]);
 
     const CHK = depth === 0 ? null : this.#prevKey;
+
     this.#prevKey = SK;
 
     this.#indicator[depth] += 1;

--- a/packages/dom-gen/src/Generator.ts
+++ b/packages/dom-gen/src/Generator.ts
@@ -26,11 +26,12 @@ class Generator implements GeneratorInterface {
     [keys: string]: string[];
   };
 
-  /** Branches order */
-  branchesOrder: string[];
-
   branchesByDepth: {
     [depth: number]: string[];
+  };
+
+  branchesLength: {
+    [SK: string]: number;
   };
 
   #prevDepth: number;
@@ -41,8 +42,8 @@ class Generator implements GeneratorInterface {
     this.#indicator = {};
 
     this.branches = {};
-    this.branchesOrder = [];
     this.branchesByDepth = {};
+    this.branchesLength = {};
 
     this.#prevDepth = -99;
 
@@ -83,21 +84,6 @@ class Generator implements GeneratorInterface {
     if (this.#indicator[dp + 2] === undefined) {
       this.#indicator[dp + 2] = 0;
     }
-  }
-
-  #updateOrder(k: string) {
-    const is = this.branchesOrder.find((key) => key === k);
-    if (!is) {
-      this.branchesOrder.push(k);
-    }
-  }
-
-  getBranchParentKey(SK: string) {
-    const keyOrder = this.branchesOrder.indexOf(SK);
-    if (keyOrder + 1 <= this.branchesOrder.length) {
-      return this.branchesOrder[keyOrder + 1];
-    }
-    return null;
   }
 
   #addElementIDToDepthCollection(SK: string, depth: number) {
@@ -154,11 +140,6 @@ class Generator implements GeneratorInterface {
      * get siblings unique key (sK) and parents key (pK)
      */
     const SK = combineKeys(depth, parentIndex);
-
-    /**
-     * Add key to the order.
-     */
-    this.#updateOrder(SK);
 
     const PK = combineKeys(depth + 1, this.#indicator[depth + 2]);
 
@@ -245,8 +226,6 @@ class Generator implements GeneratorInterface {
     } else {
       delete this.branches[SK];
     }
-
-    this.branchesOrder = this.branchesOrder.filter((key) => key !== SK);
 
     Object.keys(this.branchesByDepth).forEach((dp) => {
       const dpNum = Number(dp);

--- a/packages/dom-gen/src/types.ts
+++ b/packages/dom-gen/src/types.ts
@@ -33,11 +33,6 @@ export interface GeneratorInterface {
     [depth: number]: string[];
   };
 
-  /** Origin length for each branch */
-  readonly branchesLength: {
-    [key: string]: number;
-  };
-
   getElmBranch(SK: string): string[];
   register(id: string, depth: number): Pointer;
   accumulateIndicators(depth: number): Keys & {

--- a/packages/dom-gen/src/types.ts
+++ b/packages/dom-gen/src/types.ts
@@ -24,19 +24,20 @@ export interface Pointer {
 }
 
 export interface GeneratorInterface {
-  branches: {
-    [keys: string]: string[];
+  readonly branches: {
+    [key: string]: string[];
   };
 
-  /** SK (branch keys) in order. */
-  branchesOrder: string[];
-
   /** Branches grouped by the same depth. */
-  branchesByDepth: {
+  readonly branchesByDepth: {
     [depth: number]: string[];
   };
 
-  getBranchParentKey(SK: string): string | null;
+  /** Origin length for each branch */
+  readonly branchesLength: {
+    [key: string]: number;
+  };
+
   getElmBranch(SK: string): string[];
   register(id: string, depth: number): Pointer;
   accumulateIndicators(depth: number): Keys & {

--- a/packages/dom-gen/test/delete.test.ts
+++ b/packages/dom-gen/test/delete.test.ts
@@ -45,12 +45,6 @@ describe("Testing clear methods", () => {
     const branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
 
     expect(branch).toStrictEqual(["id-0", "id-1"]);
-
-    expect(domGen.branchesOrder).toMatchInlineSnapshot(`
-      Array [
-        "0-0",
-      ]
-    `);
   });
 
   it("The new generated branch has its key inside the branch depth array", () => {
@@ -100,12 +94,6 @@ describe("Testing clear methods", () => {
 
     expect(branch).toStrictEqual(["id-1", "id-0"]);
 
-    expect(domGen.branchesOrder).toMatchInlineSnapshot(`
-      Array [
-        "0-0",
-      ]
-    `);
-
     expect(domGen.branchesByDepth).toMatchInlineSnapshot(`
       Object {
         "0": Array [
@@ -121,7 +109,6 @@ describe("Testing clear methods", () => {
     const branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
 
     expect(branch).toBeUndefined();
-    expect(domGen.branchesOrder).toMatchInlineSnapshot(`Array []`);
     expect(domGen.branchesByDepth).toMatchInlineSnapshot(`Object {}`);
   });
 
@@ -154,12 +141,6 @@ describe("Testing clear methods", () => {
     const branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
 
     expect(branch).toStrictEqual(["id-0", "id-1"]);
-
-    expect(domGen.branchesOrder).toMatchInlineSnapshot(`
-      Array [
-        "0-0",
-      ]
-    `);
 
     expect(domGen.branchesByDepth).toMatchInlineSnapshot(`
       Object {

--- a/packages/dom-gen/test/gen.asc.test.ts
+++ b/packages/dom-gen/test/gen.asc.test.ts
@@ -42,10 +42,6 @@ describe("DOM Relationship Generator: Ascending-Simple", () => {
       expect(branch).toStrictEqual(["id-0"]);
     });
 
-    it("Initiates branch order array with the new generated branch key", () => {
-      expect(domGen.branchesOrder).toStrictEqual([KEYS_CHILDREN_D0.SK]);
-    });
-
     it("Adds the new branch into its depth", () => {
       expect(domGen.branchesByDepth).toMatchInlineSnapshot(`
         Object {
@@ -76,7 +72,6 @@ describe("DOM Relationship Generator: Ascending-Simple", () => {
       let branch = domGen.getElmBranch(pointerChild0D0.keys.SK);
 
       expect(branch).toStrictEqual(["id-0", "id-1"]);
-      expect(domGen.branchesOrder).toStrictEqual([KEYS_CHILDREN_D0.SK]);
 
       // DOM-root
       // │
@@ -129,11 +124,6 @@ describe("DOM Relationship Generator: Ascending-Simple", () => {
       expect(pointerChild1D0.keys.PK).toBe(pointerParent0D1.keys.SK);
       expect(pointerChild2D0.keys.PK).toBe(pointerParent0D1.keys.SK);
 
-      expect(domGen.branchesOrder).toStrictEqual([
-        KEYS_CHILDREN_D0.SK,
-        pointerParent0D1.keys.SK,
-      ]);
-
       expect(pointerParent0D1).toStrictEqual({
         keys: {
           CHK: "0-0",
@@ -179,12 +169,6 @@ describe("DOM Relationship Generator: Ascending-Simple", () => {
       pointerGrandParent0D2 = domGen.register("id-grand-parent-1", 2);
 
       expect(pointerParent0D1.keys.PK).toBe(pointerGrandParent0D2.keys.SK);
-
-      expect(domGen.branchesOrder).toStrictEqual([
-        KEYS_CHILDREN_D0.SK,
-        pointerParent0D1.keys.SK,
-        pointerGrandParent0D2.keys.SK,
-      ]);
 
       expect(pointerGrandParent0D2).toStrictEqual({
         keys: {
@@ -242,15 +226,6 @@ describe("DOM Relationship Generator: Ascending-Simple", () => {
       expect(pointerChild3D0.order.parent).not.toBe(
         pointerChild0D0.order.parent
       );
-
-      expect(domGen.branchesOrder).toMatchInlineSnapshot(`
-        Array [
-          "0-0",
-          "1-0",
-          "2-0",
-          "0-1",
-        ]
-      `);
 
       expect(pointerChild3D0).toStrictEqual({
         keys: {


### PR DESCRIPTION
- [x] Remove unused instances and methods not used in the store and refactor related tests.
- [x] Add origin length to determine when to restore and when the container is expanding.
- [x] Refactor unit test for meta extractor.
- [x] Fix continuity in extending orphan container (#534)
![extending orphan container](https://user-images.githubusercontent.com/19228730/168804876-066bc748-5bfc-4e4c-8ec0-80f2d20ae6c4.gif)
