### PR TITLE
Introduce new events: `$onDragCommitted` and `$onDragTransformed`

### DIFF
--- a/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
@@ -295,6 +295,10 @@ class DraggableInteractive extends DraggableAxes {
 
     this.setDraggedTransformProcess(isFallback, latestCycle, willReconcile);
 
+    if (this.events) {
+      this.events.cleanup();
+    }
+
     this.threshold.destroy();
   }
 }

--- a/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
@@ -296,7 +296,7 @@ class DraggableInteractive extends DraggableAxes {
     this.setDraggedTransformProcess(isFallback, latestCycle, willReconcile);
 
     if (this.events) {
-      this.events.cleanup();
+      this.events.cleanupAttr();
     }
 
     this.threshold.destroy();

--- a/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableInteractive.ts
@@ -285,7 +285,7 @@ class DraggableInteractive extends DraggableAxes {
     isFallback: boolean,
     latestCycle: AbstractDFlexCycle,
     willReconcile: boolean,
-  ) {
+  ): void {
     const draggedDOM = store.interactiveDOM.get(this.draggedElm.id)!;
     const mirrorElement = this.mirrorDOM || null;
 
@@ -294,10 +294,6 @@ class DraggableInteractive extends DraggableAxes {
     this.appendDraggedToContainerDimensions(false);
 
     this.setDraggedTransformProcess(isFallback, latestCycle, willReconcile);
-
-    if (this.events) {
-      this.events.cleanup();
-    }
 
     this.threshold.destroy();
   }

--- a/packages/dflex-dnd/src/Events/DFlexEvents.ts
+++ b/packages/dflex-dnd/src/Events/DFlexEvents.ts
@@ -56,44 +56,50 @@ function domEventUpdater(
 ): void {
   DOM.dispatchEvent(dflexEvent);
 
-  const isDragEvent = dflexEvent.detail.type === DRAG_CAT;
+  const isDragMovementEvent = dflexEvent.detail.type === DRAG_CAT;
 
-  const isNotSpecialEvent =
-    eventName !== ON_COMMITTED && eventName !== ON_TRANSFORMED;
+  if (!isDragMovementEvent) {
+    return;
+  }
 
-  if (isDragEvent && isNotSpecialEvent) {
-    switch (eventName) {
-      case ON_ENTER_CONTAINER:
-        // Remove attr.
-        DRAG_ATTR_STATUS[OUT_CONTAINER] = false;
-        updateDOMAttr<DragAttr>(DOM, OUT_CONTAINER, true);
+  const isMutationEvent =
+    eventName === ON_COMMITTED || eventName === ON_TRANSFORMED;
 
-        break;
+  if (isMutationEvent) {
+    return;
+  }
 
-      case ON_ENTER_THRESHOLD:
-        // Remove attr.
-        DRAG_ATTR_STATUS[OUT_THRESHOLD] = false;
-        updateDOMAttr<DragAttr>(DOM, OUT_THRESHOLD, true);
+  switch (eventName) {
+    case ON_ENTER_CONTAINER:
+      // Remove attr.
+      DRAG_ATTR_STATUS[OUT_CONTAINER] = false;
+      updateDOMAttr<DragAttr>(DOM, OUT_CONTAINER, true);
 
-        break;
+      break;
 
-      case ON_OUT_CONTAINER:
-        DRAG_ATTR_STATUS[OUT_CONTAINER] = true;
-        updateDOMAttr<DragAttr>(DOM, OUT_CONTAINER, false);
-        break;
+    case ON_ENTER_THRESHOLD:
+      // Remove attr.
+      DRAG_ATTR_STATUS[OUT_THRESHOLD] = false;
+      updateDOMAttr<DragAttr>(DOM, OUT_THRESHOLD, true);
 
-      case ON_OUT_THRESHOLD:
-        DRAG_ATTR_STATUS[OUT_THRESHOLD] = true;
-        updateDOMAttr<DragAttr>(DOM, OUT_THRESHOLD, false);
+      break;
 
-        break;
+    case ON_OUT_CONTAINER:
+      DRAG_ATTR_STATUS[OUT_CONTAINER] = true;
+      updateDOMAttr<DragAttr>(DOM, OUT_CONTAINER, false);
+      break;
 
-      default:
-        if (__DEV__) {
-          throw new Error(`Unexpected event name: ${eventName}`);
-        }
-        break;
-    }
+    case ON_OUT_THRESHOLD:
+      DRAG_ATTR_STATUS[OUT_THRESHOLD] = true;
+      updateDOMAttr<DragAttr>(DOM, OUT_THRESHOLD, false);
+
+      break;
+
+    default:
+      if (__DEV__) {
+        throw new Error(`Unexpected event name: ${eventName}`);
+      }
+      break;
   }
 }
 

--- a/packages/dflex-dnd/src/Events/DFlexEvents.ts
+++ b/packages/dflex-dnd/src/Events/DFlexEvents.ts
@@ -179,7 +179,12 @@ function DFlexEvent(dispatcher: HTMLElement) {
     dispatchDFlexEvent(dispatcher, eventName, payload);
   }
 
-  function cleanup(): void {
+  /**
+   * Cleans up drag-related attributes.
+   * This function iterates over DRAG_ATTR_STATUS and updates corresponding DOM
+   * attributes.
+   */
+  function cleanupAttr(): void {
     (
       Object.keys(DRAG_ATTR_STATUS) as (keyof typeof DRAG_ATTR_STATUS)[]
     ).forEach((key) => {
@@ -191,7 +196,7 @@ function DFlexEvent(dispatcher: HTMLElement) {
 
   return {
     dispatch,
-    cleanup,
+    cleanupAttr,
   };
 }
 

--- a/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
+++ b/packages/dflex-dnd/src/LayoutManager/DFlexDnDStore.ts
@@ -900,6 +900,18 @@ class DFlexDnDStore extends DFlexBaseStore {
     return undefined;
   }
 
+  getParentBySK(SK: string): HTMLElement | undefined {
+    const container = this.containers.get(SK)!;
+
+    if (container) {
+      const target = this.interactiveDOM.get(container.id);
+
+      return target;
+    }
+
+    return undefined;
+  }
+
   cleanupSiblingsAttachments(BK: string, SK: string, depth: number): void {
     const scroll = this.scrolls.get(SK)!;
 

--- a/packages/dflex-utils/src/environment/updateDOMAttr.ts
+++ b/packages/dflex-utils/src/environment/updateDOMAttr.ts
@@ -13,9 +13,9 @@ function updateDOMAttr<T extends string>(
       if (!DOM.hasAttribute(attrName)) {
         throw new Error(`Attribute ${attrName} does not exist on the element.`);
       }
-
-      DOM.removeAttribute(attrName);
     }
+
+    DOM.removeAttribute(attrName);
 
     return;
   }

--- a/playgrounds/dflex-dnd-playground/src/components/DFlexDnDComponent.tsx
+++ b/playgrounds/dflex-dnd-playground/src/components/DFlexDnDComponent.tsx
@@ -99,12 +99,21 @@ const DFlexDnDComponent = ({
       document.removeEventListener("mousemove", onMouseMove);
 
       if (useDFlexEvents) {
+        // Removing interactivity events.
         document.removeEventListener("$onDragLeave", onDFlexInteractivityEvent);
         document.removeEventListener("$onDragOver", onDFlexInteractivityEvent);
 
+        // Removing drag events.
         document.removeEventListener("$onDragOutContainer", onDFlexDragEvent);
-        document.removeEventListener("$onDragOutContainer", onDFlexDragEvent);
+        document.removeEventListener("$onDragEnterContainer", onDFlexDragEvent);
 
+        document.removeEventListener("$onDragOutThreshold", onDFlexDragEvent);
+        document.removeEventListener("$onDragEnterThreshold", onDFlexDragEvent);
+
+        document.removeEventListener("$onDragCommitted", onDFlexDragEvent);
+        document.removeEventListener("$onDragTransomed", onDFlexDragEvent);
+
+        // Removing siblings events.
         document.removeEventListener("$onLiftUpSiblings", onDFlexSiblingsEvent);
         document.removeEventListener(
           "$onMoveDownSiblings",
@@ -133,7 +142,13 @@ const DFlexDnDComponent = ({
 
           // Add drag events.
           document.addEventListener("$onDragOutContainer", onDFlexDragEvent);
-          document.addEventListener("$onDragOutContainer", onDFlexDragEvent);
+          document.addEventListener("$onDragEnterContainer", onDFlexDragEvent);
+
+          document.addEventListener("$onDragOutThreshold", onDFlexDragEvent);
+          document.addEventListener("$onDragEnterThreshold", onDFlexDragEvent);
+
+          document.addEventListener("$onDragCommitted", onDFlexDragEvent);
+          document.addEventListener("$onDragTransomed", onDFlexDragEvent);
 
           // Add siblings events.
           document.addEventListener("$onLiftUpSiblings", onDFlexSiblingsEvent);


### PR DESCRIPTION
This PR adds two new drag end events: `$onDragCommitted` and `$onDragTransformed`. These allow consumers to handle drag endings differently depending on whether the drag was committed to the DOM or just transformed.

Both event payloads emit the following details:

```ts
type PayloadDragMutation = {
  /** Represents the main category of the drag event. */
  type: typeof DRAG_CAT;

  /** Indicates the timestamp when the event occurred. */
  timestamp: number;

  /** Targeted elements */
  element: HTMLElement;

  indexes: {
    /** The initial index of the moved element. */
    initial: number;

    /** The index where it was inserted in the receiving container. */
    inserted: number;
  };

  containers: {
    /** The container from which the element originated. */
    origin: HTMLElement;

    /** The container where the element is now located. */
    target: HTMLElement;
  };
}
```
The `$onDragCommitted` event is fired when a drag ends and changes are reconciled back to the data store. The `$onDragTransformed` event is fired if there is no reconciliation, but the element is transformed visually.

The motivation for this change is to allow consumers to handle committed drags differently than drags that were just transformed with no data changes. For example, triggering a re-render or data fetch on commit but not on transform.