### PR TITLE
Add a stabilizer mechanism preventing dragged from being stuck inside an intersected area

### DIFF
--- a/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
+++ b/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
@@ -475,7 +475,7 @@ class DFlexCoreElement extends DFlexBaseElement {
       translate: this.translate instanceof PointNum ? this.translate : null,
       order: this.VDOMOrder,
       initialPosition: this._initialPosition.getInstance(),
-      rect: this.rect.getRect(),
+      rect: this.rect,
       hasTransformedFromOrigin: this.hasTransformedFromOrigin(),
       hasPendingTransformation: this.hasPendingTransform,
       isVisible: this.isVisible,

--- a/packages/dflex-dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableAxes.ts
@@ -9,6 +9,7 @@ import {
   BoxNum,
   BoxRectAbstract,
   Tracker,
+  Axis,
 } from "@dflex/utils";
 
 import type { DFlexElement } from "@dflex/core-instance";
@@ -90,6 +91,8 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
    * Note: Scroll position included, these points ignore viewport.
    */
   private _absoluteCurrentPosition: BoxNum;
+
+  private _prevPoint: PointNum;
 
   private isLayoutStateUpdated: boolean;
 
@@ -189,6 +192,8 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
       rect.left
     );
 
+    this._prevPoint = new PointNum(x, y);
+
     this.restrictions = opts.restrictions;
 
     this.restrictionsStatus = opts.restrictionsStatus;
@@ -272,6 +277,10 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
    * @param y
    */
   setAbsoluteCurrentPosition(x: number, y: number): void {
+    const pre = this._absoluteCurrentPosition;
+
+    this._prevPoint.setAxes(pre.left, pre.top);
+
     const edgePosLeft = x - this.innerOffset.x;
     const edgePosTop = y - this.innerOffset.y;
 
@@ -293,6 +302,29 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
    */
   getAbsoluteCurrentPosition(): BoxNum {
     return this._absoluteCurrentPosition;
+  }
+
+  getDirectionByAxis(axis: Axis): "r" | "l" | "d" | "u" {
+    const { x: previousX, y: previousY } = this._prevPoint;
+    const { left: currentX, top: currentY } = this._absoluteCurrentPosition;
+
+    if (axis === "x") {
+      if (currentX > previousX) {
+        // Box moved right
+        return "r";
+      }
+
+      // Box moved left
+      return "l";
+    }
+
+    if (currentY > previousY) {
+      // Box moved down
+      return "d";
+    }
+
+    // Box moved up
+    return "u";
   }
 
   /**

--- a/packages/dflex-dnd/src/Mechanism/DFlexMechanismController.ts
+++ b/packages/dflex-dnd/src/Mechanism/DFlexMechanismController.ts
@@ -386,7 +386,7 @@ class DFlexMechanismController extends DFlexScrollableElement {
   private _actionCaller(
     newGridPos: number,
     maxGrid: number,
-    isIncrease: boolean
+    shouldIncrease: boolean
   ): void {
     if (__DEV__) {
       if (newGridPos < -1) {
@@ -414,6 +414,7 @@ class DFlexMechanismController extends DFlexScrollableElement {
       return;
     }
 
+    // Switch elements if thresholds are intersected.
     const {
       draggedElm: { id: draggedID },
     } = this.draggable;
@@ -422,7 +423,7 @@ class DFlexMechanismController extends DFlexScrollableElement {
 
     const siblings = store.getElmSiblingsByKey(SK);
 
-    const elmIndex = index + -1 * (isIncrease ? -1 : 1);
+    const elmIndex = index + -1 * (shouldIncrease ? -1 : 1);
 
     const id = siblings[elmIndex];
 
@@ -449,9 +450,10 @@ class DFlexMechanismController extends DFlexScrollableElement {
       this.draggable.threshold.thresholds[draggedID]
     );
 
+    // TODO: This is not tested.
     if (isIntersect) {
       this.draggable.setDraggedTempIndex(elmIndex);
-      this.updateElement(id, siblings, cycleID, isIncrease);
+      this.updateElement(id, siblings, cycleID, shouldIncrease);
     } else {
       if (__DEV__) {
         if (featureFlags.enableMechanismDebugger) {
@@ -500,7 +502,7 @@ class DFlexMechanismController extends DFlexScrollableElement {
         }
       }
 
-      this._actionCaller(newPos, grid[axis], isOut[id].bottom);
+      this._actionCaller(newPos, grid[axis], shouldIncrease);
 
       return true;
     }

--- a/packages/dflex-dnd/src/Mechanism/DFlexPositionUpdater.ts
+++ b/packages/dflex-dnd/src/Mechanism/DFlexPositionUpdater.ts
@@ -231,7 +231,7 @@ class DFlexPositionUpdater {
     }
   }
 
-  private updateDraggable(
+  private _updateDraggable(
     axis: Axes,
     elmDirection: Direction,
     element: DFlexElement
@@ -250,13 +250,17 @@ class DFlexPositionUpdater {
       this.draggable.occupiedTranslate[axis] += this.draggedTransition[axis];
     }
 
-    // this.draggable.occupiedTranslate.clone(this.draggedTransition);
-
-    // this.draggable.occupiedTranslate.increase(
-    //   this.draggedTransition.getMultiplied(draggedDirection)
-    // );
-
     this.draggable.gridPlaceholder.clone(grid);
+
+    if (__DEV__) {
+      if (featureFlags.enableMechanismDebugger) {
+        // eslint-disable-next-line no-console
+        console.log(
+          "_updateDraggable: new grid is",
+          this.draggable.gridPlaceholder
+        );
+      }
+    }
   }
 
   private updateIndicators(
@@ -276,10 +280,17 @@ class DFlexPositionUpdater {
       this.setDistanceBtwPositions(axis, elmDirection, element);
     }
 
-    this.updateDraggable(axis, elmDirection, element);
+    this._updateDraggable(axis, elmDirection, element);
   }
 
   protected updateDraggedThresholdPosition(x: number, y: number) {
+    if (__DEV__) {
+      if (featureFlags.enableMechanismDebugger) {
+        // eslint-disable-next-line no-console
+        console.log(`updateDraggedThresholdPosition: ${x}/${y}`);
+      }
+    }
+
     const {
       threshold,
       draggedElm: {

--- a/packages/dflex-utils/src/Box/Box.ts
+++ b/packages/dflex-utils/src/Box/Box.ts
@@ -4,6 +4,13 @@ import AbstractBox from "./AbstractBox";
 
 /** Four direction instance - clockwise */
 class Box<T> extends AbstractBox<T> {
+  clone(box: AbstractBox<T>): void {
+    this.top = box.top;
+    this.right = box.right;
+    this.bottom = box.bottom;
+    this.left = box.left;
+  }
+
   /**
    * Set all directions.
    *

--- a/packages/dflex-utils/src/Box/BoxNum.ts
+++ b/packages/dflex-utils/src/Box/BoxNum.ts
@@ -47,6 +47,7 @@ class BoxNum extends Box<number> {
     // Determine the coordinates of the new box
     const left = Math.min(box.left, this.left);
     const top = Math.min(box.top, this.top);
+
     const right = Math.max(box.right, this.right);
     const bottom = Math.max(box.bottom, this.bottom);
 

--- a/packages/dflex-utils/src/Box/BoxNum.ts
+++ b/packages/dflex-utils/src/Box/BoxNum.ts
@@ -43,20 +43,36 @@ class BoxNum extends Box<number> {
     return !this.isNotIntersect(box);
   }
 
+  getSurroundingBox(box: AbstractBox): AbstractBox {
+    // Determine the coordinates of the new box
+    const left = Math.min(box.left, this.left);
+    const top = Math.min(box.top, this.top);
+    const right = Math.max(box.right, this.right);
+    const bottom = Math.max(box.bottom, this.bottom);
+
+    // Create and return the new box
+    return {
+      left,
+      top,
+      right,
+      bottom,
+    };
+  }
+
   /**
    * True when it's inside of other box.
    *
    * @param box
    * @returns
    */
-  // isInside(box: AbstractBox): boolean {
-  //   return (
-  //     this.top >= box.top &&
-  //     this.right <= box.right &&
-  //     this.bottom <= box.bottom &&
-  //     this.left >= box.left
-  //   );
-  // }
+  isInside(box: AbstractBox): boolean {
+    return (
+      this.top >= box.top &&
+      this.right <= box.right &&
+      this.bottom <= box.bottom &&
+      this.left >= box.left
+    );
+  }
 
   isPositionedY(box: AbstractBox) {
     return this._isUnder(box) || this._isAbove(box);

--- a/packages/dflex-utils/src/Threshold/Threshold.ts
+++ b/packages/dflex-utils/src/Threshold/Threshold.ts
@@ -103,6 +103,18 @@ class DFlexThreshold {
     this.isOut[key].setFalsy();
   }
 
+  getOrCreateElmMainThreshold(
+    key: string,
+    rect: AbstractBox,
+    isInner: boolean
+  ): BoxNum {
+    if (!this.thresholds[key]) {
+      this.thresholds[key] = this._pixels.composeBox(rect, isInner);
+    }
+
+    return this.thresholds[key];
+  }
+
   /**
    * Assign outer threshold for the container. Along with another threshold
    * called insertion threshold which defines the area where the element can be

--- a/packages/dflex-utils/src/Threshold/Threshold.ts
+++ b/packages/dflex-utils/src/Threshold/Threshold.ts
@@ -103,16 +103,8 @@ class DFlexThreshold {
     this.isOut[key].setFalsy();
   }
 
-  getOrCreateElmMainThreshold(
-    key: string,
-    rect: AbstractBox,
-    isInner: boolean
-  ): BoxNum {
-    if (!this.thresholds[key]) {
-      this.thresholds[key] = this._pixels.composeBox(rect, isInner);
-    }
-
-    return this.thresholds[key];
+  getElmMainThreshold(rect: AbstractBox): BoxNum {
+    return this._pixels.composeBox(rect, false);
   }
 
   /**


### PR DESCRIPTION
Create stabilizing zone to prevent dragged from being stuck between two intersected thresholds.
E.g: Dragged moved into a new threshold but triggered the previous one because it's stuck inside the zone causing jarring behavior; the back-and-forth transition.