### PR TITLE
Fix observer disconnecting when reconciling the DOM

### DIFF
--- a/packages/dflex-dnd-playground/tests/multiple-containers/strict/horizontally.bottom.spec.ts
+++ b/packages/dflex-dnd-playground/tests/multiple-containers/strict/horizontally.bottom.spec.ts
@@ -23,17 +23,17 @@ test.describe
   let activeBrowser: Browser;
 
   // Second container.
-  let elmC2_parent: Locator;
-  let elmC2_1: Locator;
-  let elmC2_2: Locator;
-  let elmC2_3: Locator;
-  let elmC2_4: Locator;
-  let elmC2_5: Locator;
+  let elmC2Parent: Locator;
+  let elmC2E1: Locator;
+  let elmC2E2: Locator;
+  let elmC2E3: Locator;
+  let elmC2E4: Locator;
+  let elmC2E5: Locator;
 
   // Third container
-  let elmC3_parent: Locator;
-  let elmC3_1: Locator;
-  let elmC3_2: Locator;
+  let elmC3Parent: Locator;
+  let elmC3E1: Locator;
+  let elmC3E2: Locator;
 
   test.beforeAll(async ({ browser, browserName }) => {
     activeBrowser = browser;
@@ -44,16 +44,16 @@ test.describe
     await page.goto("/migration");
 
     [
-      elmC3_parent,
-      elmC3_1,
-      elmC3_2,
+      elmC3Parent,
+      elmC3E1,
+      elmC3E2,
 
-      elmC2_parent,
-      elmC2_1,
-      elmC2_2,
-      elmC2_3,
-      elmC2_4,
-      elmC2_5,
+      elmC2Parent,
+      elmC2E1,
+      elmC2E2,
+      elmC2E3,
+      elmC2E4,
+      elmC2E5,
     ] = await Promise.all([
       page.locator("#id-p3"),
       page.locator("#c3-1"),
@@ -75,7 +75,7 @@ test.describe
   });
 
   test("Transforms element (#c3-2) - outside the origin container(3) inside container(2)", async () => {
-    await getDraggedRect(elmC3_2);
+    await getDraggedRect(elmC3E2);
     await moveDragged(-230, -1);
   });
 
@@ -85,18 +85,18 @@ test.describe
 
   test("Siblings from the original container positioned correctly", async () => {
     await Promise.all([
-      expect(elmC3_1).toHaveCSS("transform", "none"),
-      expect(elmC3_2).toHaveCSS("transform", "matrix(1, 0, 0, 1, -226, 12)"),
+      expect(elmC3E1).toHaveCSS("transform", "none"),
+      expect(elmC3E2).toHaveCSS("transform", "matrix(1, 0, 0, 1, -226, 12)"),
     ]);
   });
 
   test("Siblings from the destination container positioned correctly", async () => {
     await Promise.all([
-      expect(elmC2_1).toHaveCSS("transform", "none"),
-      expect(elmC2_2).toHaveCSS("transform", "none"),
-      expect(elmC2_3).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
-      expect(elmC2_4).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
-      expect(elmC2_5).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
+      expect(elmC2E1).toHaveCSS("transform", "none"),
+      expect(elmC2E2).toHaveCSS("transform", "none"),
+      expect(elmC2E3).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
+      expect(elmC2E4).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
+      expect(elmC2E5).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
     ]);
   });
 
@@ -105,11 +105,11 @@ test.describe
   });
 
   test("Siblings have the correct order in origin container(C3)", async () => {
-    await assertChildrenOrderIDs(elmC3_parent, ["c3-1"]);
+    await assertChildrenOrderIDs(elmC3Parent, ["c3-1"]);
   });
 
   test("Siblings have the correct order in destination container(C2)", async () => {
-    await assertChildrenOrderIDs(elmC2_parent, [
+    await assertChildrenOrderIDs(elmC2Parent, [
       "c2-1",
       "c2-2",
       "c3-2", // The new child.

--- a/packages/dflex-dnd-playground/tests/multiple-containers/strict/horizontally.bottom.spec.ts
+++ b/packages/dflex-dnd-playground/tests/multiple-containers/strict/horizontally.bottom.spec.ts
@@ -1,0 +1,92 @@
+import {
+  test,
+  expect,
+  Page,
+  Locator,
+  BrowserContext,
+  Browser,
+} from "@playwright/test";
+
+import {
+  DraggedRect,
+  getDraggedRect,
+  initialize,
+  invokeKeyboardAndAssertEmittedMsg,
+  moveDragged,
+} from "../../utils";
+
+test.describe
+  .serial("Transitioning the last element into the bottom of a bigger container horizontally", async () => {
+  let page: Page;
+  let context: BrowserContext;
+  let activeBrowser: Browser;
+
+  let draggedRect: DraggedRect;
+
+  // Second container.
+  let elmC2_1: Locator;
+  let elmC2_2: Locator;
+  let elmC2_3: Locator;
+  let elmC2_4: Locator;
+  let elmC2_5: Locator;
+
+  // Third container
+  let elmC3_1: Locator;
+  let elmC3_2: Locator;
+
+  test.beforeAll(async ({ browser, browserName }) => {
+    activeBrowser = browser;
+
+    context = await activeBrowser.newContext();
+    page = await context.newPage();
+    initialize(page, browserName);
+    await page.goto("/migration");
+
+    [elmC3_1, elmC3_2, elmC2_1, elmC2_2, elmC2_3, elmC2_4, elmC2_5] =
+      await Promise.all([
+        page.locator("#c3-1"),
+        page.locator("#c3-2"),
+        page.locator("#c2-1"),
+        page.locator("#c2-2"),
+        page.locator("#c2-3"),
+        page.locator("#c2-4"),
+        page.locator("#c2-5"),
+      ]);
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+    await context.close();
+    // await activeBrowser.close();
+  });
+
+  test("Transforms element (#c3-2) - outside the origin container(3) inside container(2)", async () => {
+    draggedRect = await getDraggedRect(elmC3_2);
+    await moveDragged(-230, -1);
+  });
+
+  test("Triggers mouseup", async () => {
+    await page.mouse.up({ button: "left", clickCount: 1 });
+  });
+
+  test("Siblings from the original container positioned correctly", async () => {
+    await Promise.all([
+      expect(elmC3_1).toHaveCSS("transform", "none"),
+      expect(elmC3_2).toHaveCSS("transform", "matrix(1, 0, 0, 1, -226, 12)"),
+    ]);
+  });
+
+  test("Siblings from the destination container positioned correctly", async () => {
+    await Promise.all([
+      expect(elmC2_1).toHaveCSS("transform", "none"),
+      expect(elmC2_2).toHaveCSS("transform", "none"),
+      expect(elmC2_3).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
+      expect(elmC2_4).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
+      expect(elmC2_5).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 112)"),
+    ]);
+  });
+
+  // test("Trigger key `c` to commit the transformed elements and read the emitted message for mutation", async () => {
+  //   await invokeKeyboardAndAssertEmittedMsg([]);
+  // });
+});

--- a/packages/dflex-dnd-playground/tests/multiple-containers/strict/horizontally.bottom.spec.ts
+++ b/packages/dflex-dnd-playground/tests/multiple-containers/strict/horizontally.bottom.spec.ts
@@ -8,7 +8,8 @@ import {
 } from "@playwright/test";
 
 import {
-  DraggedRect,
+  assertChildrenOrderIDs,
+  // DraggedRect,
   getDraggedRect,
   initialize,
   invokeKeyboardAndAssertEmittedMsg,
@@ -21,9 +22,8 @@ test.describe
   let context: BrowserContext;
   let activeBrowser: Browser;
 
-  let draggedRect: DraggedRect;
-
   // Second container.
+  let elmC2_parent: Locator;
   let elmC2_1: Locator;
   let elmC2_2: Locator;
   let elmC2_3: Locator;
@@ -31,6 +31,7 @@ test.describe
   let elmC2_5: Locator;
 
   // Third container
+  let elmC3_parent: Locator;
   let elmC3_1: Locator;
   let elmC3_2: Locator;
 
@@ -42,16 +43,29 @@ test.describe
     initialize(page, browserName);
     await page.goto("/migration");
 
-    [elmC3_1, elmC3_2, elmC2_1, elmC2_2, elmC2_3, elmC2_4, elmC2_5] =
-      await Promise.all([
-        page.locator("#c3-1"),
-        page.locator("#c3-2"),
-        page.locator("#c2-1"),
-        page.locator("#c2-2"),
-        page.locator("#c2-3"),
-        page.locator("#c2-4"),
-        page.locator("#c2-5"),
-      ]);
+    [
+      elmC3_parent,
+      elmC3_1,
+      elmC3_2,
+
+      elmC2_parent,
+      elmC2_1,
+      elmC2_2,
+      elmC2_3,
+      elmC2_4,
+      elmC2_5,
+    ] = await Promise.all([
+      page.locator("#id-p3"),
+      page.locator("#c3-1"),
+      page.locator("#c3-2"),
+
+      page.locator("#id-p2"),
+      page.locator("#c2-1"),
+      page.locator("#c2-2"),
+      page.locator("#c2-3"),
+      page.locator("#c2-4"),
+      page.locator("#c2-5"),
+    ]);
   });
 
   test.afterAll(async () => {
@@ -61,7 +75,7 @@ test.describe
   });
 
   test("Transforms element (#c3-2) - outside the origin container(3) inside container(2)", async () => {
-    draggedRect = await getDraggedRect(elmC3_2);
+    await getDraggedRect(elmC3_2);
     await moveDragged(-230, -1);
   });
 
@@ -86,7 +100,22 @@ test.describe
     ]);
   });
 
-  // test("Trigger key `c` to commit the transformed elements and read the emitted message for mutation", async () => {
-  //   await invokeKeyboardAndAssertEmittedMsg([]);
-  // });
+  test("Trigger key `c` to commit the transformed elements and read the emitted message for mutation", async () => {
+    await invokeKeyboardAndAssertEmittedMsg(["c3-1"]);
+  });
+
+  test("Siblings have the correct order in origin container(C3)", async () => {
+    await assertChildrenOrderIDs(elmC3_parent, ["c3-1"]);
+  });
+
+  test("Siblings have the correct order in destination container(C2)", async () => {
+    await assertChildrenOrderIDs(elmC2_parent, [
+      "c2-1",
+      "c2-2",
+      "c3-2", // The new child.
+      "c2-3",
+      "c2-4",
+      "c2-5",
+    ]);
+  });
 });

--- a/packages/dflex-dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableAxes.ts
@@ -139,6 +139,7 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
     if (store.migration === null) {
       store.migration = new DFlexCycle(
         VDOMOrder.self,
+        this.draggedElm.id,
         SK,
         cycleID,
         // TODO: refactor this to use if the dragged belongs to scroll container or not.
@@ -147,6 +148,7 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
     } else {
       store.migration.add(
         VDOMOrder.self,
+        this.draggedElm.id,
         SK,
         cycleID,
         // TODO: refactor this to use if the dragged belongs to scroll container or not.

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDOMReconciler.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDOMReconciler.ts
@@ -41,7 +41,13 @@ function commitElm(
   const [dflexElm, elmDOM] = store.getElmWithDOM(elmID);
 
   if (dflexElm.hasTransformedFromOrigin()) {
-    if (dflexElm.needReconciliation()) {
+    if (
+      dflexElm.needReconciliation() ||
+      // Until the element owns its transformation between containers history we
+      // can't rely only on the local indicators as it only reflects the
+      // elements movement inside the origin container.
+      store.migration.filter([dflexElm.id], false)
+    ) {
       switchElmDOMPosition(branchIDs, branchDOM, store, dflexElm, elmDOM);
     }
 

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDOMReconciler.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDOMReconciler.ts
@@ -3,7 +3,7 @@ import type { ELmBranch } from "@dflex/dom-gen";
 import type DFlexDnDStore from "./DFlexDnDStore";
 
 function switchElmDOMPosition(
-  branchIDs: ELmBranch,
+  branchIDs: Readonly<ELmBranch>,
   branchDOM: HTMLElement,
   store: DFlexDnDStore,
   dflexElm: DFlexElement,
@@ -33,7 +33,7 @@ function switchElmDOMPosition(
 }
 
 function commitElm(
-  branchIDs: ELmBranch,
+  branchIDs: Readonly<ELmBranch>,
   branchDOM: HTMLElement,
   store: DFlexDnDStore,
   elmID: string
@@ -58,7 +58,7 @@ function commitElm(
  * @returns
  */
 function DFlexDOMReconciler(
-  branchIDs: ELmBranch,
+  branchIDs: Readonly<ELmBranch>,
   branchDOM: HTMLElement,
   store: DFlexDnDStore,
   container: DFlexParentContainer

--- a/packages/dflex-dnd/src/LayoutManager/DFlexScheduler.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexScheduler.ts
@@ -20,7 +20,7 @@ function execTask(
   options: SchedulerOptions | null,
   evt?: DFlexListenerEvents
 ) {
-  if (options && options.onUpdate) {
+  if (options?.onUpdate) {
     store.deferred.push(options.onUpdate);
   }
 
@@ -29,7 +29,7 @@ function execTask(
   }
 
   try {
-    if (options && options.rAF) {
+    if (options?.rAF) {
       requestAnimationFrame(updateFn);
     } else {
       updateFn();

--- a/packages/dflex-dnd/src/Mechanism/DFlexMechanismController.ts
+++ b/packages/dflex-dnd/src/Mechanism/DFlexMechanismController.ts
@@ -242,6 +242,7 @@ class DFlexMechanismController extends DFlexScrollableElement {
 
         migration.add(
           NaN,
+          draggedElm.id,
           newSK,
           cycleID,
           store.scrolls.get(newSK)!.hasOverflow.isOneTruthy()

--- a/packages/dflex-dnd/src/Mechanism/EndCycle.ts
+++ b/packages/dflex-dnd/src/Mechanism/EndCycle.ts
@@ -67,7 +67,7 @@ class EndCycle extends DFlexMechanismController {
     const { migration } = store;
     const latestCycle = migration.latest();
 
-    const sessionCycles = migration.filter(session);
+    const sessionCycles = migration.filter(session, true);
 
     let isFallback = false;
 

--- a/packages/dflex-utils/src/DFlexCycle/DFlexCycle.ts
+++ b/packages/dflex-utils/src/DFlexCycle/DFlexCycle.ts
@@ -1,6 +1,9 @@
 /* eslint-disable max-classes-per-file */
 
 class AbstractDFlexCycle {
+  /** Transitioning element ID. */
+  id: string;
+
   /** Last known index for draggable before transitioning. */
   index: number;
 
@@ -19,10 +22,17 @@ class AbstractDFlexCycle {
   /** Defined during the transition. */
   marginTop: number | null;
 
-  constructor(index: number, SK: string, id: string, hasScroll: boolean) {
+  constructor(
+    index: number,
+    id: string,
+    SK: string,
+    cycleID: string,
+    hasScroll: boolean
+  ) {
     this.index = index;
     this.SK = SK;
-    this.cycleID = id;
+    this.id = id;
+    this.cycleID = cycleID;
     this.hasScroll = hasScroll;
     this.numberOfTransformedELm = 0;
 
@@ -42,8 +52,16 @@ class DFlexCycle {
   /** Only true when transitioning. */
   isTransitioning!: boolean;
 
-  constructor(index: number, SK: string, id: string, hasScroll: boolean) {
-    this._migrations = [new AbstractDFlexCycle(index, SK, id, hasScroll)];
+  constructor(
+    index: number,
+    id: string,
+    SK: string,
+    cycleID: string,
+    hasScroll: boolean
+  ) {
+    this._migrations = [
+      new AbstractDFlexCycle(index, id, SK, cycleID, hasScroll),
+    ];
     this.containerKeys = new Set([SK]);
     this.complete();
   }
@@ -63,15 +81,16 @@ class DFlexCycle {
   }
 
   /**
-   * Get all cycles filtered by ids.
+   * Get all cycles filtered by cycleI-IDs or element-IDs.
    *
    * @param cycleIDs
+   * @param byCycleID
    * @returns
    */
-  filter(cycleIDs: string[]): AbstractDFlexCycle[] {
-    return this._migrations.filter((_) =>
-      cycleIDs.find((i) => i === _.cycleID)
-    );
+  filter(cycleIDs: string[], byCycleID: boolean): AbstractDFlexCycle[] {
+    return byCycleID
+      ? this._migrations.filter((_) => cycleIDs.find((i) => i === _.cycleID))
+      : this._migrations.filter((_) => cycleIDs.find((i) => i === _.id));
   }
 
   flush(cycleIDs: string[]): void {
@@ -130,11 +149,19 @@ class DFlexCycle {
    *
    * @param index
    * @param SK
-   * @param id
+   * @param cycleID
    * @param hasScroll
    */
-  add(index: number, SK: string, id: string, hasScroll: boolean): void {
-    this._migrations.push(new AbstractDFlexCycle(index, SK, id, hasScroll));
+  add(
+    index: number,
+    id: string,
+    SK: string,
+    cycleID: string,
+    hasScroll: boolean
+  ): void {
+    this._migrations.push(
+      new AbstractDFlexCycle(index, id, SK, cycleID, hasScroll)
+    );
     this.containerKeys.add(SK);
   }
 


### PR DESCRIPTION
- [x] Start migrating the DOM reconciliation test between containers to the `Playwright`.
- [x] Fix the error caused by triggering the observer during DOM reconciliation.
- [x] Add migrated elements into the `Migration` instance. 