### PR TITLE
Support resizing window for transformed/non-transformed containers alike

### DIFF
--- a/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
+++ b/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
@@ -420,7 +420,7 @@ class DFlexCoreElement extends DFlexBaseElement {
     this.rollBack(DOM, cycleID);
   }
 
-  refreshIndicators(DOM: HTMLElement): void {
+  refreshIndicators(DOM: HTMLElement, initElmRect: boolean): void {
     this._translateHistory = undefined;
 
     this.translate.setAxes(0, 0);
@@ -435,7 +435,9 @@ class DFlexCoreElement extends DFlexBaseElement {
       DOM.removeAttribute("style");
     }
 
-    this.initElmRect(DOM);
+    if (initElmRect) {
+      this.initElmRect(DOM);
+    }
   }
 
   getSerializedInstance(): DFlexSerializedElement {

--- a/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
+++ b/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
@@ -124,9 +124,6 @@ class DFlexCoreElement extends DFlexBaseElement {
     this._initialPosition.setAxes(left, top);
 
     this.rect.setByPointAndDimensions(top, left, height, width);
-
-    // This method also used for resetting.
-    this.DOMGrid.setAxes(0, 0);
   }
 
   private _updateCurrentIndicators(newPos: AxesPoint): void {
@@ -420,7 +417,7 @@ class DFlexCoreElement extends DFlexBaseElement {
     this.rollBack(DOM, cycleID);
   }
 
-  refreshIndicators(DOM: HTMLElement, initElmRect: boolean): void {
+  refreshIndicators(DOM: HTMLElement): void {
     this._translateHistory = undefined;
 
     this.translate.setAxes(0, 0);
@@ -435,9 +432,9 @@ class DFlexCoreElement extends DFlexBaseElement {
       DOM.removeAttribute("style");
     }
 
-    if (initElmRect) {
-      this.initElmRect(DOM);
-    }
+    this.initElmRect(DOM);
+
+    this.DOMGrid.setAxes(0, 0);
   }
 
   getSerializedInstance(): DFlexSerializedElement {

--- a/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
+++ b/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
@@ -113,7 +113,7 @@ class DFlexCoreElement extends DFlexBaseElement {
     this.DOMGrid = new PointNum(0, 0);
   }
 
-  private _initIndicators(DOM: HTMLElement): void {
+  initElmRect(DOM: HTMLElement): void {
     const { height, width, left, top } = DOM.getBoundingClientRect();
 
     /**
@@ -176,7 +176,7 @@ class DFlexCoreElement extends DFlexBaseElement {
 
   resume(DOM: HTMLElement): void {
     this.initTranslate();
-    this._initIndicators(DOM);
+    this.initElmRect(DOM);
   }
 
   changeVisibility(DOM: HTMLElement, isVisible: boolean): void {
@@ -435,7 +435,7 @@ class DFlexCoreElement extends DFlexBaseElement {
       DOM.removeAttribute("style");
     }
 
-    this._initIndicators(DOM);
+    this.initElmRect(DOM);
   }
 
   getSerializedInstance(): DFlexSerializedElement {

--- a/packages/dflex-dnd-playground/src/App.tsx
+++ b/packages/dflex-dnd-playground/src/App.tsx
@@ -73,7 +73,7 @@ const App = () => {
 
   React.useEffect(() => {
     return () => {
-      store.destroy();
+      // store.destroy();
     };
   }, []);
 

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDOMReconciler.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDOMReconciler.ts
@@ -127,7 +127,7 @@ function DFlexDOMReconciler(
     for (let i = 0; i <= branchIDs.length - 1; i += 1) {
       const [dflexElm, elmDOM] = store.getElmWithDOM(branchIDs[i]);
 
-      dflexElm.refreshIndicators(elmDOM, true);
+      dflexElm.refreshIndicators(elmDOM);
 
       if (__DEV__) {
         setElmGridAndAssertPosition(
@@ -138,17 +138,15 @@ function DFlexDOMReconciler(
           store,
           container
         );
-
-        return;
+      } else {
+        store.setElmGridBridge(container, dflexElm);
       }
-
-      store.setElmGridBridge(container, dflexElm);
     }
   } else {
     while (reconciledElmQueue.length) {
       const [dflexElm, elmDOM] = reconciledElmQueue.pop()!;
 
-      dflexElm.refreshIndicators(elmDOM, true);
+      dflexElm.refreshIndicators(elmDOM);
     }
   }
 
@@ -156,14 +154,18 @@ function DFlexDOMReconciler(
     for (let i = 0; i <= branchIDs.length - 1; i += 1) {
       const dflexElm = store.registry.get(branchIDs[i])!;
 
-      setElmGridAndAssertPosition(
-        branchIDs[i],
-        dflexElm,
-        i,
-        branchDOM,
-        store,
-        container
-      );
+      if (__DEV__) {
+        setElmGridAndAssertPosition(
+          branchIDs[i],
+          dflexElm,
+          i,
+          branchDOM,
+          store,
+          container
+        );
+      } else {
+        store.setElmGridBridge(container, dflexElm);
+      }
     }
   }
 }

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
@@ -155,8 +155,10 @@ class DFlexDnDStore extends DFlexBaseStore {
     let container: DFlexParentContainer;
     let scroll: DFlexScrollContainer;
 
-    if (!this.unifiedContainerDimensions[depth]) {
-      this.unifiedContainerDimensions[depth] = Object.seal({
+    const targetingLayerDepth = depth - 1;
+
+    if (!this.unifiedContainerDimensions[targetingLayerDepth]) {
+      this.unifiedContainerDimensions[targetingLayerDepth] = Object.seal({
         width: 0,
         height: 0,
       });
@@ -214,11 +216,7 @@ class DFlexDnDStore extends DFlexBaseStore {
 
     updateBranchVisibilityLinearly(this, SK);
 
-    // This is not right, but it's workaround. The ideal solution is to observe the layer itself.
-    // E.g, find a solution where we have the higher order parent.
-    if (depth === 0) {
-      addMutationObserver(this, SK, DOM);
-    }
+    addMutationObserver(this, SK, DOM);
   }
 
   register(element: RegisterInputOpts) {

--- a/packages/dflex-dnd/src/LayoutManager/DFlexMutations.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexMutations.ts
@@ -154,7 +154,7 @@ function initMutationObserver(store: DFlexDnDStore, SK: string) {
   const terminatedDOMiDs: TerminatedDOMiDs = new Set();
   const changedIds: ChangedIds = new Set();
 
-  store.observer.set(
+  store.mutationObserverMap.set(
     SK,
     new MutationObserver(
       (mutations: MutationRecord[], observer: MutationObserver) => {
@@ -175,15 +175,40 @@ function addMutationObserver(
   SK: string,
   DOMTarget: HTMLElement
 ) {
-  if (!store.observer.has(SK)) {
+  if (!store.mutationObserverMap.has(SK)) {
     initMutationObserver(store, SK);
   }
 
-  store.observer.get(SK)!.observe(DOMTarget, observerConfig);
+  store.mutationObserverMap.get(SK)!.observe(DOMTarget, observerConfig);
+}
+
+function initResizeObserver(store: DFlexDnDStore, SK: string) {
+  store.resizeObserverMap.set(
+    SK,
+    new ResizeObserver((entries: ResizeObserverEntry[]) => {
+      entries.forEach((entry) => {
+        const {
+          target: { id },
+        } = entry;
+      });
+    })
+  );
+}
+
+function addResizeObserver(
+  store: DFlexDnDStore,
+  SK: string,
+  DOMTarget: HTMLElement
+) {
+  if (!store.resizeObserverMap.has(SK)) {
+    initResizeObserver(store, SK);
+  }
+
+  store.resizeObserverMap.get(SK)!.observe(DOMTarget);
 }
 
 type DFlexLMutationPlugin = ReturnType<typeof addMutationObserver>;
 
 export type { DFlexLMutationPlugin };
 
-export { getIsProcessingMutations, addMutationObserver };
+export { getIsProcessingMutations, addMutationObserver, addResizeObserver };

--- a/packages/dflex-dnd/src/LayoutManager/DFlexMutations.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexMutations.ts
@@ -182,33 +182,8 @@ function addMutationObserver(
   store.mutationObserverMap.get(SK)!.observe(DOMTarget, observerConfig);
 }
 
-function initResizeObserver(store: DFlexDnDStore, SK: string) {
-  store.resizeObserverMap.set(
-    SK,
-    new ResizeObserver((entries: ResizeObserverEntry[]) => {
-      entries.forEach((entry) => {
-        const {
-          target: { id },
-        } = entry;
-      });
-    })
-  );
-}
-
-function addResizeObserver(
-  store: DFlexDnDStore,
-  SK: string,
-  DOMTarget: HTMLElement
-) {
-  if (!store.resizeObserverMap.has(SK)) {
-    initResizeObserver(store, SK);
-  }
-
-  store.resizeObserverMap.get(SK)!.observe(DOMTarget);
-}
-
 type DFlexLMutationPlugin = ReturnType<typeof addMutationObserver>;
 
 export type { DFlexLMutationPlugin };
 
-export { getIsProcessingMutations, addMutationObserver, addResizeObserver };
+export { getIsProcessingMutations, addMutationObserver };

--- a/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
+++ b/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
@@ -57,7 +57,9 @@ DFlexDnDStore {
       id="id-4"
     />
   </div>,
+  "_observerHighestDepth": 1,
   "_queue": [],
+  "_windowResizeHandler": [Function],
   "containers": Map {
     "0-0" => DFlexParentContainer {
       "_boundariesByRow": {
@@ -182,9 +184,8 @@ DFlexDnDStore {
     "subscribe": [Function],
   },
   "migration": null,
-  "observer": Map {
-    "0-0" => MutationObserver {},
-    "0-1" => MutationObserver {},
+  "mutationObserverMap": Map {
+    "1-0" => MutationObserver {},
   },
   "queueTimeoutId": undefined,
   "registry": Map {

--- a/packages/dflex-draggable/src/DFlexDraggableStore.ts
+++ b/packages/dflex-draggable/src/DFlexDraggableStore.ts
@@ -1,3 +1,4 @@
+import type { Keys } from "@dflex/dom-gen";
 import DFlexBaseStore from "@dflex/store";
 import { canUseDOM } from "@dflex/utils";
 
@@ -19,7 +20,9 @@ class DFlexDraggableStore extends DFlexBaseStore {
     dflexNode.resume(DOM);
   }
 
-  private _initBranch(SK: string) {
+  private _initBranch(keys: Keys) {
+    const { SK } = keys;
+
     this.getElmBranchByKey(SK).forEach(this._initElmDOMInstance);
   }
 

--- a/packages/dflex-store/src/DFlexBaseStore.ts
+++ b/packages/dflex-store/src/DFlexBaseStore.ts
@@ -196,7 +196,7 @@ class DFlexBaseStore {
       DOM.dataset.dflexKey = keys.CHK;
 
       if (typeof branchComposedCallBack === "function") {
-        branchComposedCallBack(keys.CHK, depth - 1, id, DOM);
+        branchComposedCallBack(keys.CHK, depth, id, DOM);
       }
     }
   }

--- a/packages/dflex-store/src/DFlexBaseStore.ts
+++ b/packages/dflex-store/src/DFlexBaseStore.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import Generator, { ELmBranch } from "@dflex/dom-gen";
+import Generator, { ELmBranch, Keys } from "@dflex/dom-gen";
 
 import { DFlexElement, DFlexElementInput } from "@dflex/core-instance";
 import {
@@ -41,7 +41,7 @@ type GetElmWithDOMOutput = [DFlexElement, HTMLElement];
 
 type BranchComposedCallBackFunction = (
   // eslint-disable-next-line no-unused-vars
-  childrenKey: string,
+  keys: Keys,
   // eslint-disable-next-line no-unused-vars
   childrenDepth: number,
   // eslint-disable-next-line no-unused-vars
@@ -196,7 +196,7 @@ class DFlexBaseStore {
       DOM.dataset.dflexKey = keys.CHK;
 
       if (typeof branchComposedCallBack === "function") {
-        branchComposedCallBack(keys.CHK, depth, id, DOM);
+        branchComposedCallBack(keys, depth, id, DOM);
       }
     }
   }


### PR DESCRIPTION
- [x] Resizing window will automatically:
    - Trigger reconciliation for transformed containers.
    - Non-transformed containers will update DOMRect.
- [x] Observers are added to the higher registered container depth instead of each parent container.
