### PR TITLE
Dev/wip 6 11

### DIFF
--- a/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
+++ b/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
@@ -258,7 +258,7 @@ class DFlexCoreElement extends DFlexBaseElement {
 
   private _transform(
     DOM: HTMLElement,
-    duration: number,
+    duration: number | null,
     onComplete: () => void = noop
   ): void {
     if (!this._isVisible) {
@@ -292,14 +292,14 @@ class DFlexCoreElement extends DFlexBaseElement {
     try {
       this._animatedFrame = requestAnimationFrame(() => {
         // No animation is needed for the element.
-        if (duration === -1) {
+        if (duration === null) {
           DFlexCoreElement.transform(DOM, this.translate.x, this.translate.y);
           transitionComplete();
 
           return;
         }
 
-        DFlexCoreElement.transition(DOM, 0, duration, this._animation.easing);
+        DFlexCoreElement.transition(DOM, 0, duration, this._animation!.easing);
         DFlexCoreElement.transform(DOM, this.translate.x, this.translate.y);
       });
     } catch (error) {
@@ -366,7 +366,7 @@ class DFlexCoreElement extends DFlexBaseElement {
   private _transformOrPend(
     DOM: HTMLElement,
     enforceTransform: boolean,
-    transformDuration: number
+    transformDuration: number | null
   ): void {
     if (enforceTransform) {
       if (!this._isVisible && this._hasPendingTransform) {
@@ -395,11 +395,11 @@ class DFlexCoreElement extends DFlexBaseElement {
     enforceTransform: boolean,
     indexIncrement: number
   ): [number, number] {
-    let calculatedDuration = -1;
+    let calculatedDuration: number | null = null;
 
-    const { duration } = this._animation;
+    if (this._animation) {
+      const { duration } = this._animation;
 
-    if (duration) {
       const oldPoint = this.translate.getInstance();
       const newPoint = this.translate.increase(elmTransition).getInstance();
 

--- a/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
+++ b/packages/dflex-core-instance/src/Element/DFlexCoreElement.ts
@@ -91,6 +91,8 @@ function assertGridBoundaries(
 
 const ANIMATION_SPEED = 20;
 
+// @ts-ignore
+// eslint-disable-next-line no-unused-vars
 function calculateAnimationDuration(from: AxesPoint, to: AxesPoint): number {
   // Calculate the horizontal and vertical distance between from and to positions
   const dx = from.x - to.x;
@@ -395,21 +397,23 @@ class DFlexCoreElement extends DFlexBaseElement {
     enforceTransform: boolean,
     indexIncrement: number
   ): [number, number] {
-    let calculatedDuration: number | null = null;
+    const calculatedDuration: number | null = null;
 
-    if (this._animation) {
-      const { duration } = this._animation;
+    // if (this._animation) {
+    //   const { duration } = this._animation;
 
-      const oldPoint = this.translate.getInstance();
-      const newPoint = this.translate.increase(elmTransition).getInstance();
+    //   const oldPoint = this.translate.getInstance();
+    //   const newPoint = this.translate.increase(elmTransition).getInstance();
 
-      calculatedDuration =
-        typeof duration === "number"
-          ? duration
-          : calculateAnimationDuration(oldPoint, newPoint);
-    } else {
-      this.translate.increase(elmTransition);
-    }
+    //   calculatedDuration =
+    //     typeof duration === "number"
+    //       ? duration
+    //       : calculateAnimationDuration(oldPoint, newPoint);
+    // } else {
+    //   this.translate.increase(elmTransition);
+    // }
+
+    this.translate.increase(elmTransition);
 
     /**
      * This offset related directly to translate Y and Y. It's isolated from

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
@@ -312,7 +312,11 @@ class DFlexDnDStore extends DFlexBaseStore {
         };
 
         // Create an instance of DFlexCoreNode and gets the DOM element into the store.
-        super.register(coreInput, this._initSiblings, this._initObservers);
+        this.addElmToRegistry(
+          coreInput,
+          this._initSiblings,
+          this._initObservers
+        );
       },
       null
     );

--- a/packages/dflex-draggable/src/DFlexDraggableStore.ts
+++ b/packages/dflex-draggable/src/DFlexDraggableStore.ts
@@ -29,7 +29,7 @@ class DFlexDraggableStore extends DFlexBaseStore {
    */
   // @ts-ignore
   register(id: string) {
-    super.register(
+    this.addElmToRegistry(
       {
         id,
         depth: 0,

--- a/packages/dflex-store/src/DFlexBaseStore.ts
+++ b/packages/dflex-store/src/DFlexBaseStore.ts
@@ -37,7 +37,10 @@ export type RegisterInputOpts = {
   animation?: Partial<AnimationOpts>;
 };
 
-export type RegisterInputBase = DeepRequired<
+/**
+ * The processed data from user input for the `register` method in DnD store.
+ */
+export type RegisterInputProcessed = DeepRequired<
   Omit<RegisterInputOpts, "animation">
 > & {
   animation: AnimationOpts;
@@ -185,7 +188,7 @@ class DFlexBaseStore {
 
   private _submitElementToRegistry(
     DOM: HTMLElement,
-    elm: RegisterInputBase,
+    elm: RegisterInputProcessed,
     dflexParentElm: null | DFlexElement
   ): Keys | null {
     const { id, depth, readonly, animation } = elm;
@@ -283,7 +286,7 @@ class DFlexBaseStore {
         }
 
         if (!this.registry.has(id)) {
-          const elm: RegisterInputBase = {
+          const elm: RegisterInputProcessed = {
             depth,
             readonly: registeredElmID !== id,
             // Assuming all siblings have the same animation settings.
@@ -320,7 +323,7 @@ class DFlexBaseStore {
     }
   }
 
-  register(
+  protected addElmToRegistry(
     element: RegisterInputOpts,
     branchComposedCallBack?: BranchComposedCallBackFunction,
     highestContainerComposedCallBack?: HighestContainerComposedCallBack

--- a/packages/dflex-store/src/index.ts
+++ b/packages/dflex-store/src/index.ts
@@ -1,5 +1,9 @@
 import DFlexBaseStore from "./DFlexBaseStore";
 
-export type { RegisterInputOpts, DFlexGlobalConfig } from "./DFlexBaseStore";
+export type {
+  RegisterInputOpts,
+  RegisterInputProcessed,
+  DFlexGlobalConfig,
+} from "./DFlexBaseStore";
 
 export default DFlexBaseStore;

--- a/packages/dflex-store/test/storeBase.test.tsx
+++ b/packages/dflex-store/test/storeBase.test.tsx
@@ -3,33 +3,47 @@ import * as React from "react";
 import * as ReactTestUtils from "react-dom/test-utils";
 import { Root, createRoot } from "react-dom/client";
 
-import BaseStore from "../src";
+import BaseStore, { RegisterInputProcessed } from "../src";
 
 describe("Testing DFlex BaseStore", () => {
-  const store = new BaseStore();
+  class Store extends BaseStore {
+    register(element: RegisterInputProcessed) {
+      this.addElmToRegistry(element);
+    }
+  }
+
+  const store = new Store();
 
   const elm0DP0 = {
     id: "id-0",
     depth: 0,
     readonly: false,
+    animation: null,
+    dragCSS: null,
   };
 
   const elm1DP0 = {
     id: "id-1",
     depth: 0,
     readonly: false,
+    animation: null,
+    dragCSS: null,
   };
 
   const elm2DP0 = {
     id: "id-2",
     depth: 0,
     readonly: false,
+    animation: null,
+    dragCSS: null,
   };
 
   const elm0DP1 = {
     id: "p-id-0",
     depth: 1,
     readonly: false,
+    animation: null,
+    dragCSS: null,
   };
 
   let container: HTMLDivElement | null;

--- a/packages/dflex-utils/src/index.ts
+++ b/packages/dflex-utils/src/index.ts
@@ -19,6 +19,9 @@ export type {
   Direction,
   AnimationOpts,
   CubicBezier,
+  CSSStyle,
+  CSSClass,
+  CSS,
 } from "./types";
 export { BOTH_AXIS } from "./types";
 

--- a/packages/dflex-utils/src/types.ts
+++ b/packages/dflex-utils/src/types.ts
@@ -34,5 +34,11 @@ export type AnimationOpts = {
    * Specifies how long the animation should take to complete.
    * (Default: 'dynamic')
    */
-  duration: null | number | "dynamic";
-};
+  duration: number | "dynamic";
+} | null;
+
+export type CSSStyle = Record<string, string | null>;
+
+export type CSSClass = string;
+
+export type CSS = CSSClass | CSSStyle;

--- a/packages/dflex-utils/test/getParsedElmTransform.test.ts
+++ b/packages/dflex-utils/test/getParsedElmTransform.test.ts
@@ -1,0 +1,48 @@
+import { getParsedElmTransform } from "../src";
+
+describe("getParsedElmTransform", () => {
+  test("returns null for empty transform value", () => {
+    const element = document.createElement("div");
+    element.style.transform = "";
+
+    const result = getParsedElmTransform(element);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null for element without transform property", () => {
+    const element = document.createElement("div");
+
+    const result = getParsedElmTransform(element);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null for transform with other functions", () => {
+    const element = document.createElement("div");
+    element.style.transform = "scale(2) rotate(45deg)";
+
+    const result = getParsedElmTransform(element);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns parsed transform matrix", () => {
+    const element = document.createElement("div");
+    element.style.transform = "matrix(1, 0, 0, 1, 10, 20)";
+
+    const result = getParsedElmTransform(element);
+
+    expect(result).toEqual([10, 20]);
+  });
+
+  test("returns parsed transform matrix from multiple transform functions", () => {
+    const element = document.createElement("div");
+    element.style.transform =
+      "translateX(50px) scale(2) matrix(1, 0, 0, 1, 30, 40)";
+
+    const result = getParsedElmTransform(element);
+
+    expect(result).toEqual([30, 40]);
+  });
+});


### PR DESCRIPTION
- Allow `null` as a valid value for element animation configuration: This change allows for more flexibility in configuring element animations. Previously, an animation configuration was required, but now null can be used to disable animations altogether. 
- Rename `super.register` to `addElmToRegistry` in the base store's internal implementation.
- Add unit test for the `getParsedElmTransform` function.