### PR TITLE
Improve `DFlexScrollContainer` performance and testability

### DIFF
--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -358,9 +358,7 @@ class DFlexScrollContainer {
     }
   });
 
-  private _throttledResizeHandler() {
-    eventDebounce(this._updateScrollRect);
-  }
+  private _throttledResizeHandler = eventDebounce(this._updateScrollRect);
 
   private _attachResizeAndScrollListeners(isAttachListener = true): void {
     /**

--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -151,10 +151,9 @@ class DFlexScrollContainer {
   }
 
   constructor(
-    element: HTMLElement,
+    firstELmDOM: HTMLElement,
     SK: string,
     branchLength: number,
-    hasToScrollToZero: boolean,
     scrollEventCallback: ScrollEventCallback
   ) {
     this.hasOverflow = new PointBool(false, false);
@@ -175,7 +174,7 @@ class DFlexScrollContainer {
     this._scrollEventCallback = null;
 
     [this.scrollContainerDOM, this.hasDocumentAsContainer] =
-      getScrollContainer(element);
+      getScrollContainer(firstELmDOM);
 
     this._setScrollRect();
 
@@ -203,10 +202,7 @@ class DFlexScrollContainer {
 
     this._setResizeAndScrollListeners();
 
-    if (
-      hasToScrollToZero &&
-      (this.scrollRect.top > 0 || this.scrollRect.left > 0)
-    ) {
+    if (true && (this.scrollRect.top > 0 || this.scrollRect.left > 0)) {
       // Scroll without callback.
       this.scrollTo(0, 0, false);
     }

--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -135,9 +135,9 @@ class DFlexScrollContainer {
   /**
    * The parent element that is owning the scroll.
    */
-  containerDOM!: HTMLElement;
+  private _containerDOM!: HTMLElement;
 
-  isDocumentContainer!: boolean;
+  private _isDocumentContainer!: boolean;
 
   private _listenerDatasetKey: string;
 
@@ -165,13 +165,13 @@ class DFlexScrollContainer {
     this._scrollEventCallback = null;
 
     const [containerDOM, isDocumentContainer] = getScrollContainer(firstELmDOM);
-    this.containerDOM = containerDOM;
-    this.isDocumentContainer = isDocumentContainer;
+    this._containerDOM = containerDOM;
+    this._isDocumentContainer = isDocumentContainer;
 
     this._updateScrollRect();
     this._updateScrollPosition(
-      this.containerDOM.scrollLeft,
-      this.containerDOM.scrollTop,
+      this._containerDOM.scrollLeft,
+      this._containerDOM.scrollTop,
       false
     );
     this._updateOverflowStatus();
@@ -239,7 +239,7 @@ class DFlexScrollContainer {
       scrollTop, // Vertical scroll position
       clientHeight, // Height of the visible portion of the container
       clientWidth, // Width of the visible portion of the container
-    } = this.containerDOM;
+    } = this._containerDOM;
 
     this.totalScrollRect.setByPointAndDimensions(
       scrollTop,
@@ -249,7 +249,7 @@ class DFlexScrollContainer {
     );
 
     // Calculate the visible portion of the container
-    if (this.isDocumentContainer) {
+    if (this._isDocumentContainer) {
       // For document container, the visible area is the entire client viewport
       this.visibleScrollRect.setByPointAndDimensions(
         0,
@@ -258,7 +258,7 @@ class DFlexScrollContainer {
         clientWidth
       );
     } else {
-      const { left, top } = this.containerDOM.getBoundingClientRect();
+      const { left, top } = this._containerDOM.getBoundingClientRect();
 
       this.visibleScrollRect.setByPointAndDimensions(
         top,
@@ -286,8 +286,8 @@ class DFlexScrollContainer {
     this.totalScrollRect.setPosition(scrollLeft, scrollTop);
 
     if (withDOM) {
-      this.containerDOM.scrollTop = scrollTop;
-      this.containerDOM.scrollLeft = scrollLeft;
+      this._containerDOM.scrollTop = scrollTop;
+      this._containerDOM.scrollLeft = scrollLeft;
     }
 
     return true;
@@ -337,9 +337,9 @@ class DFlexScrollContainer {
   ): void {
     const datasetKey = this._listenerDatasetKey;
     const datasetValue = hasScrollListener.toString();
-    const targetElement = this.isDocumentContainer
+    const targetElement = this._isDocumentContainer
       ? document.body
-      : this.containerDOM;
+      : this._containerDOM;
 
     if (isAttachListener) {
       targetElement.dataset[datasetKey] = datasetValue;
@@ -349,7 +349,7 @@ class DFlexScrollContainer {
   }
 
   private _throttledScrollHandler = eventDebounce(() => {
-    const { scrollLeft, scrollTop } = this.containerDOM;
+    const { scrollLeft, scrollTop } = this._containerDOM;
 
     const isUpdated = this._updateScrollPosition(scrollLeft, scrollTop, false);
 
@@ -369,7 +369,7 @@ class DFlexScrollContainer {
       ? "addEventListener"
       : "removeEventListener";
 
-    const container = this.isDocumentContainer ? window : this.containerDOM;
+    const container = this._isDocumentContainer ? window : this._containerDOM;
 
     const options = { passive: true };
 
@@ -379,7 +379,7 @@ class DFlexScrollContainer {
       container[eventAction]("scroll", this._throttledScrollHandler, options);
 
       this._updateDOMDataset(isAttachListener, true);
-    } else if (!this.isDocumentContainer) {
+    } else if (!this._isDocumentContainer) {
       this._updateDOMDataset(isAttachListener, false);
     }
   }
@@ -515,7 +515,7 @@ class DFlexScrollContainer {
       version: 3,
       key: this._SK,
       hasOverFlow: this.hasOverflow.getInstance(),
-      hasDocumentAsContainer: this.isDocumentContainer,
+      hasDocumentAsContainer: this._isDocumentContainer,
       scrollRect: this.totalScrollRect.getBox(),
       scrollContainerRect: this.visibleScrollRect.getBox(),
       visibleScreen: this._getVisibleScreen(),
@@ -530,7 +530,7 @@ class DFlexScrollContainer {
     this._scrollEventCallback = null;
     this._attachResizeAndScrollListeners(false);
     // @ts-expect-error
-    this.containerDOM = null;
+    this._containerDOM = null;
   }
 }
 

--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -40,36 +40,30 @@ function isStaticallyPositioned(DOM: Element): boolean {
 function getScrollContainer(baseDOMElm: HTMLElement): [HTMLElement, boolean] {
   let hasDocumentAsContainer = false;
 
-  const baseComputedStyle = getElmComputedStyle(baseDOMElm);
-  const baseELmPosition = baseComputedStyle.getPropertyValue("position");
+  const { position: baseELmPosition } = getElmComputedStyle(baseDOMElm);
   const excludeStaticParents = baseELmPosition === "absolute";
 
   const scrollContainerDOM = getParentElm(baseDOMElm, (parentDOM) => {
+    const { overflowX, overflowY } = getElmComputedStyle(parentDOM);
+    const parentRect = parentDOM.getBoundingClientRect();
+
     if (excludeStaticParents && isStaticallyPositioned(parentDOM)) {
       return false;
     }
 
-    const parentComputedStyle = getElmComputedStyle(parentDOM);
-
-    const parentRect = parentDOM.getBoundingClientRect();
-
-    const overflowY = parentComputedStyle.getPropertyValue("overflow-y");
-
-    if (OVERFLOW_REGEX.test(overflowY)) {
-      if (parentDOM.scrollHeight === Math.round(parentRect.height)) {
-        hasDocumentAsContainer = true;
-      }
-
+    if (
+      OVERFLOW_REGEX.test(overflowY) &&
+      parentDOM.scrollHeight === Math.round(parentRect.height)
+    ) {
+      hasDocumentAsContainer = true;
       return true;
     }
 
-    const overflowX = parentComputedStyle.getPropertyValue("overflow-x");
-
-    if (OVERFLOW_REGEX.test(overflowX)) {
-      if (parentDOM.scrollWidth === Math.round(parentRect.width)) {
-        hasDocumentAsContainer = true;
-      }
-
+    if (
+      OVERFLOW_REGEX.test(overflowX) &&
+      parentDOM.scrollWidth === Math.round(parentRect.width)
+    ) {
+      hasDocumentAsContainer = true;
       return true;
     }
 
@@ -81,12 +75,10 @@ function getScrollContainer(baseDOMElm: HTMLElement): [HTMLElement, boolean] {
     baseELmPosition === "fixed" ||
     !scrollContainerDOM
   ) {
-    hasDocumentAsContainer = true;
-
     return [document.documentElement, true];
   }
 
-  return [scrollContainerDOM, hasDocumentAsContainer];
+  return [scrollContainerDOM, false];
 }
 
 function widthOrHeight(direction: "x" | "y"): "width" | "height" {

--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -181,7 +181,7 @@ class DFlexScrollContainer {
 
   isDocumentContainer!: boolean;
 
-  private _listenerDataset: string;
+  private _listenerDatasetKey: string;
 
   static getType(): string {
     return "scroll:container";
@@ -196,7 +196,7 @@ class DFlexScrollContainer {
     this._SK = SK;
     this._threshold_inner_key = `scroll_inner_${SK}`;
     this._threshold_outer_key = `scroll_outer_${SK}`;
-    this._listenerDataset = `dflexScrollListener_${SK}`;
+    this._listenerDatasetKey = `dflexScrollListener_${SK}`;
 
     this.hasOverflow = new PointBool(false, false);
     this.totalScrollRect = new BoxRect(0, 0, 0, 0);
@@ -234,7 +234,7 @@ class DFlexScrollContainer {
     this._attachResizeAndScrollListeners();
 
     if (this.totalScrollRect.top > 0 || this.totalScrollRect.left > 0) {
-      this.scrollTo(0, 0);
+      this._updateScrollPosition(0, 0, true);
     }
   }
 
@@ -377,7 +377,7 @@ class DFlexScrollContainer {
     isAttachListener: boolean,
     hasScrollListener: boolean
   ): void {
-    const datasetKey = this._listenerDataset;
+    const datasetKey = this._listenerDatasetKey;
     const datasetValue = hasScrollListener.toString();
     const targetElement = this.isDocumentContainer
       ? document.body

--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -471,30 +471,36 @@ class DFlexScrollContainer {
     return top + height + this.totalScrollRect.top;
   }
 
-  getElmPositionInViewport(topPos: number, leftPos: number): [number, number] {
-    const { top, left } = this.totalScrollRect;
+  getElmViewportPosition(
+    elmTopPos: number,
+    elmLeftPos: number
+  ): [number, number] {
+    const { top: totalScrollTop, left: totalScrollLeft } = this.totalScrollRect;
 
-    return [topPos - top, leftPos - left];
+    const viewportTop = elmTopPos - totalScrollTop;
+    const viewportLeft = elmLeftPos - totalScrollLeft;
+
+    return [viewportTop, viewportLeft];
   }
 
-  isElmVisibleViewport(
+  isElementInViewport(
     topPos: number,
     leftPos: number,
     height: number,
     width: number
   ): boolean {
-    const [top, left] = this.getElmPositionInViewport(topPos, leftPos);
-
-    const currentTopWithScroll = top;
-    const currentLeftWithScroll = left;
+    const [viewportTop, viewportLeft] = this.getElmViewportPosition(
+      topPos,
+      leftPos
+    );
 
     const isOutThreshold =
       this._outerThresholdInViewport!.isShallowOutThreshold(
         this._threshold_outer_key,
-        currentTopWithScroll,
-        currentLeftWithScroll + width,
-        currentTopWithScroll + height,
-        currentLeftWithScroll
+        viewportTop,
+        viewportLeft + width,
+        viewportTop + height,
+        viewportLeft
       );
 
     return !isOutThreshold;

--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -9,6 +9,7 @@ import {
   getParentElm,
   PointBool,
   Threshold,
+  getElmComputedStyle,
 } from "@dflex/utils";
 
 import type { ThresholdPercentages, AbstractBox } from "@dflex/utils";
@@ -31,7 +32,7 @@ export type DFlexSerializedScroll = {
 const OVERFLOW_REGEX = /(auto|scroll|overlay)/;
 
 function isStaticallyPositioned(DOM: Element): boolean {
-  const computedStyle = getComputedStyle(DOM);
+  const computedStyle = getElmComputedStyle(DOM);
   const position = computedStyle.getPropertyValue("position");
   return position === "static";
 }
@@ -39,7 +40,7 @@ function isStaticallyPositioned(DOM: Element): boolean {
 function getScrollContainer(baseDOMElm: HTMLElement): [HTMLElement, boolean] {
   let hasDocumentAsContainer = false;
 
-  const baseComputedStyle = getComputedStyle(baseDOMElm);
+  const baseComputedStyle = getElmComputedStyle(baseDOMElm);
   const baseELmPosition = baseComputedStyle.getPropertyValue("position");
   const excludeStaticParents = baseELmPosition === "absolute";
 
@@ -48,7 +49,7 @@ function getScrollContainer(baseDOMElm: HTMLElement): [HTMLElement, boolean] {
       return false;
     }
 
-    const parentComputedStyle = getComputedStyle(parentDOM);
+    const parentComputedStyle = getElmComputedStyle(parentDOM);
 
     const parentRect = parentDOM.getBoundingClientRect();
 

--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -4,7 +4,6 @@ import {
   Axis,
   Dimensions,
   Direction,
-  BoxNum,
   BoxRect,
   getParentElm,
   PointBool,
@@ -26,7 +25,6 @@ export type DFlexSerializedScroll = {
   hasDocumentAsContainer: boolean;
   scrollRect: AbstractBox;
   scrollContainerRect: AbstractBox;
-  invisibleDistance: AbstractBox;
   visibleScreen: Dimensions;
 };
 
@@ -94,6 +92,49 @@ function hasOverFlow(
   return scrollRect[dimension] / threshold > scrollContainerRect[dimension];
 }
 
+type ThrottledListener = () => void;
+
+interface AnimatedThrottleControl extends ThrottledListener {
+  isPaused: () => boolean;
+  pause: () => void;
+  resume: () => void;
+}
+
+function animatedThrottle(listener: () => void): AnimatedThrottleControl {
+  let hasThrottledFrame: number | null = null;
+  let isPaused = false;
+
+  const throttledListener: AnimatedThrottleControl = () => {
+    if (hasThrottledFrame !== null) {
+      cancelAnimationFrame(hasThrottledFrame);
+    }
+
+    if (isPaused) {
+      return;
+    }
+
+    hasThrottledFrame = requestAnimationFrame(() => {
+      listener();
+      hasThrottledFrame = null;
+    });
+  };
+
+  throttledListener.isPaused = () => isPaused;
+
+  throttledListener.pause = () => {
+    isPaused = true;
+  };
+
+  throttledListener.resume = () => {
+    if (isPaused) {
+      isPaused = false;
+      throttledListener();
+    }
+  };
+
+  return throttledListener;
+}
+
 const MAX_NUM_OF_SIBLINGS_BEFORE_DYNAMIC_VISIBILITY = 10;
 
 const OUTER_THRESHOLD: ThresholdPercentages = {
@@ -117,14 +158,12 @@ class DFlexScrollContainer {
   /**
    * scroll container in the viewport. Only in the visible area.
    */
-  scrollContainerRect: BoxRect;
+  visibleScrollRect: BoxRect;
 
   /**
    * The entire scroll rect visible and invisible.
    */
-  scrollRect: BoxRect;
-
-  invisibleDistance: BoxNum;
+  totalScrollRect: BoxRect;
 
   hasOverflow: PointBool;
 
@@ -138,11 +177,9 @@ class DFlexScrollContainer {
   /**
    * The parent element that is owning the scroll.
    */
-  scrollContainerDOM!: HTMLElement;
+  containerDOM!: HTMLElement;
 
-  private _hasThrottledFrame: number | null;
-
-  hasDocumentAsContainer!: boolean;
+  isDocumentContainer!: boolean;
 
   private _listenerDataset: string;
 
@@ -156,82 +193,116 @@ class DFlexScrollContainer {
     branchLength: number,
     scrollEventCallback: ScrollEventCallback
   ) {
-    this.hasOverflow = new PointBool(false, false);
-    this.invisibleDistance = new BoxNum(0, 0, 0, 0);
-    this.scrollRect = new BoxRect(0, 0, 0, 0);
-    this.scrollContainerRect = new BoxRect(0, 0, 0, 0);
-
-    this.allowDynamicVisibility = false;
-    this._innerThresholdInViewport = null;
-    this._outerThresholdInViewport = null;
     this._SK = SK;
     this._threshold_inner_key = `scroll_inner_${SK}`;
     this._threshold_outer_key = `scroll_outer_${SK}`;
     this._listenerDataset = `dflexScrollListener_${SK}`;
 
-    this._hasThrottledFrame = null;
-
+    this.hasOverflow = new PointBool(false, false);
+    this.totalScrollRect = new BoxRect(0, 0, 0, 0);
+    this.visibleScrollRect = new BoxRect(0, 0, 0, 0);
+    this.allowDynamicVisibility = false;
+    this._innerThresholdInViewport = null;
+    this._outerThresholdInViewport = null;
     this._scrollEventCallback = null;
 
-    [this.scrollContainerDOM, this.hasDocumentAsContainer] =
-      getScrollContainer(firstELmDOM);
+    const [containerDOM, isDocumentContainer] = getScrollContainer(firstELmDOM);
+    this.containerDOM = containerDOM;
+    this.isDocumentContainer = isDocumentContainer;
 
-    this._setScrollRect();
+    this._updateScrollRect();
+    this._updateScrollPosition(
+      this.containerDOM.scrollLeft,
+      this.containerDOM.scrollTop,
+      false
+    );
+    this._updateOverflowStatus();
 
-    const { scrollLeft, scrollTop } = this.scrollContainerDOM;
-
-    this._updateInvisibleDistance(scrollLeft, scrollTop, false);
-
-    this._setOverflow();
-
-    // Check allowDynamicVisibility after taking into consideration the length of
-    // the branch itself.
-    if (branchLength > MAX_NUM_OF_SIBLINGS_BEFORE_DYNAMIC_VISIBILITY) {
-      if (this.allowDynamicVisibility) {
-        this._scrollEventCallback = scrollEventCallback;
-
-        this._outerThresholdInViewport = new Threshold(OUTER_THRESHOLD);
-
-        this._outerThresholdInViewport.setMainThreshold(
-          this._threshold_outer_key,
-          this.scrollContainerRect,
-          false
-        );
-      }
+    if (
+      branchLength > MAX_NUM_OF_SIBLINGS_BEFORE_DYNAMIC_VISIBILITY &&
+      this.allowDynamicVisibility
+    ) {
+      this._scrollEventCallback = scrollEventCallback;
+      this._outerThresholdInViewport = new Threshold(OUTER_THRESHOLD);
+      this._outerThresholdInViewport.setMainThreshold(
+        this._threshold_outer_key,
+        this.visibleScrollRect,
+        false
+      );
     }
 
-    this._setResizeAndScrollListeners();
+    this._attachResizeAndScrollListeners();
 
-    if (true && (this.scrollRect.top > 0 || this.scrollRect.left > 0)) {
-      // Scroll without callback.
-      this.scrollTo(0, 0, false);
+    if (this.totalScrollRect.top > 0 || this.totalScrollRect.left > 0) {
+      this.scrollTo(0, 0);
     }
   }
 
-  private _setScrollRect(): void {
-    const { scrollHeight, scrollWidth, scrollLeft, scrollTop } =
-      this.scrollContainerDOM;
+  private _updateOverflowStatus(): void {
+    const checkOverflow = (axis: Axis, checkHalf?: boolean) =>
+      hasOverFlow(
+        this.totalScrollRect,
+        this.visibleScrollRect,
+        axis,
+        checkHalf
+      );
 
-    this.scrollRect.setByPointAndDimensions(
+    const hasOverflowX = checkOverflow("x");
+    const hasOverflowY = checkOverflow("y");
+
+    this.hasOverflow.setAxes(hasOverflowX, hasOverflowY);
+    this.allowDynamicVisibility = false;
+
+    if (hasOverflowY) {
+      // Check if the scrollRect dimension for the given axis is more than half of the scrollContainerRect dimension.
+      this.allowDynamicVisibility = checkOverflow("y", true);
+
+      return;
+    }
+
+    if (hasOverflowX) {
+      // Check if the scrollRect dimension for the given axis is more than half of the scrollContainerRect dimension.
+      this.allowDynamicVisibility = checkOverflow("x", true);
+    }
+  }
+
+  /**
+   * Updates the scroll-related rectangles based on the container's dimensions and scroll positions.
+   * - Updates the overall scroll rectangle representing the entire scrollable content.
+   * - Calculates the visible scroll rectangle representing the visible portion of the container.
+   *   For document containers, it represents the entire client viewport.
+   *   For non-document containers, it takes into account the container's position.
+   */
+  private _updateScrollRect(): void {
+    const {
+      scrollHeight, // Total height of the scrollable content
+      scrollWidth, // Total width of the scrollable content
+      scrollLeft, // Horizontal scroll position
+      scrollTop, // Vertical scroll position
+      clientHeight, // Height of the visible portion of the container
+      clientWidth, // Width of the visible portion of the container
+    } = this.containerDOM;
+
+    this.totalScrollRect.setByPointAndDimensions(
       scrollTop,
       scrollLeft,
       scrollHeight,
       scrollWidth
     );
 
-    const { clientHeight, clientWidth } = this.scrollContainerDOM;
+    // Calculate the visible portion of the container
+    if (this.isDocumentContainer) {
+      // For document container, the visible area is the entire client viewport
+      this.visibleScrollRect.setByPointAndDimensions(
+        0,
+        0,
+        clientHeight,
+        clientWidth
+      );
+    } else {
+      const { left, top } = this.containerDOM.getBoundingClientRect();
 
-    this.scrollContainerRect.setByPointAndDimensions(
-      0,
-      0,
-      clientHeight,
-      clientWidth
-    );
-
-    if (!this.hasDocumentAsContainer) {
-      const { left, top } = this.scrollContainerDOM.getBoundingClientRect();
-
-      this.scrollContainerRect.setByPointAndDimensions(
+      this.visibleScrollRect.setByPointAndDimensions(
         top,
         left,
         clientHeight,
@@ -240,84 +311,36 @@ class DFlexScrollContainer {
     }
   }
 
-  private _setOverflow(): void {
-    this.hasOverflow.setAxes(
-      hasOverFlow(this.scrollRect, this.scrollContainerRect, "x"),
-      hasOverFlow(this.scrollRect, this.scrollContainerRect, "y")
+  private _updateScrollPosition(
+    scrollLeft: number,
+    scrollTop: number,
+    withDOM: boolean
+  ): boolean {
+    const shouldUpdate = this.totalScrollRect.hasEqualPosition(
+      scrollLeft,
+      scrollTop
     );
 
-    this.allowDynamicVisibility = false;
-
-    if (
-      this.hasOverflow.y &&
-      hasOverFlow(this.scrollRect, this.scrollContainerRect, "y", true)
-    ) {
-      this.allowDynamicVisibility = true;
-
-      return;
-    }
-
-    if (
-      this.hasOverflow.x &&
-      hasOverFlow(this.scrollRect, this.scrollContainerRect, "x", true)
-    ) {
-      this.allowDynamicVisibility = true;
-    }
-  }
-
-  private _updateScrollCoordinates(): boolean {
-    const { scrollLeft, scrollTop } = this.scrollContainerDOM;
-
-    const isUpdated =
-      scrollTop !== this.scrollRect.top || scrollLeft !== this.scrollRect.left;
-
-    if (!isUpdated) {
+    if (!shouldUpdate) {
       return false;
     }
 
-    this._updateInvisibleDistance(scrollLeft, scrollTop, false);
+    this.totalScrollRect.setPosition(scrollLeft, scrollTop);
 
-    return isUpdated;
+    if (withDOM) {
+      this.containerDOM.scrollTop = scrollTop;
+      this.containerDOM.scrollLeft = scrollLeft;
+    }
+
+    return true;
   }
 
-  /**
-   * When the scroll container is scrolling, the invisible distance is updated
-   * with synthetic values instead of DOM listener values.
-   *
-   * One way binding, because when the scroll container is scrolled then the
-   * is not dragging anymore.
-   *
-   * @param scrollLeft
-   * @param scrollTop
-   */
-  private _updateInvisibleDistance(
-    scrollLeft: number,
-    scrollTop: number,
-    triggerScrollEventCallback: boolean
-  ): void {
-    this.scrollRect.top = scrollTop;
-    this.scrollRect.left = scrollLeft;
+  scrollTo(x: number, y: number): void {
+    this._updateScrollPosition(x, y, true);
 
-    const invisibleYTop = this.scrollRect.height - scrollTop;
-    const invisibleXLeft = this.scrollRect.width - scrollLeft;
-
-    this.invisibleDistance.setBox(
-      scrollTop,
-      invisibleXLeft - this.scrollContainerRect.width,
-      invisibleYTop - this.scrollContainerRect.height,
-      scrollLeft
-    );
-
-    if (triggerScrollEventCallback && this._scrollEventCallback !== null) {
+    if (this._scrollEventCallback) {
       this._scrollEventCallback(this._SK);
     }
-  }
-
-  scrollTo(x: number, y: number, triggerScrollEventCallback: boolean): void {
-    this._updateInvisibleDistance(x, y, triggerScrollEventCallback);
-
-    this.scrollContainerDOM.scrollTop = y;
-    this.scrollContainerDOM.scrollLeft = x;
   }
 
   /**
@@ -326,53 +349,82 @@ class DFlexScrollContainer {
    * @param direction
    * @returns
    */
-  hasInvisibleSpace(axis: Axis, direction: Direction): boolean {
-    const val = this.invisibleDistance.getOne(axis, direction);
+  hasScrollableArea(axis: Axis, direction: Direction): boolean {
+    if (!this.hasOverflow[axis]) {
+      return false;
+    }
 
-    // TODO: replace zero with container plus dragged distance boundaries.
-    return val > 0;
+    const scrollRect =
+      axis === "x" ? this.totalScrollRect.width : this.totalScrollRect.height;
+
+    const visibleRect =
+      axis === "x"
+        ? this.visibleScrollRect.width
+        : this.visibleScrollRect.height;
+
+    if (direction === 1) {
+      return scrollRect - visibleRect > 0;
+    }
+
+    if (direction === -1) {
+      return visibleRect > 0;
+    }
+
+    return false;
   }
 
-  private _tagDOMString(
+  private _updateDOMDataset(
     isAttachListener: boolean,
     hasScrollListener: boolean
   ): void {
-    const elmHoldDataset = this.hasDocumentAsContainer
+    const datasetKey = this._listenerDataset;
+    const datasetValue = hasScrollListener.toString();
+    const targetElement = this.isDocumentContainer
       ? document.body
-      : this.scrollContainerDOM;
+      : this.containerDOM;
 
     if (isAttachListener) {
-      elmHoldDataset.dataset[this._listenerDataset] = `${hasScrollListener}`;
+      targetElement.dataset[datasetKey] = datasetValue;
     } else {
-      delete elmHoldDataset.dataset[this._listenerDataset];
+      delete targetElement.dataset[datasetKey];
     }
   }
 
-  private _setResizeAndScrollListeners(isAttachListener = true): void {
+  private _throttledScrollHandler = animatedThrottle(() => {
+    const { scrollLeft, scrollTop } = this.containerDOM;
+
+    const isUpdated = this._updateScrollPosition(scrollLeft, scrollTop, false);
+
+    if (isUpdated && this._scrollEventCallback) {
+      this._scrollEventCallback(this._SK);
+    }
+  });
+
+  private _throttledResizeHandler() {
+    animatedThrottle(this._updateScrollRect);
+  }
+
+  private _attachResizeAndScrollListeners(isAttachListener = true): void {
     /**
      * No need to set scroll listener if there is no scroll.
      */
 
-    const type = isAttachListener ? "addEventListener" : "removeEventListener";
+    const eventAction = isAttachListener
+      ? "addEventListener"
+      : "removeEventListener";
 
-    const container = this.hasDocumentAsContainer
-      ? window
-      : this.scrollContainerDOM;
+    const container = this.isDocumentContainer ? window : this.containerDOM;
 
-    const opts = { passive: true };
+    const options = { passive: true };
 
-    container[type]("resize", this.animatedResizeListener, opts);
+    container[eventAction]("resize", this._throttledResizeHandler, options);
 
     if (this.hasOverflow.isOneTruthy()) {
-      container[type]("scroll", this.animatedScrollListener, opts);
+      container[eventAction]("scroll", this._throttledScrollHandler, options);
 
-      this._tagDOMString(isAttachListener, true);
-
-      return;
-    }
-
-    if (!this.hasDocumentAsContainer) {
-      this._tagDOMString(isAttachListener, false);
+      this._updateDOMDataset(isAttachListener, true);
+    } else if (!this.isDocumentContainer) {
+      this._updateDOMDataset(isAttachListener, false);
     }
   }
 
@@ -384,14 +436,18 @@ class DFlexScrollContainer {
    * Note: when listener is off make sure you call `updateInvisibleDistance` to
    * keep the the container in sync with the scrollable instance.
    *
-   * @param pausePlease
+   * @param pause
    */
-  pauseListeners(pausePlease: boolean): void {
-    this._hasThrottledFrame = pausePlease ? 1 : null;
+  pauseListeners(pause: boolean): void {
+    if (pause) {
+      this._throttledScrollHandler.pause();
+    } else {
+      this._throttledScrollHandler.resume();
+    }
   }
 
-  private _garbageCollectInnerThreshold() {
-    if (this._innerThresholdInViewport !== null) {
+  private _clearInnerThreshold(): void {
+    if (this._innerThresholdInViewport) {
       this._innerThresholdInViewport.destroy();
       this._innerThresholdInViewport = null;
     }
@@ -407,13 +463,13 @@ class DFlexScrollContainer {
    * @param threshold
    */
   setInnerThreshold(threshold: ThresholdPercentages) {
-    this._garbageCollectInnerThreshold();
+    this._clearInnerThreshold();
 
     this._innerThresholdInViewport = new Threshold(threshold);
 
     this._innerThresholdInViewport.setMainThreshold(
       this._threshold_inner_key,
-      this.scrollContainerRect,
+      this.visibleScrollRect,
       true
     );
   }
@@ -425,7 +481,7 @@ class DFlexScrollContainer {
     endingPos: number
   ): boolean {
     const adjustToViewport =
-      axis === "y" ? this.scrollRect.top : this.scrollRect.left;
+      axis === "y" ? this.totalScrollRect.top : this.totalScrollRect.left;
 
     return (
       this.hasOverflow[axis] &&
@@ -444,9 +500,9 @@ class DFlexScrollContainer {
    * @returns
    */
   getMaximumScrollContainerLeft() {
-    const { left, width } = this.scrollContainerRect;
+    const { left, width } = this.visibleScrollRect;
 
-    return left + width + this.scrollRect.left;
+    return left + width + this.totalScrollRect.left;
   }
 
   /**
@@ -454,13 +510,13 @@ class DFlexScrollContainer {
    * @returns
    */
   getMaximumScrollContainerTop() {
-    const { top, height } = this.scrollContainerRect;
+    const { top, height } = this.visibleScrollRect;
 
-    return top + height + this.scrollRect.top;
+    return top + height + this.totalScrollRect.top;
   }
 
   getElmPositionInViewport(topPos: number, leftPos: number): [number, number] {
-    const { top, left } = this.scrollRect;
+    const { top, left } = this.totalScrollRect;
 
     return [topPos - top, leftPos - left];
   }
@@ -488,39 +544,8 @@ class DFlexScrollContainer {
     return !isOutThreshold;
   }
 
-  private _animatedListener(
-    listener: typeof this._setScrollRect | typeof this._updateScrollCoordinates,
-    cb: ScrollEventCallback | null
-  ) {
-    if (this._hasThrottledFrame !== null) {
-      cancelAnimationFrame(this._hasThrottledFrame);
-    }
-
-    this._hasThrottledFrame = requestAnimationFrame(() => {
-      const isUpdated = listener();
-
-      if (isUpdated && cb) {
-        cb(this._SK);
-      }
-
-      this._hasThrottledFrame = null;
-    });
-  }
-
-  private animatedScrollListener = () => {
-    this._animatedListener.call(
-      this,
-      this._updateScrollCoordinates.bind(this),
-      this._scrollEventCallback
-    );
-  };
-
-  private animatedResizeListener = () => {
-    this._animatedListener.call(this, this._setScrollRect.bind(this), null);
-  };
-
   private _getVisibleScreen(): Dimensions {
-    const { height, width } = this.scrollContainerRect;
+    const { height, width } = this.visibleScrollRect;
 
     return {
       height,
@@ -534,10 +559,9 @@ class DFlexScrollContainer {
       version: 3,
       key: this._SK,
       hasOverFlow: this.hasOverflow.getInstance(),
-      hasDocumentAsContainer: this.hasDocumentAsContainer,
-      scrollRect: this.scrollRect.getBox(),
-      scrollContainerRect: this.scrollContainerRect.getBox(),
-      invisibleDistance: this.invisibleDistance.getBox(),
+      hasDocumentAsContainer: this.isDocumentContainer,
+      scrollRect: this.totalScrollRect.getBox(),
+      scrollContainerRect: this.visibleScrollRect.getBox(),
       visibleScreen: this._getVisibleScreen(),
     };
   }
@@ -546,11 +570,11 @@ class DFlexScrollContainer {
    * Clean up the container instances.
    */
   destroy(): void {
-    this._garbageCollectInnerThreshold();
+    this._clearInnerThreshold();
     this._scrollEventCallback = null;
-    this._setResizeAndScrollListeners(false);
+    this._attachResizeAndScrollListeners(false);
     // @ts-expect-error
-    this.scrollContainerDOM = null;
+    this.containerDOM = null;
   }
 }
 

--- a/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
+++ b/packages/dflex-core-instance/src/Container/DFlexScrollContainer.ts
@@ -9,7 +9,7 @@ import {
   getParentElm,
   PointBool,
   Threshold,
-  getElmComputedStyle,
+  getCachedComputedStyle,
   getDimensionTypeByAxis,
 } from "@dflex/utils";
 
@@ -33,7 +33,7 @@ export type DFlexSerializedScroll = {
 const OVERFLOW_REGEX = /(auto|scroll|overlay)/;
 
 function isStaticallyPositioned(DOM: Element): boolean {
-  const computedStyle = getElmComputedStyle(DOM);
+  const computedStyle = getCachedComputedStyle(DOM);
   const position = computedStyle.getPropertyValue("position");
   return position === "static";
 }
@@ -41,11 +41,11 @@ function isStaticallyPositioned(DOM: Element): boolean {
 function getScrollContainer(baseDOMElm: HTMLElement): [HTMLElement, boolean] {
   let hasDocumentAsContainer = false;
 
-  const { position: baseELmPosition } = getElmComputedStyle(baseDOMElm);
+  const { position: baseELmPosition } = getCachedComputedStyle(baseDOMElm);
   const excludeStaticParents = baseELmPosition === "absolute";
 
   const scrollContainerDOM = getParentElm(baseDOMElm, (parentDOM) => {
-    const { overflowX, overflowY } = getElmComputedStyle(parentDOM);
+    const { overflowX, overflowY } = getCachedComputedStyle(parentDOM);
     const parentRect = parentDOM.getBoundingClientRect();
 
     if (excludeStaticParents && isStaticallyPositioned(parentDOM)) {

--- a/packages/dflex-dnd-playground/cypress/e2e/same-container-vertical/extended/edgeCases/differentViewport.inOut1.cy.ts
+++ b/packages/dflex-dnd-playground/cypress/e2e/same-container-vertical/extended/edgeCases/differentViewport.inOut1.cy.ts
@@ -61,13 +61,25 @@ context(
       });
 
       it("Visible elements all are lifted up", () => {
+        const failedElementIds = [];
+
         for (let i = 91; i < 100; i += 1) {
-          cy.get(`#${i}-extended`).should(
-            "have.css",
-            "transform",
-            "matrix(1, 0, 0, 1, 0, -59.1875)"
-          );
+          cy.get(`#${i}-extended`).then(($el) => {
+            const transform = Cypress.$($el).css("transform");
+            const expectedTransform = "matrix(1, 0, 0, 1, 0, -59.1875)";
+
+            if (transform !== expectedTransform) {
+              failedElementIds.push(`#${i}-extended`);
+            }
+          });
         }
+
+        cy.wrap(failedElementIds).should((ids) => {
+          if (ids.length > 0) {
+            const failedElements = ids.join(", ");
+            throw new Error(`Assertion failed for elements: ${failedElements}`);
+          }
+        });
       });
 
       it("Release Dragged", () => {

--- a/packages/dflex-dnd-playground/cypress/e2e/same-container-vertical/extended/edgeCases/differentViewport.inOut1.cy.ts
+++ b/packages/dflex-dnd-playground/cypress/e2e/same-container-vertical/extended/edgeCases/differentViewport.inOut1.cy.ts
@@ -63,7 +63,7 @@ context(
       it("Visible elements all are lifted up", () => {
         const failedElementIds = [];
 
-        for (let i = 91; i < 100; i += 1) {
+        for (let i = 91; i < 99; i += 1) {
           cy.get(`#${i}-extended`).then(($el) => {
             const transform = Cypress.$($el).css("transform");
             const expectedTransform = "matrix(1, 0, 0, 1, 0, -59.1875)";

--- a/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
@@ -146,7 +146,7 @@ class DraggableInteractive extends DraggableAxes {
 
       const initPos = this.draggedElm.getInitialPosition();
 
-      const viewportPos = scroll.getElmPositionInViewport(initPos.y, initPos.x);
+      const viewportPos = scroll.getElmViewportPosition(initPos.y, initPos.x);
 
       this.setDOMAttrAndStyle(
         this.draggedDOM,

--- a/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
@@ -14,10 +14,21 @@ import type { ScrollOpts, FinalDndOpts, Commit } from "../types";
 import DraggableAxes from "./DraggableAxes";
 
 function throwIfElmIsEmpty(siblings: string[]) {
+  const maxLength = 10; // Maximum number of siblings to include in the error message
+
   if (siblings.some((item) => typeof item !== "string" || item.length === 0)) {
-    throw new Error(
-      `Siblings ${JSON.stringify(siblings)} contains empty string`
-    );
+    let errorMessage = "throwIfElmIsEmpty: Siblings contain empty string";
+
+    const validSiblings = siblings.filter((item) => typeof item === "string");
+    if (validSiblings.length > maxLength) {
+      const remainingSiblings = validSiblings.length - maxLength;
+      const displayedSiblings = validSiblings.slice(0, maxLength).join(", ");
+      errorMessage += `. Displaying first ${maxLength} siblings: ${displayedSiblings}, and ${remainingSiblings} more.`;
+    } else {
+      errorMessage += `: ${validSiblings.join(", ")}`;
+    }
+
+    throw new Error(errorMessage);
   }
 }
 

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
@@ -8,7 +8,7 @@ import {
   Dimensions,
   featureFlags,
   DFlexCycle,
-  clearComputedStyleMap,
+  clearComputedStyleCache,
   updateELmDOMGrid,
   setFixedDimensions,
 } from "@dflex/utils";
@@ -347,7 +347,7 @@ class DFlexDnDStore extends DFlexBaseStore {
 
     // Set a timeout to restore the styles after 100ms
     this._resizeTimeoutId = setTimeout(() => {
-      clearComputedStyleMap();
+      clearComputedStyleCache();
 
       this._forEachContainerDOM((DOM) => {
         setFixedDimensions(DOM);

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
@@ -190,23 +190,26 @@ class DFlexDnDStore extends DFlexBaseStore {
 
       if (siblings.length === 0 || !this.interactiveDOM.has(siblings[0])) {
         throw new Error(
-          `_initSiblings: Unable to find DOM element for branch ${siblings} at index: ${0}`
+          `_initSiblings: Unable to find DOM element for siblings ${JSON.stringify(
+            siblings
+          )} at index 0.`
         );
       }
     }
 
+    const firstELmDOM = this.interactiveDOM.get(siblings[0])!;
+
     const scroll = new DFlexScrollContainer(
-      this.interactiveDOM.get(siblings[0])!,
+      firstELmDOM,
       SK,
       siblings.length,
-      true,
       updateBranchVisibilityLinearly.bind(null, this)
     );
 
     if (this.scrolls.has(SK)) {
       if (__DEV__) {
         // eslint-disable-next-line no-console
-        console.warn(`_initSiblings: Scroll with key:${SK} already exists.`);
+        console.warn(`_initSiblings: Scroll with key ${SK} already exists.`);
       }
 
       this.scrolls.get(SK)!.destroy();

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
@@ -30,7 +30,7 @@ import initDFlexListeners, {
 
 import scheduler, { SchedulerOptions, UpdateFn } from "./DFlexScheduler";
 
-import updateBranchVisibilityLinearly from "./DFlexVisibilityUpdater";
+import updateSiblingsVisibilityLinearly from "./DFlexVisibilityUpdater";
 
 import {
   addObserver,
@@ -203,7 +203,7 @@ class DFlexDnDStore extends DFlexBaseStore {
       firstELmDOM,
       SK,
       siblings.length,
-      updateBranchVisibilityLinearly.bind(null, this)
+      updateSiblingsVisibilityLinearly.bind(null, this)
     );
 
     if (this.scrolls.has(SK)) {
@@ -238,7 +238,7 @@ class DFlexDnDStore extends DFlexBaseStore {
 
     siblings.forEach(initElmGrid);
 
-    updateBranchVisibilityLinearly(this, SK);
+    updateSiblingsVisibilityLinearly(this, SK);
   }
 
   _initObservers() {

--- a/packages/dflex-dnd/src/LayoutManager/DFlexVisibilityUpdater.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexVisibilityUpdater.ts
@@ -11,7 +11,7 @@ function updateElmVisibility(
 ): boolean {
   const { rect } = elm;
 
-  const isVisible = scroll.isElmVisibleViewport(
+  const isVisible = scroll.isElementInViewport(
     rect.top,
     rect.left,
     rect.height,

--- a/packages/dflex-dnd/src/Mechanism/DFlexScrollableElement.ts
+++ b/packages/dflex-dnd/src/Mechanism/DFlexScrollableElement.ts
@@ -63,8 +63,8 @@ class DFlexScrollableElement extends DFlexPositionUpdater {
     this._clearScrollAnimatedFrame = this._clearScrollAnimatedFrame.bind(this);
 
     const {
-      scrollRect: { left, top },
-      scrollContainerRect: { width, height },
+      totalScrollRect: { left, top },
+      visibleScrollRect: { width, height },
     } = store.scrolls.get(SK)!;
 
     this._scrollThrottleMS = Math.round(
@@ -166,8 +166,8 @@ class DFlexScrollableElement extends DFlexPositionUpdater {
     }
 
     const canScroll = (): boolean =>
-      (isOutV && scroll.hasInvisibleSpace("y", draggedDirV)) ||
-      (isOutH && scroll.hasInvisibleSpace("x", draggedDirH));
+      (isOutV && scroll.hasScrollableArea("y", draggedDirV)) ||
+      (isOutH && scroll.hasScrollableArea("x", draggedDirH));
 
     // If there's not scrollable area, we don't need to scroll.
     if (!canScroll()) {
@@ -179,8 +179,12 @@ class DFlexScrollableElement extends DFlexPositionUpdater {
     let startingTime: number;
     let prevTimestamp: number;
 
-    const EXECUTION_FRAME_RATE_MS_V = Math.round(scroll.scrollRect.height / 2);
-    const EXECUTION_FRAME_RATE_MS_H = Math.round(scroll.scrollRect.width / 2);
+    const EXECUTION_FRAME_RATE_MS_V = Math.round(
+      scroll.totalScrollRect.height / 2
+    );
+    const EXECUTION_FRAME_RATE_MS_H = Math.round(
+      scroll.totalScrollRect.width / 2
+    );
 
     const scrollAnimatedFrame = (timestamp: number) => {
       scroll.pauseListeners(true);
@@ -211,11 +215,7 @@ class DFlexScrollableElement extends DFlexPositionUpdater {
         // Increase scroll speed.
         this._lastScrollSpeed += Math.round(acc);
 
-        scroll.scrollTo(
-          this.currentScrollAxes.x,
-          this.currentScrollAxes.y,
-          true
-        );
+        scroll.scrollTo(this.currentScrollAxes.x, this.currentScrollAxes.y);
       }
 
       // Stop the animation after 2 seconds

--- a/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
+++ b/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
@@ -523,6 +523,7 @@ DFlexDnDStore {
       "_scrollEventCallback": null,
       "_threshold_inner_key": "scroll_inner_dflex_sk_0_0",
       "_threshold_outer_key": "scroll_outer_dflex_sk_0_0",
+      "_throttledResizeHandler": [Function],
       "_throttledScrollHandler": [Function],
       "allowDynamicVisibility": false,
       "containerDOM": <html>
@@ -602,6 +603,7 @@ DFlexDnDStore {
       "_scrollEventCallback": null,
       "_threshold_inner_key": "scroll_inner_dflex_sk_0_1",
       "_threshold_outer_key": "scroll_outer_dflex_sk_0_1",
+      "_throttledResizeHandler": [Function],
       "_throttledScrollHandler": [Function],
       "allowDynamicVisibility": false,
       "containerDOM": <html>

--- a/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
+++ b/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
@@ -517,16 +517,7 @@ DFlexDnDStore {
   "scrolls": Map {
     "dflex_sk_0_0" => DFlexScrollContainer {
       "_SK": "dflex_sk_0_0",
-      "_innerThresholdInViewport": null,
-      "_listenerDatasetKey": "dflexScrollListener_dflex_sk_0_0",
-      "_outerThresholdInViewport": null,
-      "_scrollEventCallback": null,
-      "_threshold_inner_key": "scroll_inner_dflex_sk_0_0",
-      "_threshold_outer_key": "scroll_outer_dflex_sk_0_0",
-      "_throttledResizeHandler": [Function],
-      "_throttledScrollHandler": [Function],
-      "allowDynamicVisibility": false,
-      "containerDOM": <html>
+      "_containerDOM": <html>
         <head />
         <body>
           <div>
@@ -573,11 +564,20 @@ DFlexDnDStore {
           </div>
         </body>
       </html>,
+      "_innerThresholdInViewport": null,
+      "_isDocumentContainer": true,
+      "_listenerDatasetKey": "dflexScrollListener_dflex_sk_0_0",
+      "_outerThresholdInViewport": null,
+      "_scrollEventCallback": null,
+      "_threshold_inner_key": "scroll_inner_dflex_sk_0_0",
+      "_threshold_outer_key": "scroll_outer_dflex_sk_0_0",
+      "_throttledResizeHandler": [Function],
+      "_throttledScrollHandler": [Function],
+      "allowDynamicVisibility": false,
       "hasOverflow": PointBool {
         "x": false,
         "y": false,
       },
-      "isDocumentContainer": true,
       "totalScrollRect": BoxRect {
         "bottom": 0,
         "height": 0,
@@ -597,16 +597,7 @@ DFlexDnDStore {
     },
     "dflex_sk_0_1" => DFlexScrollContainer {
       "_SK": "dflex_sk_0_1",
-      "_innerThresholdInViewport": null,
-      "_listenerDatasetKey": "dflexScrollListener_dflex_sk_0_1",
-      "_outerThresholdInViewport": null,
-      "_scrollEventCallback": null,
-      "_threshold_inner_key": "scroll_inner_dflex_sk_0_1",
-      "_threshold_outer_key": "scroll_outer_dflex_sk_0_1",
-      "_throttledResizeHandler": [Function],
-      "_throttledScrollHandler": [Function],
-      "allowDynamicVisibility": false,
-      "containerDOM": <html>
+      "_containerDOM": <html>
         <head />
         <body>
           <div>
@@ -653,11 +644,20 @@ DFlexDnDStore {
           </div>
         </body>
       </html>,
+      "_innerThresholdInViewport": null,
+      "_isDocumentContainer": true,
+      "_listenerDatasetKey": "dflexScrollListener_dflex_sk_0_1",
+      "_outerThresholdInViewport": null,
+      "_scrollEventCallback": null,
+      "_threshold_inner_key": "scroll_inner_dflex_sk_0_1",
+      "_threshold_outer_key": "scroll_outer_dflex_sk_0_1",
+      "_throttledResizeHandler": [Function],
+      "_throttledScrollHandler": [Function],
+      "allowDynamicVisibility": false,
       "hasOverflow": PointBool {
         "x": false,
         "y": false,
       },
-      "isDocumentContainer": true,
       "totalScrollRect": BoxRect {
         "bottom": 0,
         "height": 0,

--- a/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
+++ b/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
@@ -517,28 +517,15 @@ DFlexDnDStore {
   "scrolls": Map {
     "dflex_sk_0_0" => DFlexScrollContainer {
       "_SK": "dflex_sk_0_0",
-      "_hasThrottledFrame": null,
       "_innerThresholdInViewport": null,
-      "_listenerDataset": "dflexScrollListener_dflex_sk_0_0",
+      "_listenerDatasetKey": "dflexScrollListener_dflex_sk_0_0",
       "_outerThresholdInViewport": null,
       "_scrollEventCallback": null,
       "_threshold_inner_key": "scroll_inner_dflex_sk_0_0",
       "_threshold_outer_key": "scroll_outer_dflex_sk_0_0",
+      "_throttledScrollHandler": [Function],
       "allowDynamicVisibility": false,
-      "animatedResizeListener": [Function],
-      "animatedScrollListener": [Function],
-      "hasDocumentAsContainer": true,
-      "hasOverflow": PointBool {
-        "x": false,
-        "y": false,
-      },
-      "invisibleDistance": BoxNum {
-        "bottom": 0,
-        "left": 0,
-        "right": 0,
-        "top": 0,
-      },
-      "scrollContainerDOM": <html>
+      "containerDOM": <html>
         <head />
         <body>
           <div>
@@ -585,7 +572,12 @@ DFlexDnDStore {
           </div>
         </body>
       </html>,
-      "scrollContainerRect": BoxRect {
+      "hasOverflow": PointBool {
+        "x": false,
+        "y": false,
+      },
+      "isDocumentContainer": true,
+      "totalScrollRect": BoxRect {
         "bottom": 0,
         "height": 0,
         "left": 0,
@@ -593,7 +585,7 @@ DFlexDnDStore {
         "top": 0,
         "width": 0,
       },
-      "scrollRect": BoxRect {
+      "visibleScrollRect": BoxRect {
         "bottom": 0,
         "height": 0,
         "left": 0,
@@ -604,28 +596,15 @@ DFlexDnDStore {
     },
     "dflex_sk_0_1" => DFlexScrollContainer {
       "_SK": "dflex_sk_0_1",
-      "_hasThrottledFrame": null,
       "_innerThresholdInViewport": null,
-      "_listenerDataset": "dflexScrollListener_dflex_sk_0_1",
+      "_listenerDatasetKey": "dflexScrollListener_dflex_sk_0_1",
       "_outerThresholdInViewport": null,
       "_scrollEventCallback": null,
       "_threshold_inner_key": "scroll_inner_dflex_sk_0_1",
       "_threshold_outer_key": "scroll_outer_dflex_sk_0_1",
+      "_throttledScrollHandler": [Function],
       "allowDynamicVisibility": false,
-      "animatedResizeListener": [Function],
-      "animatedScrollListener": [Function],
-      "hasDocumentAsContainer": true,
-      "hasOverflow": PointBool {
-        "x": false,
-        "y": false,
-      },
-      "invisibleDistance": BoxNum {
-        "bottom": 0,
-        "left": 0,
-        "right": 0,
-        "top": 0,
-      },
-      "scrollContainerDOM": <html>
+      "containerDOM": <html>
         <head />
         <body>
           <div>
@@ -672,7 +651,12 @@ DFlexDnDStore {
           </div>
         </body>
       </html>,
-      "scrollContainerRect": BoxRect {
+      "hasOverflow": PointBool {
+        "x": false,
+        "y": false,
+      },
+      "isDocumentContainer": true,
+      "totalScrollRect": BoxRect {
         "bottom": 0,
         "height": 0,
         "left": 0,
@@ -680,7 +664,7 @@ DFlexDnDStore {
         "top": 0,
         "width": 0,
       },
-      "scrollRect": BoxRect {
+      "visibleScrollRect": BoxRect {
         "bottom": 0,
         "height": 0,
         "left": 0,

--- a/packages/dflex-utils/src/Box/Box.ts
+++ b/packages/dflex-utils/src/Box/Box.ts
@@ -116,6 +116,10 @@ class Box<T> extends AbstractBox<T> {
     this.left = x;
   }
 
+  hasEqualPosition(x: T, y: T): boolean {
+    return this.top === y || this.left === x;
+  }
+
   /**
    * Get starting point instance.
    *

--- a/packages/dflex-utils/src/FeatureFlags.ts
+++ b/packages/dflex-utils/src/FeatureFlags.ts
@@ -14,4 +14,4 @@ export const enableUndoSiblingsDebugger = false;
 
 export const enableRegisterDebugger = false;
 
-export const enableMechanismDebugger = true;
+export const enableMechanismDebugger = false;

--- a/packages/dflex-utils/src/collections/computedStyleUtils.ts
+++ b/packages/dflex-utils/src/collections/computedStyleUtils.ts
@@ -13,7 +13,7 @@ let computedStyleCache = new WeakMap<Element, CSSStyleDeclaration>();
  * @param DOM
  * @returns
  */
-function getElmComputedStyle(DOM: Element): CSSStyleDeclaration {
+function getCachedComputedStyle(DOM: Element): CSSStyleDeclaration {
   if (computedStyleCache.has(DOM)) {
     return computedStyleCache.get(DOM)!;
   }
@@ -38,7 +38,7 @@ const ERROR_INVALID_POSITION = (id: string, actual: string, expected: string) =>
   `setRelativePosition: Element ${id} must be positioned as relative. Found: ${actual}. Expected: ${expected}.`;
 
 function setRelativePosition(DOM: HTMLElement): void {
-  const computedStyle = getElmComputedStyle(DOM);
+  const computedStyle = getCachedComputedStyle(DOM);
 
   const position = computedStyle.getPropertyValue("position");
 
@@ -116,7 +116,7 @@ function getComputedDimension(
  * @returns
  */
 function getElmComputedDimensions(DOM: HTMLElement): Dimensions {
-  const computedStyle = getElmComputedStyle(DOM);
+  const computedStyle = getCachedComputedStyle(DOM);
 
   if (__DEV__) {
     const computedWidth = computedStyle.getPropertyValue("width");
@@ -155,7 +155,7 @@ function getElmMargin() {
 }
 
 export {
-  getElmComputedStyle,
+  getCachedComputedStyle,
   clearComputedStyleCache,
   setRelativePosition,
   setFixedDimensions,

--- a/packages/dflex-utils/src/collections/computedStyleUtils.ts
+++ b/packages/dflex-utils/src/collections/computedStyleUtils.ts
@@ -32,6 +32,11 @@ function clearComputedStyleCache() {
 const CSS_VAL_REGEX = /^([0-9]*\.[0-9]*|[0-9]*)(px)$/;
 const CSS_FORBIDDEN_POSITION_REGEX = /absolute|fixed/;
 
+const EXPECTED_POS = "relative";
+
+const ERROR_INVALID_POSITION = (id: string, actual: string, expected: string) =>
+  `setRelativePosition: Element ${id} must be positioned as relative. Found: ${actual}. Expected: ${expected}.`;
+
 function setRelativePosition(DOM: HTMLElement): void {
   const computedStyle = getElmComputedStyle(DOM);
 
@@ -39,12 +44,10 @@ function setRelativePosition(DOM: HTMLElement): void {
 
   if (CSS_FORBIDDEN_POSITION_REGEX.test(position)) {
     if (__DEV__) {
-      throw new Error(
-        `Containers must be positioned as relative. Received: ${position}. Element: ${DOM.id}.`
-      );
+      throw new Error(ERROR_INVALID_POSITION(DOM.id, position, EXPECTED_POS));
     }
 
-    DOM.style.position = "relative";
+    DOM.style.position = EXPECTED_POS;
   }
 }
 

--- a/packages/dflex-utils/src/collections/computedStyleUtils.ts
+++ b/packages/dflex-utils/src/collections/computedStyleUtils.ts
@@ -5,7 +5,7 @@ import type { Dimensions } from "../types";
 import warnOnce from "./warnOnce";
 import * as CSSPropNames from "./constants";
 
-let computedStyleMap = new WeakMap<HTMLElement, CSSStyleDeclaration>();
+let computedStyleCache = new WeakMap<Element, CSSStyleDeclaration>();
 
 /**
  * Gets cached computed style if available.
@@ -13,20 +13,20 @@ let computedStyleMap = new WeakMap<HTMLElement, CSSStyleDeclaration>();
  * @param DOM
  * @returns
  */
-function getElmComputedStyle(DOM: HTMLElement): CSSStyleDeclaration {
-  if (computedStyleMap.has(DOM)) {
-    return computedStyleMap.get(DOM)!;
+function getElmComputedStyle(DOM: Element): CSSStyleDeclaration {
+  if (computedStyleCache.has(DOM)) {
+    return computedStyleCache.get(DOM)!;
   }
 
   const computedStyle = getComputedStyle(DOM);
 
-  computedStyleMap.set(DOM, computedStyle);
+  computedStyleCache.set(DOM, computedStyle);
 
   return computedStyle;
 }
 
-function clearComputedStyleMap() {
-  computedStyleMap = new WeakMap();
+function clearComputedStyleCache() {
+  computedStyleCache = new WeakMap();
 }
 
 const CSS_VAL_REGEX = /^([0-9]*\.[0-9]*|[0-9]*)(px)$/;
@@ -153,7 +153,7 @@ function getElmMargin() {
 
 export {
   getElmComputedStyle,
-  clearComputedStyleMap,
+  clearComputedStyleCache,
   setRelativePosition,
   setFixedDimensions,
   getElmComputedDimensions,

--- a/packages/dflex-utils/src/collections/index.ts
+++ b/packages/dflex-utils/src/collections/index.ts
@@ -8,7 +8,7 @@ export {
 } from "./getRectTypeByAxis";
 
 export {
-  getElmComputedStyle,
+  getCachedComputedStyle,
   clearComputedStyleCache,
   setRelativePosition,
   setFixedDimensions,

--- a/packages/dflex-utils/src/collections/index.ts
+++ b/packages/dflex-utils/src/collections/index.ts
@@ -9,7 +9,7 @@ export {
 
 export {
   getElmComputedStyle,
-  clearComputedStyleMap,
+  clearComputedStyleCache,
   setRelativePosition,
   setFixedDimensions,
   getElmComputedDimensions,

--- a/packages/dflex-utils/src/dom/getParentElm.ts
+++ b/packages/dflex-utils/src/dom/getParentElm.ts
@@ -16,8 +16,9 @@ function getParentElm(
       if (__DEV__) {
         if (iterationCounter > MAX_LOOP_ELEMENTS_TO_WARN) {
           throw new Error(
-            `getParentElm: DFlex detects performance issues during iterating for nearest parent element.` +
-              `Please check your registered interactive element at id:${baseElement.id}.`
+            `getParentElm: DFlex detected performance issues while iterating to find the nearest parent element. ` +
+              `The element with ID ${baseElement.id} may have an excessive number of ancestors. ` +
+              `Iteration count: ${iterationCounter}.`
           );
         }
       }

--- a/packages/dflex-utils/src/eventDebounce/eventDebounce.ts
+++ b/packages/dflex-utils/src/eventDebounce/eventDebounce.ts
@@ -1,0 +1,81 @@
+type DebouncedListener = () => void;
+
+interface DebounceControl extends DebouncedListener {
+  isPaused: () => boolean;
+  pause: () => void;
+  resume: () => void;
+}
+
+function eventDebounce(
+  listener: DebouncedListener,
+  immediate = false,
+  throttle = 200
+): DebounceControl {
+  let rAFid: number | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let isPaused = false;
+  let lastCall = Date.now();
+
+  const debouncedListener: DebounceControl = () => {
+    if (isPaused) {
+      return;
+    }
+
+    const currentTime = Date.now();
+    const timeSinceLastCall = currentTime - lastCall;
+
+    const shouldCallListener = immediate || timeSinceLastCall >= throttle;
+
+    if (shouldCallListener) {
+      if (rAFid) {
+        cancelAnimationFrame(rAFid);
+        rAFid = null;
+      }
+
+      rAFid = requestAnimationFrame(() => {
+        listener();
+        rAFid = null;
+      });
+
+      lastCall = currentTime;
+    } else {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+
+      // Schedule a delayed listener to be executed after the throttle period.
+      timeoutId = setTimeout(() => {
+        debouncedListener();
+        timeoutId = null;
+      }, throttle);
+    }
+  };
+
+  debouncedListener.isPaused = () => isPaused;
+
+  debouncedListener.pause = () => {
+    if (!isPaused) {
+      isPaused = true;
+      if (rAFid) {
+        cancelAnimationFrame(rAFid);
+        rAFid = null;
+      }
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    }
+  };
+
+  debouncedListener.resume = () => {
+    if (isPaused) {
+      isPaused = false;
+      debouncedListener();
+    }
+  };
+
+  return debouncedListener;
+}
+
+export default eventDebounce;

--- a/packages/dflex-utils/src/eventDebounce/index.ts
+++ b/packages/dflex-utils/src/eventDebounce/index.ts
@@ -1,0 +1,3 @@
+import eventDebounce from "./eventDebounce";
+
+export default eventDebounce;

--- a/packages/dflex-utils/src/index.ts
+++ b/packages/dflex-utils/src/index.ts
@@ -18,7 +18,7 @@ export {
   combineKeys,
   warnOnce,
   assertElementPosition,
-  getElmComputedStyle,
+  getCachedComputedStyle,
   clearComputedStyleCache,
   setRelativePosition,
   setFixedDimensions,

--- a/packages/dflex-utils/src/index.ts
+++ b/packages/dflex-utils/src/index.ts
@@ -7,6 +7,7 @@ export type { ThresholdPercentages } from "./Threshold";
 
 export { default as Tracker } from "./Tracker";
 export { default as TaskQueue } from "./TaskQueue";
+export { default as eventDebounce } from "./eventDebounce";
 
 export { DFlexCycle } from "./DFlexCycle";
 export type { AbstractDFlexCycle } from "./DFlexCycle";

--- a/packages/dflex-utils/src/index.ts
+++ b/packages/dflex-utils/src/index.ts
@@ -19,7 +19,7 @@ export {
   warnOnce,
   assertElementPosition,
   getElmComputedStyle,
-  clearComputedStyleMap,
+  clearComputedStyleCache,
   setRelativePosition,
   setFixedDimensions,
   getElmComputedDimensions,

--- a/packages/dflex-utils/test/eventDebounce.test.ts
+++ b/packages/dflex-utils/test/eventDebounce.test.ts
@@ -16,7 +16,7 @@ describe("eventDebounce", () => {
     jest.clearAllTimers();
   });
 
-  test("should execute the listener immediately if immediate flag is set", () => {
+  test("Executes the listener immediately if immediate flag is set", () => {
     debounceControl = eventDebounce(listener, true);
     debounceControl();
     expect(listener).toHaveBeenCalledTimes(0);
@@ -24,14 +24,14 @@ describe("eventDebounce", () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  test("should execute the listener after the throttle period", () => {
+  test("Executes the listener after the throttle period", () => {
     debounceControl();
     expect(listener).not.toHaveBeenCalled();
     jest.runAllTimers();
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  test("should execute the last call one time", () => {
+  test("Executes the last call one time", () => {
     debounceControl();
     debounceControl();
     debounceControl();
@@ -41,7 +41,7 @@ describe("eventDebounce", () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  test("should pause and resume the debounce control", () => {
+  test("Pauses and resumes the debounce control", () => {
     debounceControl();
     debounceControl.pause();
     jest.runAllTimers();

--- a/packages/dflex-utils/test/eventDebounce.test.ts
+++ b/packages/dflex-utils/test/eventDebounce.test.ts
@@ -1,0 +1,53 @@
+import { eventDebounce } from "../src";
+
+jest.useFakeTimers();
+
+describe("eventDebounce", () => {
+  let listener: jest.Mock;
+  let debounceControl: ReturnType<typeof eventDebounce>;
+
+  beforeEach(() => {
+    listener = jest.fn();
+    debounceControl = eventDebounce(listener);
+  });
+
+  afterEach(() => {
+    debounceControl.pause();
+    jest.clearAllTimers();
+  });
+
+  test("should execute the listener immediately if immediate flag is set", () => {
+    debounceControl = eventDebounce(listener, true);
+    debounceControl();
+    expect(listener).toHaveBeenCalledTimes(0);
+    jest.runAllTimers();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test("should execute the listener after the throttle period", () => {
+    debounceControl();
+    expect(listener).not.toHaveBeenCalled();
+    jest.runAllTimers();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test("should execute the last call one time", () => {
+    debounceControl();
+    debounceControl();
+    debounceControl();
+    debounceControl();
+    debounceControl();
+    jest.runAllTimers();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test("should pause and resume the debounce control", () => {
+    debounceControl();
+    debounceControl.pause();
+    jest.runAllTimers();
+    expect(listener).not.toHaveBeenCalled();
+    debounceControl.resume();
+    jest.runAllTimers();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,19 +1028,19 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
       eslint: 8.39.0
-      eslint-visitor-keys: 3.4.0
+      eslint-visitor-keys: 3.4.1
 
   /@eslint-community/regexpp@4.5.1:
     resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  /@eslint/eslintrc@2.0.2:
-    resolution: {integrity: sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==}
+  /@eslint/eslintrc@2.0.3:
+    resolution: {integrity: sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4(supports-color@8.1.1)
-      espree: 9.5.1
+      espree: 9.5.2
       globals: 13.20.0
       ignore: 5.2.4
       import-fresh: 3.3.0
@@ -1956,7 +1956,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.59.2
-      eslint-visitor-keys: 3.4.0
+      eslint-visitor-keys: 3.4.1
     dev: false
 
   /@vitejs/plugin-react@4.0.0(vite@4.3.5):
@@ -2367,7 +2367,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001482
-      electron-to-chromium: 1.4.384
+      electron-to-chromium: 1.4.385
       node-releases: 2.0.10
       update-browserslist-db: 1.0.11(browserslist@4.21.5)
     dev: true
@@ -2938,8 +2938,8 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /electron-to-chromium@1.4.384:
-    resolution: {integrity: sha512-I97q0MmRAAqj53+a8vZsDkEXBZki+ehYAOPzwtQzALip52aEp2+BJqHFtTlsfjoqVZYwPpHC8wM6MbsSZQ/Eqw==}
+  /electron-to-chromium@1.4.385:
+    resolution: {integrity: sha512-L9zlje9bIw0h+CwPQumiuVlfMcV4boxRjFIWDcLfFqTZNbkwOExBzfmswytHawObQX4OUhtNv8gIiB21kOurIg==}
     dev: true
 
   /emittery@0.13.1:
@@ -3345,8 +3345,8 @@ packages:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  /eslint-visitor-keys@3.4.0:
-    resolution: {integrity: sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==}
+  /eslint-visitor-keys@3.4.1:
+    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /eslint@8.39.0:
@@ -3356,7 +3356,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.39.0)
       '@eslint-community/regexpp': 4.5.1
-      '@eslint/eslintrc': 2.0.2
+      '@eslint/eslintrc': 2.0.3
       '@eslint/js': 8.39.0
       '@humanwhocodes/config-array': 0.11.8
       '@humanwhocodes/module-importer': 1.0.1
@@ -3368,8 +3368,8 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
-      eslint-visitor-keys: 3.4.0
-      espree: 9.5.1
+      eslint-visitor-keys: 3.4.1
+      espree: 9.5.2
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -3397,13 +3397,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /espree@9.5.1:
-    resolution: {integrity: sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==}
+  /espree@9.5.2:
+    resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       acorn: 8.8.2
       acorn-jsx: 5.3.2(acorn@8.8.2)
-      eslint-visitor-keys: 3.4.0
+      eslint-visitor-keys: 3.4.1
 
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}


### PR DESCRIPTION
- Removing an extra class instance.
- Decoupling event debouncing and testing it in isolation.
- Refactoring updateSiblingsVisibilityLinearly to enhance conditions.