### PR TITLE
Introduce `enableDragSettleOnSwitch` flag for enhanced drag behavior

### DIFF
--- a/packages/dflex-dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableAxes.ts
@@ -355,14 +355,18 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
   }
 
   isNotSettled() {
-    const { SK, index } = store.migration.latest();
+    const { migration } = store;
+
+    const { SK, index, numberOfTransformedELm } = migration.latest();
 
     const lastElm = store.getElmSiblingsByKey(SK).length - 1;
 
     const isLeavingFromBottom = index === lastElm;
 
     return (
-      !isLeavingFromBottom && (this.isOutThreshold() || this.isOutThreshold(SK))
+      !isLeavingFromBottom &&
+      ((numberOfTransformedELm > 0 ? false : this.isOutThreshold()) ||
+        this.isOutThreshold(SK))
     );
   }
 }

--- a/packages/dflex-dnd/src/Draggable/DraggableAxes.ts
+++ b/packages/dflex-dnd/src/Draggable/DraggableAxes.ts
@@ -354,8 +354,11 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
     return this.threshold.isOutThreshold(key, absolute, null);
   }
 
-  isNotSettled() {
-    const { migration } = store;
+  isNotSettled(): boolean {
+    const {
+      migration,
+      globals: { enableDragSettleOnSwitch },
+    } = store;
 
     const { SK, index, numberOfTransformedELm } = migration.latest();
 
@@ -365,7 +368,11 @@ class DraggableAxes extends DFlexBaseDraggable<DFlexElement> {
 
     return (
       !isLeavingFromBottom &&
-      ((numberOfTransformedELm > 0 ? false : this.isOutThreshold()) ||
+      ((enableDragSettleOnSwitch
+        ? numberOfTransformedELm > 0
+          ? false
+          : this.isOutThreshold()
+        : this.isOutThreshold()) ||
         this.isOutThreshold(SK))
     );
   }

--- a/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
+++ b/packages/dflex-dnd/test/__snapshots__/layoutManager.test.tsx.snap
@@ -160,6 +160,7 @@ DFlexDnDStore {
   "deferred": [],
   "deletedDOM": WeakSet {},
   "globals": {
+    "enableDragSettleOnSwitch": true,
     "enableEvents": true,
     "enableListeners": true,
     "removeEmptyContainer": false,

--- a/packages/dflex-store/src/DFlexBaseStore.ts
+++ b/packages/dflex-store/src/DFlexBaseStore.ts
@@ -35,7 +35,7 @@ export type RegisterInputOpts = {
   /**
    * The depth of the targeted element within its container, starting from zero.
    * A higher depth value means the element is visually positioned above elements with lower depth values.
-   * Default: 0
+   * @default 0
    *
    * `Example`: 1, 2, 3, ...
    *
@@ -44,7 +44,7 @@ export type RegisterInputOpts = {
   /**
    * Indicates whether the element is read-only and won't be transformed during drag and drop interactions,
    * but it still belongs to the same interactive container.
-   * Default: false
+   * @default false
    *
    */
   readonly?: boolean;
@@ -86,6 +86,7 @@ export type DFlexGlobalConfig = {
   /**
    * If set to true, empty containers will be automatically removed if all of
    * its elements have been successfully migrated.
+   * @default false
    */
   removeEmptyContainer: boolean;
 
@@ -93,16 +94,19 @@ export type DFlexGlobalConfig = {
    * If true, allows a dragged element to switch positions with another element
    * and settle into the new position, even if the drag didn't end inside the
    * new position bounds.
+   * @default true
    */
   enableDragSettleOnSwitch: boolean;
 
   /**
    * If true, enables DFlex events.
+   * @default true
    */
   enableEvents: boolean;
 
   /**
    * If true, enables DFlex listeners.
+   * @default true
    */
   enableListeners: boolean;
 };

--- a/packages/dflex-store/src/DFlexBaseStore.ts
+++ b/packages/dflex-store/src/DFlexBaseStore.ts
@@ -79,16 +79,32 @@ export type RegisterInputProcessed = DeepRequired<
   CSSTransform: CSS | null;
 };
 
+/**
+ * Configuration options for DFlex.
+ */
 export type DFlexGlobalConfig = {
+  /**
+   * If set to true, empty containers will be automatically removed if all of
+   * its elements have been successfully migrated.
+   */
   removeEmptyContainer: boolean;
-  enableEvents: boolean;
-  enableListeners: boolean;
+
   /**
    * If true, allows a dragged element to switch positions with another element
    * and settle into the new position, even if the drag didn't end inside the
    * new position bounds.
    */
   enableDragSettleOnSwitch: boolean;
+
+  /**
+   * If true, enables DFlex events.
+   */
+  enableEvents: boolean;
+
+  /**
+   * If true, enables DFlex listeners.
+   */
+  enableListeners: boolean;
 };
 
 const DEFAULT_GLOBAL_CONFIG = {

--- a/packages/dflex-store/src/DFlexBaseStore.ts
+++ b/packages/dflex-store/src/DFlexBaseStore.ts
@@ -83,12 +83,19 @@ export type DFlexGlobalConfig = {
   removeEmptyContainer: boolean;
   enableEvents: boolean;
   enableListeners: boolean;
+  /**
+   * If true, allows a dragged element to switch positions with another element
+   * and settle into the new position, even if the drag didn't end inside the
+   * new position bounds.
+   */
+  enableDragSettleOnSwitch: boolean;
 };
 
 const DEFAULT_GLOBAL_CONFIG = {
   removeEmptyContainer: false,
   enableEvents: true,
   enableListeners: true,
+  enableDragSettleOnSwitch: true,
 };
 
 if (__DEV__) {

--- a/packages/dflex-utils/src/environment/updateDOMAttr.ts
+++ b/packages/dflex-utils/src/environment/updateDOMAttr.ts
@@ -11,7 +11,8 @@ function updateDOMAttr<T extends string>(
   if (isRemove) {
     if (__DEV__) {
       if (!DOM.hasAttribute(attrName)) {
-        throw new Error(`Attribute ${attrName} does not exist on the element.`);
+        // eslint-disable-next-line no-console
+        console.error(`Attribute ${attrName} does not exist on the element.`);
       }
     }
 

--- a/playgrounds/dflex-dnd-playground/src/App.tsx
+++ b/playgrounds/dflex-dnd-playground/src/App.tsx
@@ -32,10 +32,12 @@ const App = () => {
   };
 
   React.useEffect(() => {
-    // Optional config.
+    // The default optional config.
     store.config({
       enableEvents: true,
+      enableListeners: true,
       removeEmptyContainer: false,
+      enableDragSettleOnSwitch: true,
     });
   }, []);
 

--- a/playgrounds/dflex-dnd-playground/src/App.tsx
+++ b/playgrounds/dflex-dnd-playground/src/App.tsx
@@ -21,6 +21,7 @@ import {
   StreamInterval,
   StreamNewELm,
   StreamIncremental,
+  BigGap,
 } from "./components";
 
 const App = () => {
@@ -99,6 +100,8 @@ const App = () => {
         <Route path="/scroll" element={<ScrollMultiLists />} />
         <Route path="/extended" element={<ExtendedList />} />
         <Route path="/scrollable-page" element={<ScrollablePage />} />
+        <Route path="/gap" element={<BigGap />} />
+
         <Route path="/windowed-dual-list" element={<WindowedDualList />} />
         <Route
           path="/restricted-container-all"

--- a/playgrounds/dflex-dnd-playground/src/components/gap/bigGap.tsx
+++ b/playgrounds/dflex-dnd-playground/src/components/gap/bigGap.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import DFlexDnDComponent from "../DFlexDnDComponent";
 
-const TodoListWithEvents = () => {
+const BigGap = () => {
   const tasks = [
     { id: "mtg", msg: "Meet with Laura" },
     { id: "org", msg: "Organize weekly meetup" },
@@ -16,7 +16,7 @@ const TodoListWithEvents = () => {
         <ul>
           {tasks.map(({ msg, id }) => (
             <DFlexDnDComponent
-              useDFlexEvents={true}
+              style={{ margin: "35px" }}
               Component={"li"}
               registerInput={{ id }}
               key={id}
@@ -35,4 +35,4 @@ const TodoListWithEvents = () => {
   );
 };
 
-export default TodoListWithEvents;
+export default BigGap;

--- a/playgrounds/dflex-dnd-playground/src/components/gap/index.ts
+++ b/playgrounds/dflex-dnd-playground/src/components/gap/index.ts
@@ -1,0 +1,3 @@
+import BigGap from "./bigGap";
+
+export default BigGap;

--- a/playgrounds/dflex-dnd-playground/src/components/index.ts
+++ b/playgrounds/dflex-dnd-playground/src/components/index.ts
@@ -1,5 +1,7 @@
 export { default as Depth1 } from "./depth";
 
+export { default as BigGap } from "./gap";
+
 export {
   AllRestrictedContainer,
   SomeRestrictedContainer,

--- a/playgrounds/dflex-dnd-playground/tests/features/dragSettleOnSwitch.spec.ts
+++ b/playgrounds/dflex-dnd-playground/tests/features/dragSettleOnSwitch.spec.ts
@@ -54,11 +54,19 @@ test.describe("Testing (enableDragSettleOnSwitch) global flag", async () => {
   });
 
   test("siblings are transformed", async () => {
-    await Promise.all([
-      expect(elm1).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 139)"),
-      expect(elm2).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, -139)"),
-      expect(elm3).toHaveCSS("transform", "none"),
-    ]);
+    if (process.platform === "win32") {
+      await Promise.all([
+        expect(elm1).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 139)"),
+        expect(elm2).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, -139)"),
+        expect(elm3).toHaveCSS("transform", "none"),
+      ]);
+    } else {
+      await Promise.all([
+        expect(elm1).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 136)"),
+        expect(elm2).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, -136)"),
+        expect(elm3).toHaveCSS("transform", "none"),
+      ]);
+    }
   });
 
   test("Trigger key `c` to commit the transformed elements and read the emitted message for mutation", async () => {

--- a/playgrounds/dflex-dnd-playground/tests/features/dragSettleOnSwitch.spec.ts
+++ b/playgrounds/dflex-dnd-playground/tests/features/dragSettleOnSwitch.spec.ts
@@ -1,0 +1,75 @@
+import {
+  expect,
+  Page,
+  Locator,
+  BrowserContext,
+  Browser,
+} from "@playwright/test";
+
+import {
+  DFlexPageTest as test,
+  getDraggedRect,
+  initialize,
+  moveDragged,
+  invokeKeyboardAndAssertEmittedMsg,
+} from "dflex-e2e-utils";
+
+test.describe("Testing (enableDragSettleOnSwitch) global flag", async () => {
+  let page: Page;
+  let context: BrowserContext;
+  let activeBrowser: Browser;
+
+  let elm1: Locator;
+  let elm2: Locator;
+  let elm3: Locator;
+
+  test.beforeAll(async ({ browser, browserName }) => {
+    activeBrowser = browser;
+
+    context = await activeBrowser.newContext();
+    page = await context.newPage();
+    initialize(page, browserName, 50);
+    await page.goto("/gap");
+
+    [elm1, elm2, elm3] = await Promise.all([
+      page.locator("#mtg"),
+      page.locator("#org"),
+      page.locator("#gym"),
+    ]);
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+    await context.close();
+    // await activeBrowser.close();
+  });
+
+  test("Move first element outside its threshold then release", async () => {
+    await getDraggedRect(elm1);
+    await moveDragged(-1, 44);
+    await page.dispatchEvent("#mtg", "mouseup", {
+      button: 0,
+      force: true,
+    });
+  });
+
+  test("siblings are transformed", async () => {
+    await Promise.all([
+      expect(elm1).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 139)"),
+      expect(elm2).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, -139)"),
+      expect(elm3).toHaveCSS("transform", "none"),
+    ]);
+  });
+
+  test("Trigger key `c` to commit the transformed elements and read the emitted message for mutation", async () => {
+    await invokeKeyboardAndAssertEmittedMsg(["org", "mtg", "gym"]);
+  });
+
+  test("siblings have none transformation", async () => {
+    await Promise.all([
+      expect(elm1).toHaveCSS("transform", "none"),
+      expect(elm2).toHaveCSS("transform", "none"),
+      expect(elm3).toHaveCSS("transform", "none"),
+    ]);
+  });
+});

--- a/playgrounds/dflex-dnd-playground/tests/features/dragSettleOnSwitch.spec.ts
+++ b/playgrounds/dflex-dnd-playground/tests/features/dragSettleOnSwitch.spec.ts
@@ -53,7 +53,12 @@ test.describe("Testing (enableDragSettleOnSwitch) global flag", async () => {
     });
   });
 
-  test("siblings are transformed", async () => {
+  test("siblings are transformed", async ({ browserName }) => {
+    test.skip(
+      browserName !== "chromium",
+      "Transformation calculations may vary between different browsers.",
+    );
+
     if (process.platform === "win32") {
       await Promise.all([
         expect(elm1).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 139)"),


### PR DESCRIPTION
Add a new flag `enableDragSettleOnSwitch ` to the global config.


```diff
/**
 * Configuration options for DFlex.
 */
type DFlexGlobalConfig = {
  /**
   * If set to true, empty containers will be automatically removed if all of
   * its elements have been successfully migrated.
   */
  removeEmptyContainer: boolean;

+ /**
+  * If true, allows a dragged element to switch positions with another element
+  * and settle into the new position, even if the drag didn't end inside the
+  * new position bounds.
+  */
+ enableDragSettleOnSwitch: boolean;

  /**
   * If true, enables DFlex events.
   */
  enableEvents: boolean;

  /**
   * If true, enables DFlex listeners.
   */
  enableListeners: boolean;
};

```
